### PR TITLE
Use `jekyll serve --watch` to make testing faster.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,6 @@ clean:
 	$(RM) -r _site
 
 serve:
-	jekyll serve $(JEKYLLOPTS)
+	jekyll serve --watch $(JEKYLLOPTS)
 
 .PHONY: all clean serve


### PR DESCRIPTION
* `jekyll build` takes its time to complete and `jekyll serve --watch`
  only recompiles the changed files.