### PR TITLE
change "proprietary code" to "windows tools" devs

### DIFF
--- a/pages/team.md
+++ b/pages/team.md
@@ -41,7 +41,7 @@ Contributors to Open-source Code
 -   Jason Mehring `nrgaway at gmail dot com` -- Debian templates improvements, Whonix integration
 -   Patrick Schleizer `adrelanos at riseup dot net` -- Whonix integration and maintenance
 
-Proprietary Code Developers
+Windows Tools Developers
 ---------------------------
 
 -   Alexander Tereshkin `alex at invisiblethingslab dot com` -- core windows (Qubes Windows Tools)


### PR DESCRIPTION
the current language is unclear whether "proprietary" refers to working on Windows (which is proprietary) or the code itself is proprietary (which has previously been the case).

Soon the Windows Tools will be open sourced, but for now (and always) it may be more clear just to refer to these developers as "Windows Tools" developers.