### PR TITLE
Fix link to Whonix documentation from the homepage.

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -193,7 +193,7 @@ redirect_from:
       </div>
       <div class="col-lg-6">
         <h3 class="text-center add-bottom">Get serious with privacy</h3>
-        <p>With Whonix integrated into Qubes, you can easily route network traffic through the Tor anonymity network. <a href="/en/doc/whonix/">Learn more</a></p>
+        <p>With Whonix integrated into Qubes, you can easily route network traffic through the Tor anonymity network. <a href="/doc/privacy/whonix/">Learn more</a></p>
       </div>
     </div>
     <div class="clearfix"></div>


### PR DESCRIPTION
The current link on the homepage leads to a 404.