### PR TITLE
Stack Overflow --> Stack Exchange

### DIFF
--- a/pages/help.md
+++ b/pages/help.md
@@ -45,9 +45,9 @@ redirect_from:
   </div>
   <div class="col-lg-4">
     <h2>StackOverflow</h2>
-    <p>Check out the QubesOS tag on StackOverflow for potential answers to any questions you may have. Not there? Ask a new question!</p>
-    <a href="https://stackoverflow.com/questions/tagged/Qubes+OS" class="btn btn-primary">
-      <i class="fa fa-stack-overflow"></i> Search StackOverflow
+    <p>Check out the QubesOS tag on StackExchange for potential answers to any questions you may have. Not there? Ask a new question!</p>
+    <a href="https://stackexchange.com/search?q=qubes" class="btn btn-primary">
+      <i class="fa fa-stack-overflow"></i> Search StackExchange
     </a>
   </div>
   <div class="col-lg-4">


### PR DESCRIPTION
user reports that StackOverflow is not appropriate for users (targeted at devs), also has no content re: Qubes:
https://groups.google.com/d/msgid/qubes-users/d92b4850-b951-44bc-b4d2-0d01a120db8a%40googlegroups.com

StackOverflow: https://stackoverflow.com/questions/tagged/qubes

vs: 

StackExchange: https://stackexchange.com/search?q=qubes

in the longer term we should consider trying to create a qubes.stackexchange.com

cc @bnvk 