### PR TITLE
Reformat R3.1 entries

### DIFF
--- a/pages/downloads.md
+++ b/pages/downloads.md
@@ -39,11 +39,24 @@ Qubes Live USB (alpha)
 Qubes Release 3.1 (release candidate)
 -------------------------------------
 
-| Source                                           | Bootable image  | [Verifiers](/doc/verifying-signatures/) |
-| ------------------------------------------------ | --------------- | --------------------------------------- |
-| [*mirrors.kernel.org*](https://mirrors.kernel.org/) (HTTPS)                     | [**Qubes-R3.1-rc2-x86_64.iso**](https://mirrors.kernel.org/qubes/iso/Qubes-R3.1-rc2-x86_64.iso)  | [[hash](https://mirrors.kernel.org/qubes/iso/Qubes-R3.1-rc2-x86_64.iso.DIGESTS)]&nbsp;[[sig](https://mirrors.kernel.org/qubes/iso/Qubes-R3.1-rc2-x86_64.iso.asc)]&nbsp;[[key](https://keys.qubes-os.org/keys/qubes-release-3-signing-key.asc)] |
-| [*ftp.qubes-os.org*](https://ftp.qubes-os.org/)   (HTTPS)                     | [**Qubes-R3.1-rc2-x86_64.iso**](https://ftp.qubes-os.org/iso/Qubes-R3.1-rc2-x86_64.iso) | [[hash](https://ftp.qubes-os.org/iso/Qubes-R3.1-rc2-x86_64.iso.DIGESTS)]&nbsp;[[sig](https://ftp.qubes-os.org/iso/Qubes-R3.1-rc2-x86_64.iso.asc)]&nbsp;[[key](https://keys.qubes-os.org/keys/qubes-release-3-signing-key.asc)] |
-| [*Rudd-O.com*](https://rudd-o.com/) (BitTorrent) | [**Qubes-R3.1-rc2-x86_64.iso.torrent**](https://rudd-o.com/downloads/qubes/Qubes-R3.1-rc2-x86_64.iso.torrent) | [[hash](https://mirrors.kernel.org/qubes/iso/Qubes-R3.1-rc2-x86_64.iso.DIGESTS)]&nbsp;[[sig](https://mirrors.kernel.org/qubes/iso/Qubes-R3.1-rc2-x86_64.iso.asc)]&nbsp;[[key](https://keys.qubes-os.org/keys/qubes-release-3-signing-key.asc)] |
+-   [**Qubes-R3.1-rc2-x86_64.iso**](https://mirrors.kernel.org/qubes/iso/Qubes-R3.1-rc2-x86_64.iso)
+      [[hash](https://mirrors.kernel.org/qubes/iso/Qubes-R3.1-rc2-x86_64.iso.DIGESTS)]
+      [[sig](https://mirrors.kernel.org/qubes/iso/Qubes-R3.1-rc2-x86_64.iso.asc)]
+      [[key](https://keys.qubes-os.org/keys/qubes-release-3-signing-key.asc)]
+      [[?](/doc/verifying-signatures/)]
+      (mirrors.kernel.org)
+-   [**Qubes-R3.1-rc2-x86_64.iso**](https://ftp.qubes-os.org/iso/Qubes-R3.1-rc2-x86_64.iso)
+      [[hash](https://ftp.qubes-os.org/iso/Qubes-R3.1-rc2-x86_64.iso.DIGESTS)]
+      [[sig](https://ftp.qubes-os.org/iso/Qubes-R3.1-rc2-x86_64.iso.asc)]
+      [[key](https://keys.qubes-os.org/keys/qubes-release-3-signing-key.asc)]
+      [[?](/doc/verifying-signatures/)]
+      (ftp.qubes-os.org)
+-   [**Qubes-R3.1-rc2-x86_64.iso.torrent**](https://rudd-o.com/downloads/qubes/Qubes-R3.1-rc2-x86_64.iso.torrent)
+      [[hash](https://mirrors.kernel.org/qubes/iso/Qubes-R3.1-rc2-x86_64.iso.DIGESTS)]
+      [[sig](https://mirrors.kernel.org/qubes/iso/Qubes-R3.1-rc2-x86_64.iso.asc)]
+      [[key](https://keys.qubes-os.org/keys/qubes-release-3-signing-key.asc)]
+      [[?](/doc/verifying-signatures/)]
+      (rudd-o.com)
 
 -   [**Installation Guide**](/doc/installation-guide/)
 -   [Release Notes](/doc/releases/3.1/release-notes/)


### PR DESCRIPTION
@marmarek @Rudd-O, Would you have any objection to this commit?

IMHO, it provides these benefits:
* Makes the formatting of R3.1 entries the same as other releases
* Makes the source easier to read and edit
* Uses only Markdown, no HTML entities
* Preserves all essential information

I am happy to explain in more detail, if you like.

(Note: If we want to distinguish the torrent from the ISOs more conspicuously than just by the file extension, there are ways to do that without significantly changing the formatting, e.g., by adding `[TORRENT]` to the end of that line.)