### PR TITLE
Update getting-started.md

### DIFF
--- a/pages/getting-started.md
+++ b/pages/getting-started.md
@@ -138,6 +138,8 @@ To allow only select AppVMs to enter full screen mode, create a per-VM section, 
 
 In order for the changes to take effect, restart the AppVM(s).
 
+More details can me found [here](/doc/full-screen-mode/).
+
 * * * * *
 
 Now that you're familiar with the basics, please have a look at the rest of the [documentation](/doc/).


### PR DESCRIPTION
added link to full screen mode docs in the same getting started section
- if the redundancy is not intentional I would suggest removing the detailed instruction from the getting started page
not everybody immediately needs full screen mode and if they want it they should probably be given all the information