### PR TITLE
remove top mention of "Qubes-certified laptops"

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -39,9 +39,6 @@ redirect_from:
       <div class="col-lg-4 col-lg-offset-2 col-md-4 col-md-offset-2">
         <a class="black-link" href="/tour/#what-is-qubes-os">What is Qubes OS?</a>
       </div>
-      <div class="col-lg-4 col-md-4">
-        <a class="black-link" href="/doc/certified-laptops/">Qubes-certified Laptops</a>
-      </div>
     </div>
     <div class="clearfix"></div>
   </div>


### PR DESCRIPTION
we can probably remove the top mention of "Qubes-certified laptops" now that there is a dedicated Qubes-certified laptops box on the homepage.

I have not tested the formatting of this edit :\