### PR TITLE
Gemfile for bundler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+gem 'jekyll'
+gem 'jekyll-redirect-from'
+gem 'json'

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,1 @@
-gem 'jekyll'
-gem 'jekyll-redirect-from'
-gem 'json'
+gem 'github-pages', group: :jekyll_plugins


### PR DESCRIPTION
This repository depends on jekyll, json and a jekyll plugin. Gemfiles are used by [Bundler](http://bundler.io/) to manage ruby dependencies. 

Issue the following commands to make use of bundler for `qubesos.github.io`
~~~
gem install bundler
cd qubesos.github.io
bundle install
bundle exec jekyll serve
~~~

`bundle exec jekyll serve` executes the command in the context of qubesos.github.io. This is helpful if one want's to fix the Jekyll version or uses another Jekyll version on the system for another project. 