### PR TITLE
Travis support, ToC links change

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: ruby
 rvm: 
  - 2.1
 install: gem install github-pages html-proofer
-script: jekyll build && htmlproofer ./_site --disable-external
+script: jekyll build && htmlproofer ./_site --disable-external --checks-to-ignore ImageCheck --file-ignore ./_site/tour/index.html --url-ignore "/qubes-issues/,https://ftp.qubes-os.org /"
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: ruby
+rvm: 
+ - 2.1
+install: gem install github-pages html-proofer
+script: jekyll build && htmlproofer ./_site --disable-external
+env:
+  global:
+  - NOKOGIRI_USE_SYSTEM_LIBRARIES=true

--- a/_data/architecture.yml
+++ b/_data/architecture.yml
@@ -38,7 +38,7 @@
   - title: Choosing Hardware
     url: /doc/#choosing-your-hardware
   - title: Installing Qubes
-    url: /doc/#installing-qubes
+    url: /doc/#installing--upgrading-qubes
   - title: Common Tasks
     url: /doc/#common-tasks
   - title: Troubleshooting
@@ -67,14 +67,8 @@
   icon: fa-newspaper-o
   sub-pages:
   - title: Announcements
-    url: /news#announcements
+    url: /news
     icon: fa-bullhorn
-  - title: Releases
-    url: /doc/releases/
-    icon: fa-rocket
-  - title: Press
-    url: /news#press
-    icon: fa-newspaper-o
   - title: Twitter
     url: https://twitter.com/QubesOS
   - title: Facebook
@@ -114,7 +108,7 @@
 #  - title: PayPal
 #    url: /donate#paypal/
   - title: Bitcoin
-    url: /donate#bitcoin
+    url: /donate
   - title: Funding
     url: /funding/
     icon: fa-money

--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -102,6 +102,7 @@ releases:
   Qubes Live USB (alpha):
     aging: no
     deprecated: no
+    link: qubes-live-usb-alpha
     testing: The Live USB edition is older than recent 3.1 release and lacks
              some of its features (and bug fixes). If you want the newest
              available image, download the 3.1 installation image.  You can

--- a/_data/team.yml
+++ b/_data/team.yml
@@ -162,7 +162,7 @@
   type: community
 
 - name: Tomasz Sterna
-  email: tomek at xiaoka dot com
+  email: tomek@xiaoka.com
   role: Installer & GUI
   type: community
 

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -30,7 +30,7 @@
     {% endfor %}
   </div>
   <div class="row footer-logo text-center">
-    <img src="/attachment/icons/logo-outline-small.svg"><strong>Qubes</strong> OS
+    <img src="/attachment/icons/logo-outline-small.svg" alt="Qubes"><strong>Qubes</strong> OS
   </div>
 </footer>
 

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -20,5 +20,4 @@
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="icon" type="image/x-icon" href="{{ "/attachment/icons/512x512/apps/qubes-logo-icon.png" | prepend: site.baseurl | }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }} - Feed" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" />
-  <link rel="alternate" type="application/atom+xml" title="Recent commits to {{ site.title }} Website’s master branch" href="{{ site.repository }}/commits/master.atom">
 </head>

--- a/js/jquery.toc.js
+++ b/js/jquery.toc.js
@@ -57,6 +57,9 @@
             h1.nextUntil('h1').filter('h2').each(function() {
                 ++innerSection;
                 var anchorId = config.anchorPrefix + tocLevel + '-' + tocSection + '-' +  + innerSection;
+                if ($(this).attr('id')) {
+                    anchorId = $(this).attr('id');
+                }
                 $(this).attr('id', anchorId);
                 levelHTML += createLevelHTML(anchorId,
                     tocLevel + 1,
@@ -68,6 +71,9 @@
                 levelHTML = '<ul>' + levelHTML + '</ul>\n';
             }
             var anchorId = config.anchorPrefix + tocLevel + '-' + tocSection;
+            if (h1.attr('id')) {
+                anchorId = h1.attr('id');
+            }
             h1.attr('id', anchorId);
             tocHTML += createLevelHTML(anchorId,
                 tocLevel,

--- a/pages/downloads.md
+++ b/pages/downloads.md
@@ -85,7 +85,7 @@ redirect_from:
       {% assign aging = release.aging | default: false %}
       {% assign deprecated = release.deprecated | default: false %}
       {% assign testing = release.testing | default: false %}
-      <h3 class="more-bottom">{{ release_name }}</h3>
+      <h3 class="more-bottom" id="{{ release.link }}">{{ release_name }}</h3>
       {% if aging %}
       <div class="alert alert-info" role="alert">
         <i class="fa fa-info-circle"></i>{% if aging != true %}{{ aging }}{% else %} This is an old, <a href="/doc/supported-versions/" class="alert-link">supported</a> release. For the best Qubes OS experience, we suggest upgrading to the latest stable release.{% endif %}

--- a/pages/getting-started.md
+++ b/pages/getting-started.md
@@ -13,7 +13,7 @@ redirect_from:
   <div class="col-lg-4 col-md-4">
     <h2>Try Qubes</h2>
     <p>You don't have to replace your current operating system in order to try out Qubes, make a bootable live USB/DVD to try it out now!</p>
-    <a href="/downloads/#qubes-live-usb-alpha/" class="btn btn-primary">
+    <a href="/downloads/#qubes-live-usb-alpha" class="btn btn-primary">
       <i class="fa fa-usb"></i> Try Qubes Live USB
     </a>
   </div>


### PR DESCRIPTION
Run `html-proofer` on every push.
This PR fixes also a bunch of links (in some cases by removing obsolete parts of page footer...)
One important change is change to ToC generating script - to preserve existing `id`, instead of replacing them with `tocAnchor-....`. This looks much nicer, but at the same time break old section links...
See individual commits for details.