### PR TITLE
change name of page to "statistics", add redirect

### DIFF
--- a/pages/statistics.md
+++ b/pages/statistics.md
@@ -1,7 +1,9 @@
 ---
 layout: default
 title: Statistics
-permalink: /counter/
+permalink: /statistics/
+redirect_from: 
+- /counter/
 ---
 
 <div style="text-align: center; margin-bottom: 3em;">


### PR DESCRIPTION
It's weird that this page is named "counter" since it is otherwise referred to as Statistics. This fixes that, and provides a redirect from /counter so existing links don't break.