### PR TITLE
Use bundle exec for jekyll invocations in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 JEKYLLOPTS = --verbose --trace
 
 all:
-	jekyll build $(JEKYLLOPTS)
+	bundle exec jekyll build $(JEKYLLOPTS)
 
 clean:
 	$(RM) -r _site
 
 serve:
-	jekyll serve --watch $(JEKYLLOPTS)
+	bundle exec jekyll serve --watch $(JEKYLLOPTS)
 
 .PHONY: all clean serve


### PR DESCRIPTION
Using [bundle exec](https://bundler.io/man/bundle-exec.1.html) is the [recommended way](https://help.github.com/articles/setting-up-your-github-pages-site-locally-with-jekyll/#step-4-build-your-local-jekyll-site) to invoke jekyll.