### PR TITLE
Donate and Partners pages entirely rewritten

### DIFF
--- a/df OBOBOBOBOBOBOBOBOBOBOB
+++ b/df OBOBOBOBOBOBOBOBOBOBOB
@@ -1,0 +1,17551 @@
+[33mcommit 29dcd79041c6c517d2d5de040727f8181f59f634[m
+Merge: 52635f4 7e65520
+Author: katsinger <github@katsinger.com>
+Date:   Thu Mar 16 20:29:04 2017 +1000
+
+    Merge branch 'master' of https://github.com/katsinger/qubesos.github.io
+
+[33mcommit 52635f45bd4b3d8864b985dc1cd0976b6a361a27[m
+Author: katsinger <github@katsinger.com>
+Date:   Thu Mar 16 19:49:55 2017 +1000
+
+    replaced hyphen with en dash
+
+[33mcommit a5f60f982e1fa0dc6d23dff337f08a650ea90022[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 16 09:24:20 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 1a494731d6b7fe7cf7c427ebf7b34249c1abc50d
+        type commit
+        tag adw_1a494731
+        tagger Andrew David Wong <adw@qubes-os.org> 1489652551 -0700
+    
+        Tag for commit 1a494731d6b7fe7cf7c427ebf7b34249c1abc50d
+    
+        1a49473 Merge branch 'jpouellet-rm-mach-inst'
+        052e3af Remove empty model-specific installation guide
+
+[33mcommit 7e6552089f1bd035a5728dd99c1050d951c3520b[m
+Author: katsinger <github@katsinger.com>
+Date:   Tue Mar 14 21:24:52 2017 +1000
+
+    replaced dash with en dash
+
+[33mcommit f09e587de8d9c42bb25ad96813ede9dc8520b3a7[m
+Author: katsinger <github@katsinger.com>
+Date:   Tue Mar 14 21:22:08 2017 +1000
+
+    Revert "added en dash"
+    
+    This reverts commit f8bb08e7e16327871fa6fcc016ac6921b4222589.
+
+[33mcommit 0f36a4c53991865431dbd328e5693feb119027a8[m
+Author: katsinger <github@katsinger.com>
+Date:   Tue Mar 14 21:20:20 2017 +1000
+
+    Revert "took away t"
+    
+    This reverts commit 1e3dd46f8e4015482f9d4fc38b161f492ac56de9.
+    
+    en dash
+
+[33mcommit b8d8e9b03b0db81c0271012273ae3704d1a69199[m
+Author: katsinger <github@katsinger.com>
+Date:   Tue Mar 14 17:52:12 2017 +1000
+
+    removed derp
+
+[33mcommit 64cf1a178f060b087a0a515768d1dc8a19c1e4dc[m
+Author: katsinger <github@katsinger.com>
+Date:   Tue Mar 14 17:49:21 2017 +1000
+
+    derp
+
+[33mcommit 132e16642569514110942a9f1cfd2ef6bbedee6a[m
+Author: katsinger <github@katsinger.com>
+Date:   Tue Mar 14 17:39:08 2017 +1000
+
+    reverse test
+
+[33mcommit a50838241f0c6bf3d12213bdb2ebc24941b6baee[m
+Author: katsinger <github@katsinger.com>
+Date:   Tue Mar 14 17:38:11 2017 +1000
+
+    test
+
+[33mcommit 0d83568d1b2928ba2a8e42c0760c3049f8d54cc8[m
+Author: katsinger <github@katsinger.com>
+Date:   Tue Mar 14 16:52:49 2017 +1000
+
+    test
+
+[33mcommit 2b449d059377caf3348d779c8f0d750ab1032814[m
+Author: katsinger <github@katsinger.com>
+Date:   Tue Mar 14 16:50:44 2017 +1000
+
+    test
+
+[33mcommit 1e3dd46f8e4015482f9d4fc38b161f492ac56de9[m
+Author: katsinger <github@katsinger.com>
+Date:   Tue Mar 14 16:34:11 2017 +1000
+
+    took away t
+
+[33mcommit f8bb08e7e16327871fa6fcc016ac6921b4222589[m
+Author: katsinger <github@katsinger.com>
+Date:   Tue Mar 14 16:29:48 2017 +1000
+
+    added en dash
+
+[33mcommit 5b390ad6b6eb9447a1a39eabb360329ed6d7ce57[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Mar 14 02:43:11 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object e7f4baf6efeb0ed943da4ee23e7076b4b845251f
+        type commit
+        tag adw_e7f4baf6
+        tagger Andrew David Wong <adw@qubes-os.org> 1489455770 -0700
+    
+        Tag for commit e7f4baf6efeb0ed943da4ee23e7076b4b845251f
+    
+        e7f4baf Change most instances of "AppVM" to "VM"
+
+[33mcommit 217bac7a5dbb97f779f57118857f55711c8f8a94[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Mar 14 02:03:07 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object df1abb784d91dc4f3034f934e02c145ecfe4c929
+        type commit
+        tag adw_df1abb78
+        tagger Andrew David Wong <adw@qubes-os.org> 1489453362 -0700
+    
+        Tag for commit df1abb784d91dc4f3034f934e02c145ecfe4c929
+    
+        df1abb7 Remove "Salt Minion" entry
+
+[33mcommit 49d0a2b6de1233fe37e394e1adda6511e3a38299[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Mar 14 01:47:09 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object dad25ed2853d9dd21b7bec4853b4fcf86c8e9d3c
+        type commit
+        tag adw_dad25ed2
+        tagger Andrew David Wong <adw@qubes-os.org> 1489452403 -0700
+    
+        Tag for commit dad25ed2853d9dd21b7bec4853b4fcf86c8e9d3c
+    
+        dad25ed Merge branch 'tasket-patch-12'
+        c9c6699 Update discussion heading for accuracy
+        e14ac54 Add note about blocked updates, apt-daily.timer
+
+[33mcommit 46fd0d3af41600e84b917c73651c104cb7807035[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Mar 12 13:26:17 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 1c32c6f1b5b0a8cbfecc59e3dbbcb2f270280b8d
+        type commit
+        tag adw_1c32c6f1
+        tagger Andrew David Wong <adw@qubes-os.org> 1489321538 -0700
+    
+        Tag for commit 1c32c6f1b5b0a8cbfecc59e3dbbcb2f270280b8d
+    
+        1c32c6f Merge branch 'Yethal-patch-7'
+        5e8188b Added Application Menu guide
+
+[33mcommit 5c18915a12840668850760e20d33c95a73a26c61[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Mar 12 13:09:43 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 5968f43bceb523b06ced64d8e32a2a6f7a18f9ba
+        type commit
+        tag adw_5968f43b
+        tagger Andrew David Wong <adw@qubes-os.org> 1489320560 -0700
+    
+        Tag for commit 5968f43bceb523b06ced64d8e32a2a6f7a18f9ba
+    
+        5968f43 Fix broken link
+
+[33mcommit 29610c10167cf3edcf23f41a4f75b3cceaca00e0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Mar 12 12:59:37 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object c72ea0d1f11d5a21d067e3f41e654514be7bb2ea
+        type commit
+        tag adw_c72ea0d1
+        tagger Andrew David Wong <adw@qubes-os.org> 1489319953 -0700
+    
+        Tag for commit c72ea0d1f11d5a21d067e3f41e654514be7bb2ea
+    
+        c72ea0d Merge branch 'Nesos-ita-patch-1'
+        3546b31 two new tips
+
+[33mcommit d92e1afa89c3a70997cb74f05c59f90e4a0014e6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Mar 10 19:56:11 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 77e205f5d37ec2f02f25d0ab611014edf9ba5130
+        type commit
+        tag adw_77e205f5
+        tagger Andrew David Wong <adw@qubes-os.org> 1489172126 -0800
+    
+        Tag for commit 77e205f5d37ec2f02f25d0ab611014edf9ba5130
+    
+        77e205f Create "Tips and Tricks" page
+
+[33mcommit 4f98a7be58c33e1fea12dc90dacd148d3ca4eb5b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Mar 10 01:10:22 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object f343ab34b0324339fe3b0da418c89552e8699aef
+        type commit
+        tag mm_f343ab34
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1489104609 +0100
+    
+        Tag for commit f343ab34b0324339fe3b0da418c89552e8699aef
+    
+        f343ab3 mgmt1: fix table syntax, adjust mgmt.pool.add argument
+
+[33mcommit 9055719135a9051b3f2e053a6e6a01a380e2e92e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 9 17:42:34 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object bd88a46b9b40cb558c296513ac4aefe22aead503
+        type commit
+        tag adw_bd88a46b
+        tagger Andrew David Wong <adw@qubes-os.org> 1489077735 -0800
+    
+        Tag for commit bd88a46b9b40cb558c296513ac4aefe22aead503
+    
+        bd88a46 Remove redundant string (closes #309)
+
+[33mcommit cff4907763c1bf4138a9ebb79a69e1d80fdf74e2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 9 17:34:00 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 118aa8a2279c0ff0cb8fe53dd5df5a633fbfe2ec
+        type commit
+        tag adw_118aa8a2
+        tagger Andrew David Wong <adw@qubes-os.org> 1489077204 -0800
+    
+        Tag for commit 118aa8a2279c0ff0cb8fe53dd5df5a633fbfe2ec
+    
+        118aa8a Merge branch 'Yethal-patch-4'
+        827a32d Added Applications Menu entry fix
+
+[33mcommit bd9eba8eefe0cba4b59140e7ca60c0f0f4317afb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 9 16:44:49 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 8c53b52e306fe8f5ce7498579e9aa91e9a604af4
+        type commit
+        tag w_8c53b52e
+        tagger Wojtek Porczyk <woju@invisiblethingslab.com> 1489074222 +0100
+    
+        Tag for commit 8c53b52e306fe8f5ce7498579e9aa91e9a604af4
+    
+        8c53b52 services/mgmt1: Update table wrt QubesOS/qubes-issues#853
+
+[33mcommit 724c00f6696c3d71c5e7fb3693db38f4d357cb1c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 8 22:11:42 2017 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        object 1ccac0692a4bb6697e247e57c239c07b0cd402b2
+        type commit
+        tag adw_1ccac069
+        tagger Andrew David Wong <adw@qubes-os.org> 1489007480 -0800
+    
+        Tag for commit 1ccac0692a4bb6697e247e57c239c07b0cd402b2
+    
+        1ccac06 Security: Canary 11
+
+[33mcommit 32805b77116f9c54b8233463eb86e7a8b2076622[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 8 22:08:38 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 8a290d90fa3856fe7be422ce60392789bd3e106e
+        type commit
+        tag adw_8a290d90
+        tagger Andrew David Wong <adw@qubes-os.org> 1489007260 -0800
+    
+        Tag for commit 8a290d90fa3856fe7be422ce60392789bd3e106e
+    
+        8a290d9 Add canary template to doc index
+        df8cd83 Update QSB and canary templates
+        2bebbb0 Add Canary 11
+        f2e336b Create canary announcement template
+
+[33mcommit 76e13600c8bf2aac060fa62484d15c8971b8fd2a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 8 01:46:10 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object e57ee84b9f98a666ce2dd95db061b6fd1370ea15
+        type commit
+        tag adw_e57ee84b
+        tagger Andrew David Wong <adw@qubes-os.org> 1488933033 -0800
+    
+        Tag for commit e57ee84b9f98a666ce2dd95db061b6fd1370ea15
+    
+        e57ee84 Merge branch 'ssixty-patch-1'
+        653fdf2 Merge branch 'patch-1' of git://github.com/ssixty/qubes-doc into ssixty-patch-1
+        f3cf593 Add Fedora 23 EOL and 24 upgrade instructions to 3.2 release notes
+
+[33mcommit 9c81f294aa2d3211deb365424d7a36b129179107[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Mar 6 20:19:18 2017 -0800
+
+    Fix typos in font names; attempt to make more legible
+
+[33mcommit 03b876c8e5d50b99936c8f002f93c7cb249e489a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Mar 7 04:25:13 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 4b777cd489906f4c8d18bef4856d56aa1b8cd641
+        type commit
+        tag adw_4b777cd4
+        tagger Andrew David Wong <adw@qubes-os.org> 1488857085 -0800
+    
+        Tag for commit 4b777cd489906f4c8d18bef4856d56aa1b8cd641
+    
+        4b777cd Add FAQ entries on Qubes website security and trust
+        785bfa7 Add git commit signature verification instructions
+
+[33mcommit 8702b56aca53b1253e6768cf9b38db1b0243a79e[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Mar 6 18:17:07 2017 -0800
+
+    Remove vestigial liquid markup
+
+[33mcommit dd932389dcda62cd0650d1c173a3ed640be7c1d1[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Mar 6 18:01:54 2017 -0800
+
+    Include project_url in feed links
+
+[33mcommit 07861527a782585263395ca9b637b9749c2a1c7e[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Mar 6 17:53:22 2017 -0800
+
+    Replace or remove ineffectual URL prepends
+
+[33mcommit 6df7d9741377048303bdb71aefd5088d1b804a84[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Mar 6 17:51:39 2017 -0800
+
+    Use root-relative links to feed
+
+[33mcommit 931e71189ba152ba94fabe2014a173c45acf4735[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Mar 6 17:50:32 2017 -0800
+
+    Remove ineffectual URL prepends
+
+[33mcommit a814acff0d5c748e8739008776bf3887ffccd009[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Mar 6 17:46:12 2017 -0800
+
+    Remove unused config variables
+
+[33mcommit 60a3d1f39aa8b14fe9e39e18fb8d793983c0b5ea[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Mar 7 01:38:03 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 5550c61fbfe345c7dd2566efd3b19e1446392b4a
+        type commit
+        tag adw_5550c61f
+        tagger Andrew David Wong <adw@qubes-os.org> 1488846969 -0800
+    
+        Tag for commit 5550c61fbfe345c7dd2566efd3b19e1446392b4a
+    
+        5550c61 Merge branch 'kemccall-patch-1'
+        e131687 typo
+
+[33mcommit b363c6df6988e0e4573d7e4ff1a1fd0b0624a644[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 6 12:30:22 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object c3f4deb2c09b13dc8a674fbab159abb1135028a0
+        type commit
+        tag adw_c3f4deb2
+        tagger Andrew David Wong <adw@qubes-os.org> 1488799793 -0800
+    
+        Tag for commit c3f4deb2c09b13dc8a674fbab159abb1135028a0
+    
+        c3f4deb Document fix for fullscreen Firefox freeze
+
+[33mcommit ac9d057bbba1e67b1baa0607440ccad3a91bbaef[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 6 02:23:18 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object bd6ca1bf0a5598dbf633f08862b9e24bb3961867
+        type commit
+        tag adw_bd6ca1bf
+        tagger Andrew David Wong <adw@qubes-os.org> 1488763363 -0800
+    
+        Tag for commit bd6ca1bf0a5598dbf633f08862b9e24bb3961867
+    
+        bd6ca1b Merge branch 'mfc-patch-35'
+        5a9c96c Remove "Location of the network driver domain" section
+        8c8fdf1 Merge branch 'patch-35' of https://github.com/mfc/qubes-doc into mfc-patch-35
+        09803e9 remove "TODO" Firewall and Proxy VM section
+
+[33mcommit 6529c6bbcd292231ee2aa31b6b12fd04ea13015b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 6 01:21:56 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 4d1814339e938e03b35359f275307449b69af2cf
+        type commit
+        tag adw_4d181433
+        tagger Andrew David Wong <adw@qubes-os.org> 1488759700 -0800
+    
+        Tag for commit 4d1814339e938e03b35359f275307449b69af2cf
+    
+        4d18143 Merge branch 'mfc-patch-34'
+        2ff787b Merge branch 'patch-34' of https://github.com/mfc/qubes-doc into mfc-patch-34
+        c1c3102 added QWT / Windows Tools
+
+[33mcommit a1c75b7e678efda8f77f28c9a1b7aad4e2b26f47[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 6 01:19:40 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 6aa134be0e14a9a7c7ad526ba0aeec060375b6f0
+        type commit
+        tag adw_6aa134be
+        tagger Andrew David Wong <adw@qubes-os.org> 1488759563 -0800
+    
+        Tag for commit 6aa134be0e14a9a7c7ad526ba0aeec060375b6f0
+    
+        6aa134b Merge branch 'mfc-patch-33'
+        1b950cd Merge branch 'patch-33' of https://github.com/mfc/qubes-doc into mfc-patch-33
+        398e473 fix line-breaking
+
+[33mcommit e268c1349f10e5f0d40fd8bd29d2ae0a65dc30d5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 6 01:18:56 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object b72ea6c52ac26fe1e6ab33ec4f7b5ee53ea1544c
+        type commit
+        tag adw_b72ea6c5
+        tagger Andrew David Wong <adw@qubes-os.org> 1488759516 -0800
+    
+        Tag for commit b72ea6c52ac26fe1e6ab33ec4f7b5ee53ea1544c
+    
+        b72ea6c Merge branch 'mfc-patch-32'
+        1720b21 updated and cleaned up instructions
+
+[33mcommit 921eae73168ec590ee6c3cf2f3aeb4a5bcb93aa9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Mar 5 12:47:48 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object aa48e09d0d5c522b5a8036d250795e2714dabdba
+        type commit
+        tag adw_aa48e09d
+        tagger Andrew David Wong <adw@qubes-os.org> 1488714441 -0800
+    
+        Tag for commit aa48e09d0d5c522b5a8036d250795e2714dabdba
+    
+        aa48e09 Merge branch 'mpodroid-patch-1'
+        2b1a14b Merge branch 'patch-1' of https://github.com/mpodroid/qubes-doc into mpodroid-patch-1
+        ca082f3 Minor updates and warning
+        2063b5b Detailed step-by-step guide for MacBookPro
+
+[33mcommit cab22efaebbfdac59829b864719c33fd031506af[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Mar 5 12:46:30 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object ba782ac0ad19c53c438a71b883104c879d507157
+        type commit
+        tag adw_ba782ac0
+        tagger Andrew David Wong <adw@qubes-os.org> 1488714362 -0800
+    
+        Tag for commit ba782ac0ad19c53c438a71b883104c879d507157
+    
+        ba782ac Merge branch 'adrelanos-patch-30'
+        84bc451 Merge branch 'patch-30' of https://github.com/adrelanos/qubes-doc into adrelanos-patch-30
+        eca1423 clarify bind-dirs usage
+
+[33mcommit eb6a6274752e67790457066c791b9d541f05f2a4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Mar 4 00:38:28 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object cab16ccb2777f6c2d063f3b3b150db463427067a
+        type commit
+        tag adw_cab16ccb
+        tagger Andrew David Wong <adw@qubes-os.org> 1488584286 -0800
+    
+        Tag for commit cab16ccb2777f6c2d063f3b3b150db463427067a
+    
+        cab16cc Merge branch 'adrelanos-patch-32'
+        bfed8c5 Merge branch 'patch-32' of https://github.com/adrelanos/qubes-doc into adrelanos-patch-32
+        0ea4b4c fix typo
+
+[33mcommit 0648c17715f3c339ed36576c3840894c37e0717e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Mar 4 00:36:17 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object c2ca89495fbbc673b976abd957c63c983f77d140
+        type commit
+        tag adw_c2ca8949
+        tagger Andrew David Wong <adw@qubes-os.org> 1488584159 -0800
+    
+        Tag for commit c2ca89495fbbc673b976abd957c63c983f77d140
+    
+        c2ca894 Merge branch 'adrelanos-patch-31'
+        29c8cf1 Merge branch 'patch-31' of https://github.com/adrelanos/qubes-doc into adrelanos-patch-31
+        ead5a97 minor
+
+[33mcommit a17b5c3abf8af44f84bfcb965d8e4b5886f28f92[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Mar 3 23:14:35 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 376efddf0f2dc777f5b286dab99e41b8a9dc1f36
+        type commit
+        tag mm_376efddf
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1488579264 +0100
+    
+        Tag for commit 376efddf0f2dc777f5b286dab99e41b8a9dc1f36
+    
+        376efdd mgmt-api: Adjust storage-related calls
+
+[33mcommit e24406a97db2d1d90288e8edecbe0684df1a6073[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Mar 3 02:54:46 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 5e5ea7caedb5c30d2592be7490e6c1d8a38ff310
+        type commit
+        tag adw_5e5ea7ca
+        tagger Andrew David Wong <adw@qubes-os.org> 1488506069 -0800
+    
+        Tag for commit 5e5ea7caedb5c30d2592be7490e6c1d8a38ff310
+    
+        5e5ea7c Merge branch 'Yethal-patch-3'
+        9c42dff Improve grammar and orthography
+        5b5c7ce Merge branch 'patch-3' of https://github.com/Yethal/qubes-doc into Yethal-patch-3
+        8c25a20 Added GSoC reference
+
+[33mcommit 00ea9430a49648248a90390b64f2b12b88c5b49e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Mar 3 02:50:44 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object ff74b6fd5f8ffea5c9be2653b101ae9df14b298a
+        type commit
+        tag adw_ff74b6fd
+        tagger Andrew David Wong <adw@qubes-os.org> 1488505824 -0800
+    
+        Tag for commit ff74b6fd5f8ffea5c9be2653b101ae9df14b298a
+    
+        ff74b6f Merge branch 'Yethal-patch-2'
+        71d9d86 Merge branch 'patch-2' of https://github.com/Yethal/qubes-doc into Yethal-patch-2
+        4f80600 Merge pull request #1 from Yethal/Yethal-patch-1
+        ae2fbd3 Reworded gsoc reference
+
+[33mcommit 115a5ad9accf45650e6a462b170e9a56ba8174a8[m
+Merge: 9efe145 27d6178
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Mar 1 23:10:24 2017 -0800
+
+    Merge branch 'jpouellet-gsoc-steps'
+
+[33mcommit 27d6178c1846ecf1bb68db9b3a0890c41a2d8fe8[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Thu Mar 2 02:04:58 2017 -0500
+
+    Add recommendations for GSoC students
+    
+    Based on my repies to posts by prospective GSoC students on qubes-devel.
+
+[33mcommit 9efe1457b0af0b22720f5b2abac83d258b3b6a85[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 2 01:10:54 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object e37f52e037204b1edb741e6a8b2cf523ff818883
+        type commit
+        tag adw_e37f52e0
+        tagger Andrew David Wong <adw@qubes-os.org> 1488413431 -0800
+    
+        Tag for commit e37f52e037204b1edb741e6a8b2cf523ff818883
+    
+        e37f52e Merge branch 'Yethal-patch-2'
+        4dc78ee Added GSoc reference
+
+[33mcommit bdb46f68db570ce0b61fd6c1fbc45841b3dc1904[m
+Merge: d5eae69 6c6fea6
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Mar 1 01:29:18 2017 -0800
+
+    Merge branch 'mfc-patch-39'
+
+[33mcommit 6c6fea663c6cc862290226e0025ea190507cc74e[m
+Merge: d5eae69 4b564d2
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Mar 1 01:28:34 2017 -0800
+
+    Merge branch 'patch-39' of https://github.com/mfc/qubesos.github.io into mfc-patch-39
+
+[33mcommit d5eae697a976b9d5f20794702daddbeb18011c0c[m
+Merge: 3dbbad3 bb1eeac
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Mar 1 01:27:43 2017 -0800
+
+    Merge branch 'mfc-patch-38'
+
+[33mcommit bb1eeac8e2dbc607831dcbb1fb200c6bfd9f8d64[m
+Merge: 3dbbad3 1d1e82d
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Mar 1 01:27:06 2017 -0800
+
+    Merge branch 'patch-38' of https://github.com/mfc/qubesos.github.io into mfc-patch-38
+
+[33mcommit 3dbbad306908aeca75f9a571dda21b1048d39a33[m
+Merge: 9b21461 ec17ae9
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Mar 1 01:25:08 2017 -0800
+
+    Merge branch 'mfc-patch-37'
+
+[33mcommit ec17ae9002961a94c69371b75db326d94c06d670[m
+Merge: 9b21461 5567749
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Mar 1 01:24:53 2017 -0800
+
+    Merge branch 'patch-37' of https://github.com/mfc/qubesos.github.io into mfc-patch-37
+
+[33mcommit 9b214613bd86d6e6acb2dcfa8abaf944573ea322[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 1 10:23:50 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object b27667206e9ffcec9e3d736f5be8bec9856c63ab
+        type commit
+        tag adw_b2766720
+        tagger Andrew David Wong <adw@qubes-os.org> 1488360217 -0800
+    
+        Tag for commit b27667206e9ffcec9e3d736f5be8bec9856c63ab
+    
+        b276672 Merge branch 'mfc-patch-29'
+        174c633 Merge branch 'patch-29' of https://github.com/mfc/qubes-doc into mfc-patch-29
+        29ef70c implemented line-break policy
+
+[33mcommit f3793f6c97329f4fb760633f535f1184c1f9abd3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 1 10:22:14 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 3ce93fff6ab73dfb3e777b6caa51fc7bfdc59526
+        type commit
+        tag adw_3ce93fff
+        tagger Andrew David Wong <adw@qubes-os.org> 1488360119 -0800
+    
+        Tag for commit 3ce93fff6ab73dfb3e777b6caa51fc7bfdc59526
+    
+        3ce93ff Merge branch 'mfc-patch-31'
+        8d18331 implement new line-break policy to ease translation
+
+[33mcommit c051079a7002986a06214a8751a855d45f260128[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 1 09:53:40 2017 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        object 54e2c3581c884ca4afeed240da6fabc2a67983ad
+        type commit
+        tag adw_54e2c358
+        tagger Andrew David Wong <adw@qubes-os.org> 1488358404 -0800
+    
+        Tag for commit 54e2c3581c884ca4afeed240da6fabc2a67983ad
+    
+        54e2c35 Announcement: R3.1 EOL on 2017-03-29
+
+[33mcommit 4b564d294e41d276502baeb1b3d2ca48dc52a0df[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Tue Feb 28 16:38:16 2017 -0500
+
+    implemented line-break policy
+
+[33mcommit 1d1e82d70ad23519c779fea72ccde2f51c7a5858[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Tue Feb 28 16:05:57 2017 -0500
+
+    added mention of Code of Conduct
+
+[33mcommit 556774917f75294090baae989fead887948ebb65[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Tue Feb 28 15:31:57 2017 -0500
+
+    added link to qubes page on gsoc site
+
+[33mcommit 5adb07b1f72fc9fe612769992a9b9491ecd9ce5b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Feb 27 18:40:22 2017 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        object b1ab68adf2d7d083c83714ca0b61f8c57b63ca04
+        type commit
+        tag adw_b1ab68ad
+        tagger Andrew David Wong <adw@qubes-os.org> 1488217186 -0800
+    
+        Tag for commit b1ab68adf2d7d083c83714ca0b61f8c57b63ca04
+    
+        b1ab68a Announcement: Google Summer of Code 2017
+
+[33mcommit 6c3d403b8ec1760009d8318b5850c567926d28bf[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Feb 27 03:12:11 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 35444c9f06b3f37bc87a64106843aed32c0ee7c5
+        type commit
+        tag mm_35444c9f
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1488161496 +0100
+    
+        Tag for commit 35444c9f06b3f37bc87a64106843aed32c0ee7c5
+    
+        35444c9 mgmt: adjust return message type definition
+
+[33mcommit 775ba9507865e935054dcd7e83400878bbd7cb6a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 26 03:01:18 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object ef3de992262af74d5671bfe564db762d12ac53b6
+        type commit
+        tag adw_ef3de992
+        tagger Andrew David Wong <adw@qubes-os.org> 1488074429 -0800
+    
+        Tag for commit ef3de992262af74d5671bfe564db762d12ac53b6
+    
+        ef3de99 Update DispVM entry
+        72b9e24 Explain intended use of DVM Templates
+
+[33mcommit 4c544cb398369ec3184b7883b2016573336b1156[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 26 02:51:04 2017 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        object 89cccd215844101f35d96136cb1a4e5fd968c2b6
+        type commit
+        tag adw_89cccd21
+        tagger Andrew David Wong <adw@qubes-os.org> 1488073814 -0800
+    
+        Tag for commit 89cccd215844101f35d96136cb1a4e5fd968c2b6
+    
+        89cccd2 Fix syntax error
+
+[33mcommit c588db7a30b427be4fb8919d91479193772faae9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 26 01:42:50 2017 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        object 7d670b2704cb89a35dbad9b4077278c968fbd44e
+        type commit
+        tag adw_7d670b27
+        tagger Andrew David Wong <adw@qubes-os.org> 1488069703 -0800
+    
+        Tag for commit 7d670b2704cb89a35dbad9b4077278c968fbd44e
+    
+        7d670b2 Merge branch 'tasket-master'
+        0f36ba1 Merge branch 'master' of https://github.com/tasket/qubes-hcl into tasket-master
+        d6d21ba Fix Chronos 7
+        0e4b056 Add (22) reports
+        e8ab54f Inspiron 7000: Fix type field
+        09458bd Razer Blade 14: Remove blank line
+
+[33mcommit fea47c1e6fc487225835998075749c459de17424[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Feb 25 05:16:12 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 61dcf25cef2e0266432fec49e79ef6aa969b50f2
+        type commit
+        tag adw_61dcf25c
+        tagger Andrew David Wong <adw@qubes-os.org> 1487996101 -0800
+    
+        Tag for commit 61dcf25cef2e0266432fec49e79ef6aa969b50f2
+    
+        61dcf25 Add FAQ entry: "Windows Update is stuck"
+
+[33mcommit a0e304544ac1fc4b6abd0ff2bb06ed2267baa4aa[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Feb 23 05:06:55 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object a94dd779a9d3ff7f6f17d93a43a7c17a478a0281
+        type commit
+        tag adw_a94dd779
+        tagger Andrew David Wong <adw@qubes-os.org> 1487822764 -0800
+    
+        Tag for commit a94dd779a9d3ff7f6f17d93a43a7c17a478a0281
+    
+        a94dd77 Merge branch 'ubestemt-patch-1'
+        7377cc3 Disable Keyboard symbols entry mode.
+
+[33mcommit 8a13931edfbc5b9190dbc98185d0555469663c4c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Feb 23 05:05:08 2017 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        object 6a9e7892e2c9aeaf064450acb3c3295f8f2e853e
+        type commit
+        tag adw_6a9e7892
+        tagger Andrew David Wong <adw@qubes-os.org> 1487822639 -0800
+    
+        Tag for commit 6a9e7892e2c9aeaf064450acb3c3295f8f2e853e
+    
+        6a9e789 Merge branch 'tasket-master'
+        082cd82 Merge branch 'master' of https://github.com/tasket/qubes-hcl into tasket-master
+        782cf08 Correct T430 model, N56VZ info, switch some to _motherboard_ type.
+        bdaba78 Correct Fixmes, typos, filename spaces.
+
+[33mcommit a8cd2b16176edbec76dc84975cf810ee04831599[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Feb 21 22:38:47 2017 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        object 605e2446cea149cdb442cc99ec11ee0195015d6a
+        type commit
+        tag adw_605e2446
+        tagger Andrew David Wong <adw@qubes-os.org> 1487713054 -0800
+    
+        Tag for commit 605e2446cea149cdb442cc99ec11ee0195015d6a
+    
+        605e244 Merge branch 'tasket-master'
+        077b5b0 Merge branch 'master' of https://github.com/tasket/qubes-hcl into tasket-master
+        a39d43f Add (27) HCL reports.
+
+[33mcommit a499c1320bc484996383f9106d576e6066e9c878[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Feb 20 16:10:25 2017 -0800
+
+    Remove links
+
+[33mcommit 97bdd7c1b8d408dbe13b2c5944de964e55674a51[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Feb 20 19:49:26 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 50d731a564135feb3f030eed2d1e8d4a1b642ee2
+        type commit
+        tag w_50d731a5
+        tagger Wojtek Porczyk <woju@invisiblethingslab.com> 1487615930 +0100
+    
+        Tag for commit 50d731a564135feb3f030eed2d1e8d4a1b642ee2
+    
+        50d731a services/mgmt1: return messages
+
+[33mcommit 5b9c424505448a43c6bb365c2b09caccbff68487[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Feb 20 10:06:22 2017 -0800
+
+    Revert "Add loeken's video series"
+    
+    This reverts commit d66fec003285c997ec9644c4bac831d62ea25325.
+
+[33mcommit a61e6f40308786ab77cdea7d5553c148055fc1b5[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Feb 20 01:40:53 2017 -0800
+
+    Update funding tiers
+
+[33mcommit c8d7541d6efcb0a3b296ced661145666f2da2ea4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 19 08:26:28 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 89ec7c82221efd6442d46ba86d9eb18283a4ded3
+        type commit
+        tag adw_89ec7c82
+        tagger Andrew David Wong <adw@qubes-os.org> 1487489119 -0800
+    
+        Tag for commit 89ec7c82221efd6442d46ba86d9eb18283a4ded3
+    
+        89ec7c8 Merge branch 'unman-2643'
+        63ff5b7 Merge branch '2643' of https://github.com/unman/qubes-doc into unman-2643
+        99d675e Update sha1 sum for BlackArch download
+
+[33mcommit 4b1fb6f1d2c1e3e483b4000034372b70a1754dce[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 19 08:20:58 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object afffe665734ed1daf8f509a6ffa14c2a941f45fb
+        type commit
+        tag adw_afffe665
+        tagger Andrew David Wong <adw@qubes-os.org> 1487488790 -0800
+    
+        Tag for commit afffe665734ed1daf8f509a6ffa14c2a941f45fb
+    
+        afffe66 Update Markdown conventions
+
+[33mcommit d985a3487a859a89e3e07b7c59dbb0690fb809ae[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 17 04:29:19 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object ab474ee5d2f55091913273737e825ddb19777824
+        type commit
+        tag adw_ab474ee5
+        tagger Andrew David Wong <adw@qubes-os.org> 1487302096 -0800
+    
+        Tag for commit ab474ee5d2f55091913273737e825ddb19777824
+    
+        ab474ee Add dev FAQ entry: QEMU is not part of the TCB
+        764cbe1 Remove "Q:" prefixes
+
+[33mcommit 1e4ea98dc526988fe56dcbf43b99240cb4c69c46[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Feb 16 15:09:27 2017 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        object 54c9716fade3b09319638e988c98f39916ecc604
+        type commit
+        tag adw_54c9716f
+        tagger Andrew David Wong <adw@qubes-os.org> 1487254044 -0800
+    
+        Tag for commit 54c9716fade3b09319638e988c98f39916ecc604
+    
+        54c9716 Merge branch 'tasket-master'
+        b5907f0 Merge branch 'master' of https://github.com/tasket/qubes-hcl into tasket-master
+        e5115a5 Correct chipset-short fields
+        4147224 Correct misspelling
+        22a8fc2 Add (14) more reports and Z97 correction.
+        56c629d Add Lenovo Thinkpad T460s 20FAS0AE00
+        51183b4 Correct tpm field
+        f60509f Correct Sony SVP11216PXB link in remark field
+        1bd185b Add HCL reports for ASUS Z97-Pro-gamer, BIOSTAR MCP6P3, Sony SVP11216PXB
+
+[33mcommit 985ce5493811eaa401260a0a723af48f28fa30db[m
+Merge: cb52f63 371986e
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Feb 16 06:04:22 2017 -0800
+
+    Merge branch 'mfc-patch-36'
+
+[33mcommit 371986ee8c65ccfc3d33925971ab6474e0753970[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Wed Feb 15 18:02:15 2017 -0500
+
+    moved projects without mentors to the bottom
+    
+    + added some details for Whonix projects.
+    + added Marek as mentor for GNOME since no one else has stepped up.
+
+[33mcommit cb52f63a726325fd95468f32105f295e0da996f8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 15 14:49:48 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object bc9abfe80eb7dad0aae3e49d1a2ed817effadbb5
+        type commit
+        tag adw_bc9abfe8
+        tagger Andrew David Wong <adw@qubes-os.org> 1487166547 -0800
+    
+        Tag for commit bc9abfe80eb7dad0aae3e49d1a2ed817effadbb5
+    
+        bc9abfe Remove Onion Service Repos page from doc index
+
+[33mcommit 69861a0c91f69ffdf7b6a8544804864aad69d158[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 15 14:48:42 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 21cb0ec125d406fbe39fdbf6479e710b5805846a
+        type commit
+        tag adw_21cb0ec1
+        tagger Andrew David Wong <adw@qubes-os.org> 1487166460 -0800
+    
+        Tag for commit 21cb0ec125d406fbe39fdbf6479e710b5805846a
+    
+        21cb0ec Delete Onion Service Repos page
+
+[33mcommit 55270ef3f31dd166d9a7b432b70c2b44d42dcb3d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 15 06:01:53 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 4b1b9083e0274af3905e4128429723659aed9563
+        type commit
+        tag adw_4b1b9083
+        tagger Andrew David Wong <adw@qubes-os.org> 1487134874 -0800
+    
+        Tag for commit 4b1b9083e0274af3905e4128429723659aed9563
+    
+        4b1b908 Merge branch 'unman-2014'
+        65d5a5e Fix slugification
+        1c245c0 Merge branch '2014' of https://github.com/unman/qubes-doc into unman-2014
+        824a4e3 Add explanation of how to deal with encrypted USB drive in Debian
+
+[33mcommit 7881e7017a6c960b7351a93d0d7c22b3d68e76c2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 15 05:56:20 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object fea98525aa8f4a8604414abd9e02a618915d6b83
+        type commit
+        tag adw_fea98525
+        tagger Andrew David Wong <adw@qubes-os.org> 1487134519 -0800
+    
+        Tag for commit fea98525aa8f4a8604414abd9e02a618915d6b83
+    
+        fea9852 Merge branch 'mfc-patch-30'
+        1e72236 un-abbreviate title, make generic example
+
+[33mcommit c168b5e1bb5424846ddd1a74494cffb14f96efcc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 12 22:45:58 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object a56f4395c8e89a3bc9062e82b9a402cc32dc54ab
+        type commit
+        tag adw_a56f4395
+        tagger Andrew David Wong <adw@qubes-os.org> 1486935918 -0800
+    
+        Tag for commit a56f4395c8e89a3bc9062e82b9a402cc32dc54ab
+    
+        a56f439 Fix broken link
+
+[33mcommit 14acaa49240032df6eb932c053581f89652ea3a2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 12 21:04:20 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 72280f07c0a61dd7c98df756b9d5b589ce9be4c1
+        type commit
+        tag adw_72280f07
+        tagger Andrew David Wong <adw@qubes-os.org> 1486929815 -0800
+    
+        Tag for commit 72280f07c0a61dd7c98df756b9d5b589ce9be4c1
+    
+        72280f0 Update with "DVM Template"; add fedora-minimal link
+
+[33mcommit 49d54f2620830f2fbec9ef0e4ede24b0614bdb33[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 12 20:01:07 2017 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        object a21f57896119dbfa177fca4492c7ba77b24ce733
+        type commit
+        tag adw_a21f5789
+        tagger Andrew David Wong <adw@qubes-os.org> 1486925943 -0800
+    
+        Tag for commit a21f57896119dbfa177fca4492c7ba77b24ce733
+    
+        a21f578 Merge branch 'tasket-master'
+        61d7a9e Add HCL report for ASUS-Q170M-C
+
+[33mcommit 8f25e639e13a5a45e3b24bfc5ef17099acc25e9d[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Feb 11 18:51:03 2017 -0800
+
+    Fix column layout on large screens
+
+[33mcommit fe21a04c1efd5e16a2d440e16ccddea322ec95be[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Feb 11 18:48:29 2017 -0800
+
+    Add Video Tours page icon
+
+[33mcommit 00f891b12fd6002eb29471936d08fdc286b5e9a4[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Feb 11 18:47:28 2017 -0800
+
+    Create new Intro page layout with top buttons (#85)
+
+[33mcommit 223f707756b22006a2ff530d8d30c9ae8bf76d97[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 12 03:22:17 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 308fa866e9533ccfb77b8c6c1b7b0f57446c7f85
+        type commit
+        tag adw_308fa866
+        tagger Andrew David Wong <adw@qubes-os.org> 1486866095 -0800
+    
+        Tag for commit 308fa866e9533ccfb77b8c6c1b7b0f57446c7f85
+    
+        308fa86 Add customization entry for "DVM Template" use case
+
+[33mcommit 89254365bc8c8e05627e88dd9766d706e7e7355b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 12 03:18:19 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 7cdf273f49b90452e418e811fd44de958e2b5907
+        type commit
+        tag adw_7cdf273f
+        tagger Andrew David Wong <adw@qubes-os.org> 1486865813 -0800
+    
+        Tag for commit 7cdf273f49b90452e418e811fd44de958e2b5907
+    
+        7cdf273 Add "DVM Template" to glossary
+
+[33mcommit 55b0a973a9aef49a57cc8d56c343e8a44fa8e699[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 12 02:40:24 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object d5d28007d6227b4edeec7e7f44e9f18859d3ddc0
+        type commit
+        tag adw_d5d28007
+        tagger Andrew David Wong <adw@qubes-os.org> 1486863531 -0800
+    
+        Tag for commit d5d28007d6227b4edeec7e7f44e9f18859d3ddc0
+    
+        d5d2800 Merge branch 'jpouellet-document-dom0-copyout'
+        7193845 Document how to copy info out of Dom0
+
+[33mcommit 0b75d63819585d3ee96eb0a89639b3f12b6ffce2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Feb 11 07:34:51 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object da473c55d159fb6232e046f53dae71515eb09889
+        type commit
+        tag adw_da473c55
+        tagger Andrew David Wong <adw@qubes-os.org> 1486794850 -0800
+    
+        Tag for commit da473c55d159fb6232e046f53dae71515eb09889
+    
+        da473c5 Merge branch 'john-david-r-smith-patch-3'
+        5e27a61 Fix Markdown table rendering
+        fe4f20d Merge branch 'patch-3' of https://github.com/john-david-r-smith/qubes-doc into john-david-r-smith-patch-3
+        c1332f4 add hint on using salt
+
+[33mcommit 821053af2e8b25d555545747663c2c456a120285[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Feb 11 07:28:17 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object b0b1cfd6e9f5697920b43b1d1988490ff4f034a8
+        type commit
+        tag adw_b0b1cfd6
+        tagger Andrew David Wong <adw@qubes-os.org> 1486794423 -0800
+    
+        Tag for commit b0b1cfd6e9f5697920b43b1d1988490ff4f034a8
+    
+        b0b1cfd Merge branch 'LordJashin32-patch-2'
+        6bec796 Merge branch 'patch-2' of https://github.com/LordJashin32/qubes-doc into LordJashin32-patch-2
+        959e2c3 Update install-nvidia-driver.md
+        5bd78f4 Update install-nvidia-driver.md
+        1d56094 Update install-nvidia-driver.md
+
+[33mcommit 3d01f1b98810819e1260c4c77e0ac4b05fec8711[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 10 02:07:53 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object a504271fb37ce02cdb40d927a4afd24b83886318
+        type commit
+        tag adw_a504271f
+        tagger Andrew David Wong <adw@qubes-os.org> 1486688811 -0800
+    
+        Tag for commit a504271fb37ce02cdb40d927a4afd24b83886318
+    
+        a504271 Merge branch 'unman-patch-13'
+        22cf2e0 Add note on services in Debian templates and install problems
+
+[33mcommit 97802639bd4de59281154470d9b4fd7b10e078a5[m
+Merge: 73c7e58 8d66bc0
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Feb 9 16:58:10 2017 -0800
+
+    Merge branch 'rustybird-gsoc-aem'
+
+[33mcommit 8d66bc0ba045fbdece76de39063b22bf03e84869[m
+Merge: 73c7e58 124c55f
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Feb 9 16:57:13 2017 -0800
+
+    Merge branch 'gsoc-aem' of https://github.com/rustybird/qubesos.github.io into rustybird-gsoc-aem
+
+[33mcommit 73c7e58633e173b5f15351958348a86d957da413[m
+Merge: 6eadb3e 98980e9
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Feb 9 16:56:17 2017 -0800
+
+    Merge branch 'omeg-master'
+
+[33mcommit 124c55f6c7a6e8f30de761e6cfc9de37aa2f2af6[m
+Author: Rusty Bird <rustybird@openmailbox.org>
+Date:   Thu Feb 9 16:15:27 2017 +0000
+
+    GSoC: Anti Evil Maid
+
+[33mcommit 98980e93ac0caf8a8542bd57cabeab2afcad45f9[m
+Author: Rafał Wojdyła <omeg@invisiblethingslab.com>
+Date:   Thu Feb 9 09:29:20 2017 +0100
+
+    gsoc: update tickets/language prerequisites
+
+[33mcommit 6eadb3e28b24fb707c222d243f595f3eef1accfc[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 13:27:27 2017 -0800
+
+    Add pointer to mailing list discussion guidelines
+
+[33mcommit 6fb3cfa13899ca878bc76e33bae1323433bfbcdb[m
+Merge: 1daa9a2 51eeb2d
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 13:24:13 2017 -0800
+
+    Merge branch 'jpouellet-jpo-mailto'
+
+[33mcommit 51eeb2d34f15777f88a6bbfae88470619060c451[m
+Merge: 1daa9a2 48c33dc
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 13:23:57 2017 -0800
+
+    Merge branch 'jpo-mailto' of https://github.com/jpouellet/qubesos.github.io into jpouellet-jpo-mailto
+
+[33mcommit 1daa9a27d089ba5a882a5983061bf0e6fc87fa33[m
+Merge: 6380cd1 4cc5eac
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 13:22:41 2017 -0800
+
+    Merge branch 'jpouellet-fix-lists'
+
+[33mcommit 4cc5eacd07c602e7dea1619d50da896b9532c73c[m
+Merge: 6380cd1 07c941c
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 13:22:05 2017 -0800
+
+    Merge branch 'fix-lists' of https://github.com/jpouellet/qubesos.github.io into jpouellet-fix-lists
+
+[33mcommit 6380cd1be93669f02680b08ae48f6a24243d2b97[m
+Merge: dbc2191 c4e0b64
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 13:21:31 2017 -0800
+
+    Merge branch 'jpouellet-a-note-on-trust'
+
+[33mcommit 48c33dcebbbdbfd7a57a601d379fcfe57e72f649[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Wed Feb 8 12:08:01 2017 -0500
+
+    GSoC: Make mentor mailto: consistent
+
+[33mcommit 07c941c83b6bdf659c11ac3b6111a6ebccdeca5e[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Wed Feb 8 10:57:17 2017 -0500
+
+    Make lists actually render as lists
+
+[33mcommit c4e0b645d96ea39f581b7e36aefb88cd5cc86b3c[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Wed Feb 8 10:48:34 2017 -0500
+
+    Add "A note on trust" to the code of conduct
+    
+    https://github.com/QubesOS/qubes-issues/issues/2163#issuecomment-278297127
+
+[33mcommit dbc2191e52dbe427af92563461e656951a7921a2[m
+Merge: c906f7e bc338a5
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 06:24:19 2017 -0800
+
+    Merge branch 'omeg-master'
+
+[33mcommit bc338a59a03fa311a9057c3add638d94993b9238[m
+Merge: c906f7e cd1ce44
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 06:24:08 2017 -0800
+
+    Merge branch 'master' of https://github.com/omeg/qubesos.github.io into omeg-master
+
+[33mcommit c906f7e9497c02c83a6b4490d4256d5674f8a6fd[m
+Merge: 2e52c36 9d3e205
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 06:23:03 2017 -0800
+
+    Merge branch 'mfc-patch-35'
+
+[33mcommit 9d3e20567d0ea6573e1d3e8d989af82b50b26b58[m
+Merge: 2e52c36 49244ce
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 06:22:50 2017 -0800
+
+    Merge branch 'patch-35' of https://github.com/mfc/qubesos.github.io into mfc-patch-35
+
+[33mcommit 2e52c3626226df871073e5c718e1192bd3743c63[m
+Merge: e0f1793 faab3cd
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 06:21:36 2017 -0800
+
+    Merge branch 'mfc-patch-34'
+
+[33mcommit faab3cdcf6cdc24c89b7f7b030c1b95335ec5b02[m
+Merge: e0f1793 e31e490
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Feb 8 06:20:00 2017 -0800
+
+    Merge branch 'patch-34' of https://github.com/mfc/qubesos.github.io into mfc-patch-34
+
+[33mcommit cd1ce448787cdfa2ea70a9b9a909aca70118b75d[m
+Author: Rafał Wojdyła <omeg@invisiblethingslab.com>
+Date:   Wed Feb 8 13:42:57 2017 +0100
+
+    gsoc: add Windows-related projects
+
+[33mcommit 49244ce6c7d1b45ff0b8558efdfdcc5301b382fc[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Tue Feb 7 18:32:25 2017 -0500
+
+    Create code-of-conduct.md
+    
+    to implement https://github.com/QubesOS/qubes-issues/issues/2163. it would not yet be linked to from any page, we would share it with qubes-project team to get feedback.
+
+[33mcommit e0f1793193f44523920aca3719fc24a6b3895a2d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 8 00:10:50 2017 +0100
+
+    gsoc: Update mentor for Unikernel
+
+[33mcommit 6867eb443e01586c36c2fbbe59eeff4d046f7c6d[m
+Merge: 55f9a1d a1e8cc4
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 8 00:07:48 2017 +0100
+
+    Merge remote-tracking branch 'origin/pr/74'
+    
+    * origin/pr/74:
+      Add unikernel details
+
+[33mcommit e31e4906e62d9bfa1229bead8e6e92112e9a7af0[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Tue Feb 7 13:38:23 2017 -0500
+
+    removed "checkboxes"
+    
+    they don't look good on website
+
+[33mcommit 55f9a1df7ceb046df24fadcb3f1ba3805c22c36c[m
+Merge: 35e1195 d05097b
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Feb 7 02:17:51 2017 -0800
+
+    Merge branch 'jpouellet-lowercase-permalink'
+
+[33mcommit d05097ba0a6020fa3eb22fff07fae2708bcf162d[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Feb 7 02:17:08 2017 -0800
+
+    Add redirect from previous permalink
+
+[33mcommit 35e11957260806cf1f247457da3f41b8b5649e94[m
+Merge: 1003ee1 b41092f
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Feb 7 02:11:59 2017 -0800
+
+    Merge branch 'lowercase-permalink' of https://github.com/jpouellet/qubesos.github.io into jpouellet-lowercase-permalink
+
+[33mcommit 1003ee170d0cb750903c10974e0cdd24c99632cd[m
+Merge: 1285b0a 116217c
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Feb 7 02:11:07 2017 -0800
+
+    Merge branch 'jpouellet-gsoc-more-projects'
+
+[33mcommit 116217c2ff131f8a5d74d54d6527ed734debb4fd[m
+Merge: 1285b0a d232528
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Feb 7 02:10:24 2017 -0800
+
+    Merge branch 'gsoc-more-projects' of https://github.com/jpouellet/qubesos.github.io into jpouellet-gsoc-more-projects
+
+[33mcommit 1285b0a5e2c2dd3f59c8c88632d430c7e0ae9805[m
+Merge: 0de7f41 49117c6
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Feb 7 02:09:23 2017 -0800
+
+    Merge branch 'jpouellet-gsoc-nitpicks'
+
+[33mcommit 49117c67878d0377dd9ef22ada7ee7610c538985[m
+Merge: 0de7f41 e7bebcf
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Feb 7 02:08:13 2017 -0800
+
+    Merge branch 'gsoc-nitpicks' of https://github.com/jpouellet/qubesos.github.io into jpouellet-gsoc-nitpicks
+
+[33mcommit 0de7f41997022f2a62e86bd438f75b1dda1dfae0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Feb 7 03:54:50 2017 +0100
+
+    GSoC: fill projects descriptions
+
+[33mcommit b41092f8a025bd30fb8cfb47894c94ef2bb5bcee[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Mon Feb 6 18:56:29 2017 -0500
+
+    GSoC: GSoC.md -> gsoc.md
+
+[33mcommit 2962a14487c572d1c9cda2c75a954bcee9380999[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Mon Feb 6 18:53:14 2017 -0500
+
+    GSoC: permalink s/GSoC/gsoc/
+    
+    For consistency with the vast majority of our other permalinks.
+
+[33mcommit d2325286a3db3d26985aabe5e66b0f924ea7db83[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Mon Feb 6 18:41:56 2017 -0500
+
+    GSoC: Add reproducible builds project idea
+
+[33mcommit bfd91b8612dcf54a93d0b6d131a47a72dd6d9c78[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Mon Feb 6 16:37:12 2017 -0500
+
+    GSoC: Link a focus stealing issue
+
+[33mcommit 033e036096f7c49fad3e445666f76dd6b54935c3[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Mon Feb 6 16:35:56 2017 -0500
+
+    GSoC: Add more project ideas
+
+[33mcommit a1e8cc42eaa1c5a330959778172feae9ac9510c5[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Mon Feb 6 15:49:21 2017 -0500
+
+    Add unikernel details
+
+[33mcommit e7bebcf0b4fa8ec178b5ebd1e3f7aabaeacd8a36[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Mon Feb 6 15:32:06 2017 -0500
+
+    Grammar
+
+[33mcommit 03853830d910af740fbbd5d112155bf774e063af[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Feb 6 15:46:36 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 0b1eb1bb5e83af201938127803c2315dc96825ea
+        type commit
+        tag adw_0b1eb1bb
+        tagger Andrew David Wong <adw@qubes-os.org> 1486392350 -0800
+    
+        Tag for commit 0b1eb1bb5e83af201938127803c2315dc96825ea
+    
+        0b1eb1b Merge branch 'ptitdoc-patch-5'
+        f5c5bc9 Merge branch 'patch-5' of https://github.com/ptitdoc/qubes-doc into ptitdoc-patch-5
+        710c3ea archlinux: fix typos
+        6d31f05 archlinux: update upgrade and debugging instructions
+        e11f3d9 Update installation instruction and start documenting template content
+        1838cde Update binary repository activation process
+
+[33mcommit 31ab9c02caad59296b187e6154abf049247f47a3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Feb 6 15:36:26 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 60d6457693129fc5d7521604d20401bb1d1708b5
+        type commit
+        tag adw_60d64576
+        tagger Andrew David Wong <adw@qubes-os.org> 1486391724 -0800
+    
+        Tag for commit 60d6457693129fc5d7521604d20401bb1d1708b5
+    
+        60d6457 Merge branch 'john-david-r-smith-master'
+        e4c7521 Fix heading
+        8835409 Wrap braces in `raw` tags to prevent parsing as liquid syntax
+        6497068 Fix list formatting
+        7fd2797 Remove <U+FEFF>
+        7d77c86 Merge branch 'master' of https://github.com/john-david-r-smith/qubes-doc into john-david-r-smith-master
+        8a226e5 use qubesctl --all state.highstate to apply states
+        034f748 extended the salt documentation
+
+[33mcommit 3e41a7395ca75ecacc62d43094f5ca874f64e531[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Feb 6 01:17:04 2017 -0800
+
+    Update row of links to other pages
+
+[33mcommit 45153bd285bfa6ba4d751fe90c7685cb553e400f[m
+Merge: b936af8 2765159
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Feb 6 00:25:06 2017 -0800
+
+    Merge branch 'mfc-patch-33'
+
+[33mcommit 27651599de2bebb5799dc506565f236637b5cb27[m
+Merge: b936af8 f37f17b
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Feb 6 00:24:19 2017 -0800
+
+    Merge branch 'patch-33' of https://github.com/mfc/qubesos.github.io into mfc-patch-33
+
+[33mcommit b936af8b6296bb2bcc3062ebdfb304d67844f9da[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Feb 6 00:15:47 2017 -0800
+
+    Replace "Hidden Service" with "Onion Service"
+
+[33mcommit 3551bcf1a9c36c104db99720cc34ea250c6c9a14[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Feb 6 00:15:01 2017 -0800
+
+    Redesign Partners page
+
+[33mcommit f37f17b0d41735d50938adfc6490c142cd9e3cff[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Sun Feb 5 17:12:34 2017 -0500
+
+    added two whonix project ideas
+
+[33mcommit cadfa47f72afee08ab7634ca43a29f422ace19f3[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Feb 5 04:00:13 2017 -0800
+
+    Fix heading levels
+
+[33mcommit cba72cf6df226da9e8666412cd940b335b8f0af3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 5 12:43:31 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 74f5e80b7016e0232cab2af7a4b799398a4715e7
+        type commit
+        tag adw_74f5e80b
+        tagger Andrew David Wong <adw@qubes-os.org> 1486294972 -0800
+    
+        Tag for commit 74f5e80b7016e0232cab2af7a4b799398a4715e7
+    
+        74f5e80 Include stanza provided by @hyperfekt
+
+[33mcommit 7e3ee57453dace8075d347a1201689ec40da8d7c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 5 12:30:50 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object b065da747bec03c3e802fc24ddbe0a653c090dd4
+        type commit
+        tag adw_b065da74
+        tagger Andrew David Wong <adw@qubes-os.org> 1486294209 -0800
+    
+        Tag for commit b065da747bec03c3e802fc24ddbe0a653c090dd4
+    
+        b065da7 Merge branch 'unman-patch-12'
+        9a1f019 Update required packages
+
+[33mcommit 81f387706d8a45a06d3f7e4c1fd7c4fb17618780[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 5 12:29:47 2017 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        object 7c7644f0885518ffaf2d694ce57cd52a78d84835
+        type commit
+        tag adw_7c7644f0
+        tagger Andrew David Wong <adw@qubes-os.org> 1486294141 -0800
+    
+        Tag for commit 7c7644f0885518ffaf2d694ce57cd52a78d84835
+    
+        7c7644f Merge branch 'mfc-patch-3'
+        f143c0e Fix date and list formatting
+        222eef0 Create 2017-02-01-qubes-project.md
+
+[33mcommit e77ce0408d7e073ebf26bf862886ea751fa839a4[m
+Merge: dc5c954 323e078
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Feb 5 03:23:55 2017 -0800
+
+    Merge branch 'mfc-patch-32'
+
+[33mcommit 323e078d57858a0ca1272a437d050adca7c69a93[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Feb 5 03:22:51 2017 -0800
+
+    Replace existing links to /counter/ with /statistics/
+
+[33mcommit 2ef56603c78bbf0e739145d4dda6cb172b209a6d[m
+Merge: dc5c954 609ac17
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Feb 5 03:17:52 2017 -0800
+
+    Merge branch 'patch-32' of https://github.com/mfc/qubesos.github.io into mfc-patch-32
+
+[33mcommit dc5c954f9cc630d8d6f5803459b73452ced11795[m
+Merge: d14b92c 5496420
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Feb 5 03:15:03 2017 -0800
+
+    Merge branch 'mfc-patch-31'
+
+[33mcommit 609ac17c198b12396ee3d00da1aa57965f08d3d1[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Sat Feb 4 14:48:59 2017 -0500
+
+    change name of page to "statistics", add redirect
+
+[33mcommit 549642057be9f2909e02f02a61a48cbbf50068fb[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Sat Feb 4 11:18:34 2017 -0500
+
+    Create GSoC.md
+
+[33mcommit 0ad03394c059b69cf4ba5cf15b970feae591bdea[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 3 12:28:27 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 8a25e5f7a9cdb1dbe86461d848615dff159022af
+        type commit
+        tag adw_8a25e5f7
+        tagger Andrew David Wong <adw@qubes-os.org> 1486121225 -0800
+    
+        Tag for commit 8a25e5f7a9cdb1dbe86461d848615dff159022af
+    
+        8a25e5f Merge branch 'ptitdoc-patch-4'
+        10bc81f Merge branch 'patch-4' of https://github.com/ptitdoc/qubes-doc into ptitdoc-patch-4
+        0f7e244 Add mailing list references
+        63378db Cleanup additionnal excessive markup
+        405ac27 Cleanup excessive markup
+        6692203 Add notes related to Qubes 3.1
+        9d8599d Update building instruction based on removed code
+
+[33mcommit d14b92cc297219ee4ec20b5b361f4fe7639b8a3f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 3 04:05:11 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object bd4298d104ea8483f990c27e3cbfeec140102d79
+        type commit
+        tag mm_bd4298d1
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1486091089 +0100
+    
+        Tag for commit bd4298d104ea8483f990c27e3cbfeec140102d79
+    
+        bd4298d Update qubes-service page to use drop-ins instead of full service override
+
+[33mcommit bd6ed97bea73872fee38e1ab9b68fe94270b500f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 1 23:47:40 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 0716df2420f7c88df74723b001a91e53076f90a9
+        type commit
+        tag adw_0716df24
+        tagger Andrew David Wong <adw@qubes-os.org> 1485989206 -0800
+    
+        Tag for commit 0716df2420f7c88df74723b001a91e53076f90a9
+    
+        0716df2 Merge branch 'Wikinaut-patch-2'
+        5a28b05 adapted the doc according to qvm-block --help
+        dff240c Adding qube "personal" example name
+
+[33mcommit c88359dccd57fc1ff761b77231b2e756d1b45f7f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 1 03:49:19 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object f6895857652a76623249210004943d67f65b1172
+        type commit
+        tag adw_f6895857
+        tagger Andrew David Wong <adw@qubes-os.org> 1485917321 -0800
+    
+        Tag for commit f6895857652a76623249210004943d67f65b1172
+    
+        f689585 Merge branch 'unman-patch-11'
+        10ac108 Merge branch 'patch-11' of https://github.com/unman/qubes-doc into unman-patch-11
+        6bcdd81 Update ubuntu.md
+
+[33mcommit 7938b15baaefced0f10fbcdb847ffa82e2d28ee3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 1 03:47:52 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 69002b7b754794888690783a08180f56c9ad0b45
+        type commit
+        tag adw_69002b7b
+        tagger Andrew David Wong <adw@qubes-os.org> 1485917197 -0800
+    
+        Tag for commit 69002b7b754794888690783a08180f56c9ad0b45
+    
+        69002b7 Fix code block syntax (closes #272)
+
+[33mcommit fc32ec96ccf28ad3c6e15810afbe311eab69c4c8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jan 29 12:50:11 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 09f22a61010689c388cb0f79e5241909a94d8bd4
+        type commit
+        tag adw_09f22a61
+        tagger Andrew David Wong <adw@qubes-os.org> 1485690549 -0800
+    
+        Tag for commit 09f22a61010689c388cb0f79e5241909a94d8bd4
+    
+        09f22a6 Merge branch 'ecneladis-patch-1'
+        f6a8159 Update list of RPC policies
+
+[33mcommit a8847377460c2c9534b6759440f1e053991e4020[m
+Merge: 03028fa 4f3c3e7
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jan 27 18:42:12 2017 -0800
+
+    Merge branch 'mfc-patch-30'
+
+[33mcommit 4f3c3e7a50844d54d0fc8e29d5eae4a07572e978[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jan 27 18:42:01 2017 -0800
+
+    Minor editing
+
+[33mcommit f807d38cc9df485d09dc10a1af38db23ff4e22a9[m
+Merge: 03028fa b8d4934
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jan 27 18:39:53 2017 -0800
+
+    Merge branch 'patch-30' of https://github.com/mfc/qubesos.github.io into mfc-patch-30
+
+[33mcommit 03028fab211c1397cb2b5c86de96180842bfbfdc[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jan 27 18:39:23 2017 -0800
+
+    Apply sidebar layout to Join and Mailing List pages
+
+[33mcommit 43c370fe1b4e8f526f0480742964779aa206f8cd[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jan 27 18:38:51 2017 -0800
+
+    Create sidebar layout for non-doc pages
+
+[33mcommit b8d4934ef8fdd2ead56768d5c6c25caa1e9c8c74[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Fri Jan 27 18:10:30 2017 -0500
+
+    added qubes-project mailing list
+
+[33mcommit e47940f586e5d0369da4866ed8b6afd9c85bff2a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jan 27 08:27:50 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 476a8317c65183c76397a421f1135354b227595f
+        type commit
+        tag adw_476a8317
+        tagger Andrew David Wong <adw@qubes-os.org> 1485502030 -0800
+    
+        Tag for commit 476a8317c65183c76397a421f1135354b227595f
+    
+        476a831 Merge branch 'mfc-patch-27'
+        4193f65 Merge branch 'patch-27' of https://github.com/mfc/qubes-doc into mfc-patch-27
+        c918bf9 edit for readability
+
+[33mcommit bf436b4faf07ecea633dc48620705b7c11e64d94[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jan 27 08:26:47 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object d3bc573ffc9c6da4e7410beb949a8039e518f433
+        type commit
+        tag adw_d3bc573f
+        tagger Andrew David Wong <adw@qubes-os.org> 1485501965 -0800
+    
+        Tag for commit d3bc573ffc9c6da4e7410beb949a8039e518f433
+    
+        d3bc573 Merge branch 'mfc-patch-26'
+        6e9f9f7 Merge branch 'patch-26' of https://github.com/mfc/qubes-doc into mfc-patch-26
+        a8af173 made more clear dom0 vs template commands
+
+[33mcommit 0532306aa7085aa210913e9bdcb0f327d83c1bb9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jan 27 08:26:06 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 739d9d5036cd45abcab63cb032eb8ee7b35e0f30
+        type commit
+        tag adw_739d9d50
+        tagger Andrew David Wong <adw@qubes-os.org> 1485501906 -0800
+    
+        Tag for commit 739d9d5036cd45abcab63cb032eb8ee7b35e0f30
+    
+        739d9d5 Merge branch 'packtsardine-patch-1'
+        dbd2325 Update DispVM Customization
+
+[33mcommit 2d5adcfe65af4604849a7e3a591eb92fc93a9122[m
+Merge: 9b373ee dd1c297
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jan 25 04:43:48 2017 -0800
+
+    Merge branch 'mfc-patch-28'
+
+[33mcommit dd1c297429dbf888755a39ef0293d04660e2fd62[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jan 25 04:43:01 2017 -0800
+
+    Fix links to partners entries
+
+[33mcommit 64f15c96f7ebd39ac718b9447344be58eb4a66fc[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jan 25 04:42:09 2017 -0800
+
+    Remove placeholders and clean up formatting
+
+[33mcommit 9b373eec8e91e5d23126e3cad7d1af2c3777a351[m
+Merge: 4de8051 0f7860e
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Jan 24 18:48:18 2017 -0800
+
+    Merge branch 'mfc-patch-29'
+
+[33mcommit 0f7860e6344ebcd10b5d54fb25adc06241858a0d[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Jan 24 18:47:26 2017 -0800
+
+    Remove text headings; use div IDs for anchor links
+
+[33mcommit f0eba92180e484cf0039f7026a3a5ec0e875f600[m
+Merge: 4de8051 803e60e
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Jan 24 18:39:30 2017 -0800
+
+    Merge branch 'patch-29' of https://github.com/mfc/qubesos.github.io into mfc-patch-29
+
+[33mcommit af8ee586a65c54ffbc20d8ec2119153a8570d4e0[m
+Merge: 4de8051 aab78be
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Jan 24 18:29:13 2017 -0800
+
+    Merge branch 'patch-28' of https://github.com/mfc/qubesos.github.io into mfc-patch-28
+
+[33mcommit 4de80518a375c140c805db2ea652319ef72e5b0d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 25 03:28:28 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 84ffbcc11c1795257527db2a92bb8e2ebd2e899c
+        type commit
+        tag adw_84ffbcc1
+        tagger Andrew David Wong <adw@qubes-os.org> 1485311250 -0800
+    
+        Tag for commit 84ffbcc11c1795257527db2a92bb8e2ebd2e899c
+    
+        84ffbcc Merge branch 'patch-2' of https://github.com/ptitdoc/qubes-doc
+        5cec994 Add --enablerepo argument
+        a1b8482 Document usage of precompiled  archlinux template
+
+[33mcommit aab78be61360e7609e85773941add34c5a9ffebb[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Mon Jan 23 20:22:10 2017 -0500
+
+    new version of funding page
+    
+    tiers, links to new partners page
+
+[33mcommit 803e60e83430500468b7024e813a0aad96ec0d9d[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Mon Jan 23 20:22:08 2017 -0500
+
+    new version of partners page
+    
+    ordered by amount, non-monetary contributions converted into dollar equivalent. headers for orgs necessary to link to them from the new funding page.
+
+[33mcommit 10aedbd26a87f88bd847fb811bc090735add2fea[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Jan 23 07:03:57 2017 -0800
+
+    Remove doc sidebar separator with sidebar itself
+    
+    QubesOS/qubes-issues#1869
+
+[33mcommit f580641ac1a616f0701bfdab5a6cdb691f571189[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Jan 23 05:31:23 2017 -0800
+
+    Improve responsiveness of doc sidebar on small screens
+    
+    QubesOS/qubes-issues#1869
+
+[33mcommit 427f03531615bfcc69ff3bd779863a7b73c5e8dd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jan 23 13:57:54 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 10b61bf0b35ad148abd7d403ca621ddf7d487e9b
+        type commit
+        tag adw_10b61bf0
+        tagger Andrew David Wong <adw@qubes-os.org> 1485176242 -0800
+    
+        Tag for commit 10b61bf0b35ad148abd7d403ca621ddf7d487e9b
+    
+        10b61bf Change "hidden service" to "onion service"
+
+[33mcommit 85a7b51fd9c41e884e9469eaba730fb6f561ebee[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Jan 23 04:37:31 2017 -0800
+
+    Add sidebar button to Doc Guidelines
+
+[33mcommit 44b06c8f37b777b84b6bb2b24591feb81067656a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jan 23 13:31:03 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 4947dd1a2f567d7ea36849853e89303ab6cceb21
+        type commit
+        tag adw_4947dd1a
+        tagger Andrew David Wong <adw@qubes-os.org> 1485174612 -0800
+    
+        Tag for commit 4947dd1a2f567d7ea36849853e89303ab6cceb21
+    
+        4947dd1 Create "Contribution Suggestions" section
+
+[33mcommit 9bb41ef4d0233621e8c4de99d0940c863c5e673b[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Sun Jan 22 20:59:24 2017 -0500
+
+    first draft, don't merge
+    
+    this is for review
+
+[33mcommit f03a77ce0aeaf38376c43d8e2ca97db2c28301db[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Jan 17 07:33:53 2017 -0800
+
+    Update _hcl submodule
+
+[33mcommit e1a13238c8add404e0d5b8b278bcb308ea005d62[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Jan 17 07:31:24 2017 -0800
+
+    Shorten menu link to fit
+
+[33mcommit d66fec003285c997ec9644c4bac831d62ea25325[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Jan 17 07:28:53 2017 -0800
+
+    Add loeken's video series
+
+[33mcommit 40a7eef84b08337c1af2a87bdfdf442ec4237ade[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jan 16 01:55:27 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object aa69a06c3c2debf3a6c9199b7a03de1b4d0aa230
+        type commit
+        tag adw_aa69a06c
+        tagger Andrew David Wong <adw@qubes-os.org> 1484528082 -0800
+    
+        Tag for commit aa69a06c3c2debf3a6c9199b7a03de1b4d0aa230
+    
+        aa69a06 Merge branch 'anonmos1-patch-1'
+        1795c34 Use new address
+
+[33mcommit c0b1ebb634e55604afd73eb193f802db1b4d67cd[m
+Merge: 30f3f38 76f78ee
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Jan 15 16:52:07 2017 -0800
+
+    Merge branch 'anonmos1-patch-1'
+
+[33mcommit 76f78ee9890546f9c55c4a91ac674a12e462bfd7[m
+Author: anonmos1 <60fpsn+3ywbufem17xog@guerrillamailblock.com>
+Date:   Sun Jan 15 18:32:18 2017 +0000
+
+    Use new address
+
+[33mcommit 30f3f380a9910ca921847ebe267ef3dbcbf18079[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jan 14 23:52:09 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 3ab4d48cc8491e41f0bc90c63992b7faa7ab82ab
+        type commit
+        tag adw_3ab4d48c
+        tagger Andrew David Wong <adw@qubes-os.org> 1484434301 -0800
+    
+        Tag for commit 3ab4d48cc8491e41f0bc90c63992b7faa7ab82ab
+    
+        3ab4d48 Merge branch 'lorenzog-master'
+        0a3a51a Minor edits
+        82f43a9 Merge branch 'master' of https://github.com/lorenzog/qubes-doc
+        dc2a854 Fixed titles, added separators, minor cosmetic changes.
+        ba59eef Merged instructions for kali-template with old page
+        b3c9713 Merge remote-tracking branch 'upstream/master'
+        9403c1f fixed broken link
+        739ccc9 incorporated feedback from discussion thread
+        eaa8e21 fixed some 'sudo' commands
+        811b091 updated instructions for Qubes 3.2
+        abf3536 Merge branch 'master' of github-lorenzo:lorenzog/qubes-doc
+        c366477 Added a few notes.
+        0dfe02b Merge pull request #1 from cyrinux/master
+        bf55fee add apt-get upgrade && apt-get dist-upgrade if not this does not work
+        ee4c6a1 WORK IN PROGRESS - Updates and cleanups
+
+[33mcommit bb34420c5c433c09bafc18e1140ab90b68c978b5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jan 14 23:30:58 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object bd3c0b96dedd0e877990442717a30567c0ecf555
+        type commit
+        tag adw_bd3c0b96
+        tagger Andrew David Wong <adw@qubes-os.org> 1484433034 -0800
+    
+        Tag for commit bd3c0b96dedd0e877990442717a30567c0ecf555
+    
+        bd3c0b9 Merge branch 'chemberger-patch-1'
+        8208221 Merge branch 'patch-1' of https://github.com/chemberger/qubes-doc into chemberger-patch-1
+        4a26e23 Contributing document link fix
+
+[33mcommit 4f4fd1e194f79b73b0b465eb25e1b46a543f7c91[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jan 14 23:30:03 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object df6de11213908d93d14c75999193fc1db406cbe2
+        type commit
+        tag adw_df6de112
+        tagger Andrew David Wong <adw@qubes-os.org> 1484432978 -0800
+    
+        Tag for commit df6de11213908d93d14c75999193fc1db406cbe2
+    
+        df6de11 Merge branch 'ezvi-patch-1'
+        7d6204f Merge branch 'patch-1' of https://github.com/ezvi/qubes-doc into ezvi-patch-1
+        c941eaa Update uefi-troubleshooting.md
+
+[33mcommit 908d8adf7256e7a26e7fd0027af021785d109f0b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jan 14 23:28:34 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object a9d20752f3d3d61dac6dc86cd5c8ad6034cfb79a
+        type commit
+        tag adw_a9d20752
+        tagger Andrew David Wong <adw@qubes-os.org> 1484432876 -0800
+    
+        Tag for commit a9d20752f3d3d61dac6dc86cd5c8ad6034cfb79a
+    
+        a9d2075 Merge branch 'thilp-patch-1'
+        ef4056c Merge branch 'patch-1' of https://github.com/thilp/qubes-doc into thilp-patch-1
+        1a855c7 signal.md: fix destination directory for app icon
+
+[33mcommit b5690632d78970c8054a4024f67c9c5929d0f731[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jan 14 15:23:08 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 5573749c16795b52a10584320f93e30f5d9e7494
+        type commit
+        tag adw_5573749c
+        tagger Andrew David Wong <adw@qubes-os.org> 1484403757 -0800
+    
+        Tag for commit 5573749c16795b52a10584320f93e30f5d9e7494
+    
+        5573749 Create minimal hidden service repo documentation
+
+[33mcommit fd9cb27f15df092b315763ec65b180f00039ac85[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Jan 14 00:38:02 2017 -0800
+
+    Add links to bottom Downloads page sections
+    
+    * Hidden service download mirror (QubesOS/qubes-issues#2265)
+    * Templates
+    * Coding guidelines
+
+[33mcommit 3fb83f3aaf098bc98e6abc6c24dfd60c5a94e444[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jan 14 09:33:01 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 6c872d389a1ab53fc9f68fb16d4799f22d101507
+        type commit
+        tag adw_6c872d38
+        tagger Andrew David Wong <adw@qubes-os.org> 1484382745 -0800
+    
+        Tag for commit 6c872d389a1ab53fc9f68fb16d4799f22d101507
+    
+        6c872d3 Link to all mirrors instead of just our FTP server
+
+[33mcommit 639edb9cf85b324c4ca3e3714eba551b798ab9fa[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Jan 14 00:04:56 2017 -0800
+
+    Add link to Tor hidden service to footer
+    
+    QubesOS/qubes-issues#1352
+
+[33mcommit 7d0c295b94dbb35b83b370c6cae7d61ff13cd025[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jan 14 01:11:15 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 2e99efd1700fb950536f00301c126a18cb44e68c
+        type commit
+        tag mm_2e99efd1
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1484352662 +0100
+    
+        Tag for commit 2e99efd1700fb950536f00301c126a18cb44e68c
+    
+        2e99efd Minor update to GUI protocol documentation
+
+[33mcommit b1632f94d6422d867b0ef8196dcd0a135bf52f0e[m
+Merge: 80d9e5f f44e836
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jan 13 01:20:16 2017 -0800
+
+    Merge branch 'mfc-patch-27'
+
+[33mcommit f44e8361ccae568eff76cb8adcd4fa76ca3e78b0[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jan 13 01:18:08 2017 -0800
+
+    Improve text and document structure
+    
+    * Formatting
+    * Orthography
+    * Wrap lines
+    * Use refrence-style links
+
+[33mcommit 50ea7736ae22bb3429ab41533b33e880d95b4447[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Thu Jan 12 06:26:03 2017 -0500
+
+    split funding by year
+
+[33mcommit 80d9e5fe4cd38e3dd6a6496f1789a973ede4635a[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jan 11 21:57:57 2017 -0800
+
+    Deprecate Live USB
+
+[33mcommit 26b345f37a4c3e2cdd35ed821595c839938e09fe[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jan 12 05:10:46 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 87dbe6eafc318cde55cd0e2eeee6d0fac8a389a0
+        type commit
+        tag adw_87dbe6ea
+        tagger Andrew David Wong <adw@qubes-os.org> 1484194211 -0800
+    
+        Tag for commit 87dbe6eafc318cde55cd0e2eeee6d0fac8a389a0
+    
+        87dbe6e Revert "Merge branch 'cgwalters-document-wifi'"
+
+[33mcommit 1cce515a6a87594ed5e0523ce9ac021f4e0b9670[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jan 12 05:00:07 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object f5d5eb46d4c8f074953f6194abfae3289ccaa230
+        type commit
+        tag adw_f5d5eb46
+        tagger Andrew David Wong <adw@qubes-os.org> 1484193467 -0800
+    
+        Tag for commit f5d5eb46d4c8f074953f6194abfae3289ccaa230
+    
+        f5d5eb4 Merge branch 'unman-patch-10'
+        fa46fea Revise for clarity, terminology, and orthography
+        d95582f Add support for updates proxy in VPN doc
+
+[33mcommit 3bd0b544565f0e564686346341ee4a4282a00ca9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 11 23:17:25 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 88a17f2042f52449f1db36d87214c9fb9d84f93b
+        type commit
+        tag adw_88a17f20
+        tagger Andrew David Wong <adw@qubes-os.org> 1484173015 -0800
+    
+        Tag for commit 88a17f2042f52449f1db36d87214c9fb9d84f93b
+    
+        88a17f2 Merge branch 'Jeeppler-patch-1'
+        728f14b Merge branch 'patch-1' of https://github.com/Jeeppler/qubes-doc into Jeeppler-patch-1
+        381020c typo change
+
+[33mcommit e634782b680b318fb8c687e2821dabed9aba290e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 11 22:12:22 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object bb60b2aef26b72f63a15ef7b88635f193b2a51bf
+        type commit
+        tag adw_bb60b2ae
+        tagger Andrew David Wong <adw@qubes-os.org> 1484169117 -0800
+    
+        Tag for commit bb60b2aef26b72f63a15ef7b88635f193b2a51bf
+    
+        bb60b2a Add FAQ entry on distrusting the infrastructure
+
+[33mcommit d3493a113379cf964348727474285e5b69b460be[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 11 21:56:56 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 2ab437d8446d9869471f4c312b1889c1e939a678
+        type commit
+        tag adw_2ab437d8
+        tagger Andrew David Wong <adw@qubes-os.org> 1484168165 -0800
+    
+        Tag for commit 2ab437d8446d9869471f4c312b1889c1e939a678
+    
+        2ab437d Add FAQ entry on using VLC to play video files
+
+[33mcommit 210d495e9dd3367a87fdd1c4aedaa3cf9669c82d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jan 8 18:02:14 2017 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        object 3dc52d25cda66c8f357f679000609a8293d0ab1e
+        type commit
+        tag adw_3dc52d25
+        tagger Andrew David Wong <adw@qubes-os.org> 1483894895 -0800
+    
+        Tag for commit 3dc52d25cda66c8f357f679000609a8293d0ab1e
+    
+        3dc52d2 Update HCL entry: Panasonic_Corporation-CF_191HC51FL
+
+[33mcommit 240b034364d9cb257272c079add2801cba5d7768[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jan 8 17:02:02 2017 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        object 8b6f0a3ff54bad2f16b4da4c9d34471640ca97f6
+        type commit
+        tag adw_8b6f0a3f
+        tagger Andrew David Wong <adw@qubes-os.org> 1483891289 -0800
+    
+        Tag for commit 8b6f0a3ff54bad2f16b4da4c9d34471640ca97f6
+    
+        8b6f0a3 Merge branch 'qmastery16-master'
+        7cff8d3 Add HCL report for Lenovo G505S (Coreboot-SeaBIOS)
+
+[33mcommit 4922254e7dfff89bbc2a837a375c01d61808cfdc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jan 7 08:47:10 2017 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        object ef9021f7e7d5cca68a56cf95a26120bdb1d3708b
+        type commit
+        tag adw_ef9021f7
+        tagger Andrew David Wong <adw@qubes-os.org> 1483775201 -0800
+    
+        Tag for commit ef9021f7e7d5cca68a56cf95a26120bdb1d3708b
+    
+        ef9021f Update my T450s HCL report
+
+[33mcommit 3e24ff1744e707386dcec6cf723538216793622e[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jan 6 23:41:18 2017 -0800
+
+    Add HCL page support for SLAT
+
+[33mcommit 801f5319324a0a3ec5883feb89f531e7c9d051ef[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jan 6 11:42:45 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 39e65004e2b6d055503107bafce2e53d91e41788
+        type commit
+        tag adw_39e65004
+        tagger Andrew David Wong <adw@qubes-os.org> 1483699341 -0800
+    
+        Tag for commit 39e65004e2b6d055503107bafce2e53d91e41788
+    
+        39e6500 Merge branch 'cgwalters-document-wifi'
+        8012d33 Clarify instructions and fix link
+        4376be1 faq: Add how to connect to WiFi
+
+[33mcommit eb699e054ca89e6e2c8fa0eb924e16fd2a7a7f93[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jan 5 14:44:26 2017 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        object c64cc233e3fa2ebeb19a80601a2d503443994b11
+        type commit
+        tag adw_c64cc233
+        tagger Andrew David Wong <adw@qubes-os.org> 1483623834 -0800
+    
+        Tag for commit c64cc233e3fa2ebeb19a80601a2d503443994b11
+    
+        c64cc23 New HCL entry: Panasonic CF-191HC51FL
+
+[33mcommit 61230828c90552d25c45a329b29f618435ba532c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jan 3 22:39:51 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 740b138532e70ed27726ac044b394ee17cc236c4
+        type commit
+        tag adw_740b1385
+        tagger Andrew David Wong <adw@qubes-os.org> 1483479566 -0800
+    
+        Tag for commit 740b138532e70ed27726ac044b394ee17cc236c4
+    
+        740b138 AEM known issue: incompatible with SSD cache
+
+[33mcommit b16fa2cb33877c390c64c1fd1d6ccf73b0987131[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jan 3 15:43:28 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 097797e8622576160eb9cab0bf24d26c62a2989a
+        type commit
+        tag adw_097797e8
+        tagger Andrew David Wong <adw@qubes-os.org> 1483454566 -0800
+    
+        Tag for commit 097797e8622576160eb9cab0bf24d26c62a2989a
+    
+        097797e Merge branch 'SunTsu-master'
+        1640330 [fix] configuration/salt.md: 	Removes leading dash from qubes:type:template: because it only works without
+
+[33mcommit 861ee64f8897c46cf573df76eed21b7c6478d216[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jan 2 23:20:43 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object be0503dd0ab769f8a947846d4942d97e3c681737
+        type commit
+        tag adw_be0503dd
+        tagger Andrew David Wong <adw@qubes-os.org> 1483395611 -0800
+    
+        Tag for commit be0503dd0ab769f8a947846d4942d97e3c681737
+    
+        be0503d Clarify that second issue does not affect R3.2 or later
+
+[33mcommit 988b8a0e079c6585f905b8a12ca488e89d7ae7aa[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jan 1 16:18:55 2017 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 7eb79f504552600e0ed670c9d9e622feaa3950da
+        type commit
+        tag adw_7eb79f50
+        tagger Andrew David Wong <adw@qubes-os.org> 1483283905 -0800
+    
+        Tag for commit 7eb79f504552600e0ed670c9d9e622feaa3950da
+    
+        7eb79f5 Merge branch 'AlmightyLaxz-patch-1'
+        bd2af3c Update remove-vm-manually.md
+
+[33mcommit 9e2deb459bdf49ac9995945efd75fe8dd394016b[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Jan 1 07:08:42 2017 -0800
+
+    Update noscript copyright year
+
+[33mcommit d2422ac02407b48b6a8b28155860d310726f7dab[m
+Merge: 364fff3 c89f9ef
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Dec 28 20:12:40 2016 -0800
+
+    Merge branch 'spmedia-master'
+    
+    QubesOS/qubes-issues#1960
+
+[33mcommit c89f9ef2b16d4353bf6bb549ef9d1a5835b79f07[m
+Author: Edmond Major III <spmediallc@gmail.com>
+Date:   Wed Dec 28 16:09:38 2016 -0600
+
+    Added FB Open Graph & LD+JSON schema meta data
+
+[33mcommit 364fff337d866486ba29b07ed35f573fae3119a7[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 25 10:33:21 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 6d4d8d374ef8551955a054122e79d1aaafc424a4
+        type commit
+        tag adw_6d4d8d37
+        tagger Andrew David Wong <adw@qubes-os.org> 1482658382 -0800
+    
+        Tag for commit 6d4d8d374ef8551955a054122e79d1aaafc424a4
+    
+        6d4d8d3 Update FAQ about "respecting distro culture"
+
+[33mcommit 3806c37cf573953a5709b0c1970ff1a85fd599e6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Dec 24 21:47:24 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 8837109931816a0381b651642cf4d1c9e5f0668a
+        type commit
+        tag adw_88371099
+        tagger Andrew David Wong <adw@qubes-os.org> 1482612420 -0800
+    
+        Tag for commit 8837109931816a0381b651642cf4d1c9e5f0668a
+    
+        8837109 Merge branch 'jpouellet-throwaway-disp'
+        cc8aeea Prefer well defined "disposable" over "throwaway"
+
+[33mcommit 99f6ed316b15a2c234789e6691a6cd8e5df99614[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 22 07:46:14 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 889578f18a426f0e993ded66066f60d597b0a2d9
+        type commit
+        tag adw_889578f1
+        tagger Andrew David Wong <adw@qubes-os.org> 1482389148 -0800
+    
+        Tag for commit 889578f18a426f0e993ded66066f60d597b0a2d9
+    
+        889578f Merge branch 'tasket-patch-10'
+        330fb3e Add Standalone VMs and TRIM/discard
+
+[33mcommit 1e908d38777e4d6d9948d04af0a7db105c99c0d2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 22 07:22:26 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 34544bff5e28fe6b18d98e8d161034956ce8f620
+        type commit
+        tag adw_34544bff
+        tagger Andrew David Wong <adw@qubes-os.org> 1482387732 -0800
+    
+        Tag for commit 34544bff5e28fe6b18d98e8d161034956ce8f620
+    
+        34544bf Add section on upgrading StandaloneVMs
+
+[33mcommit dae55ab57413291d7ce7315e1cb264a680bd743e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 22 07:02:26 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 03e0cb27b49063b0c595e22c5ddec029ce252160
+        type commit
+        tag adw_03e0cb27
+        tagger Andrew David Wong <adw@qubes-os.org> 1482386529 -0800
+    
+        Tag for commit 03e0cb27b49063b0c595e22c5ddec029ce252160
+    
+        03e0cb2 Update Fedora TemplateVM upgrade instructions
+
+[33mcommit 32cf99ca7bf42fdd3ed4c4bafa3e0edb08401bd8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 22 05:04:33 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 2532dce7884878c8add532f1971c94071f1e9967
+        type commit
+        tag adw_2532dce7
+        tagger Andrew David Wong <adw@qubes-os.org> 1482379111 -0800
+    
+        Tag for commit 2532dce7884878c8add532f1971c94071f1e9967
+    
+        2532dce Merge branch 'jpouellet-headings'
+        fc13a32 Merge branch 'headings' of https://github.com/jpouellet/qubes-doc into jpouellet-headings
+        e592b9c Prefer 2nd level headings where appropriate
+
+[33mcommit 0d28fd35fd1b64618c803c75e30163c8a2df0848[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Dec 21 18:16:28 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 44872c7a6a4e078dee7bebc7a7f6ce2cb9cbcfe6
+        type commit
+        tag w_44872c7a
+        tagger Wojtek Porczyk <woju@invisiblethingslab.com> 1482340511 +0100
+    
+        Tag for commit 44872c7a6a4e078dee7bebc7a7f6ce2cb9cbcfe6
+    
+        44872c7 services/mgmt-design: first draft (unfinished)
+
+[33mcommit ee523d05c8448cbf985f6ab93f004a8fad0ee5ea[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Dec 21 18:14:31 2016 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        object 054f7acb6fe2e4ac5e516cab1c4acb4b799d15f7
+        type commit
+        tag w_054f7acb
+        tagger Wojtek Porczyk <woju@invisiblethingslab.com> 1482340442 +0100
+    
+        Tag for commit 054f7acb6fe2e4ac5e516cab1c4acb4b799d15f7
+    
+        054f7ac wiki/mgmt: architecture diagram for MGMT
+
+[33mcommit e2f18b8e6187038609db27f5ed479c8b5e888b11[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Dec 21 09:15:47 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 959c6c610359da021da42d3050737ac45d78013d
+        type commit
+        tag adw_959c6c61
+        tagger Andrew David Wong <adw@qubes-os.org> 1482308115 -0800
+    
+        Tag for commit 959c6c610359da021da42d3050737ac45d78013d
+    
+        959c6c6 Merge branch 'adrelanos-patch-29'
+        5618d7e Merge branch 'patch-29' of https://github.com/adrelanos/qubes-doc into adrelanos-patch-29
+        59cb512 instruct to create /rw/config/qubes-bind-dirs.d
+
+[33mcommit f6a039f8a0b9acd827a4d9160d363c0485110922[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Dec 21 09:13:27 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object e3d42ecab7df53277acca2b3189543ab700723ed
+        type commit
+        tag adw_e3d42eca
+        tagger Andrew David Wong <adw@qubes-os.org> 1482307985 -0800
+    
+        Tag for commit e3d42ecab7df53277acca2b3189543ab700723ed
+    
+        e3d42ec Merge branch 'podmo-patch-1'
+        bb727ab Update fedora-minimal.md
+
+[33mcommit 916038f624fd10eb229522c0f659f35c3c9bfc8d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 20 18:19:06 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        object 2a0c4037a3c9b71b73b941178bc0cb7a3e8404aa
+        type commit
+        tag adw_2a0c4037
+        tagger Andrew David Wong <adw@qubes-os.org> 1482254330 -0800
+    
+        Tag for commit 2a0c4037a3c9b71b73b941178bc0cb7a3e8404aa
+    
+        2a0c403 Organize old post categories
+
+[33mcommit a7a2058b9f88375c4be681e4a7ab01e5002bcb63[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 20 16:02:16 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object ac7b5c0cfc4101e61ed9fc4c3763de5a946a93d5
+        type commit
+        tag adw_ac7b5c0c
+        tagger Andrew David Wong <adw@qubes-os.org> 1482246103 -0800
+    
+        Tag for commit ac7b5c0cfc4101e61ed9fc4c3763de5a946a93d5
+    
+        ac7b5c0 Specify correct Windows power option settings
+
+[33mcommit 16a049ff34aa05c472a4aae8720afb4e4d8aa2a7[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 20 15:45:21 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 0d493e9f1ed5ab2bfcd4edb5fbfcc74931102d4f
+        type commit
+        tag adw_0d493e9f
+        tagger Andrew David Wong <adw@qubes-os.org> 1482245103 -0800
+    
+        Tag for commit 0d493e9f1ed5ab2bfcd4edb5fbfcc74931102d4f
+    
+        0d493e9 Update doc index
+
+[33mcommit ab633de5a53b5fe8d7641f216267ad6df0aac971[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Dec 20 06:37:17 2016 -0800
+
+    Update section on quoting appropriately
+
+[33mcommit 5381395f034a840dfd83fb16e540d740e375d44f[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Dec 20 06:17:43 2016 -0800
+
+    Add important links to top of doc index
+
+[33mcommit 758146e4b3667b45ca280dd2dc11c42e6c113599[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Dec 20 06:03:14 2016 -0800
+
+    Create dedicated doc index layout
+
+[33mcommit efab8594f07717ae526c3ba513232673866841d6[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Dec 20 05:57:16 2016 -0800
+
+    Team page: minor cosmetic cleanup
+
+[33mcommit 5f8bdb91a8ebd16f9de4da9374768d6f75c37ce3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 20 14:36:43 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 7683212c12a955f666391869f61ee6988f251682
+        type commit
+        tag adw_7683212c
+        tagger Andrew David Wong <adw@qubes-os.org> 1482240985 -0800
+    
+        Tag for commit 7683212c12a955f666391869f61ee6988f251682
+    
+        7683212 Create page on removing VMs manually
+
+[33mcommit ee60c25cc579cb40370f004cd95deaf9ed03c271[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 20 12:05:14 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 9e5eb9e36713ae879484d2e2e5685ae00bffd0ea
+        type commit
+        tag adw_9e5eb9e3
+        tagger Andrew David Wong <adw@qubes-os.org> 1482231897 -0800
+    
+        Tag for commit 9e5eb9e36713ae879484d2e2e5685ae00bffd0ea
+    
+        9e5eb9e Fix typo
+
+[33mcommit d20893eebe7ba40f51da65c7449847cfbb4fa1c5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 20 12:04:44 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 45e4ad4eab40ff3abaa42ef254efbbacbd80db48
+        type commit
+        tag adw_45e4ad4e
+        tagger Andrew David Wong <adw@qubes-os.org> 1482231866 -0800
+    
+        Tag for commit 45e4ad4eab40ff3abaa42ef254efbbacbd80db48
+    
+        45e4ad4 Add QSB 28
+
+[33mcommit 115f96228f06eb488ff1e5497bf0f2ddd45a7d97[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 20 12:03:36 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        object 0fbf7c360287dcfeb18df954a21b49cbcb8ff95f
+        type commit
+        tag adw_0fbf7c36
+        tagger Andrew David Wong <adw@qubes-os.org> 1482231789 -0800
+    
+        Tag for commit 0fbf7c360287dcfeb18df954a21b49cbcb8ff95f
+    
+        0fbf7c3 Security: QSB 28
+
+[33mcommit df9a40db35fbb319951509ea863a7a09ed76f038[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 20 09:48:45 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object f03dbddaaa973bb8151092f58fd2e12ce460da92
+        type commit
+        tag adw_f03dbdda
+        tagger Andrew David Wong <adw@qubes-os.org> 1482223699 -0800
+    
+        Tag for commit f03dbddaaa973bb8151092f58fd2e12ce460da92
+    
+        f03dbdd Merge branch 'free5lot-patch-3'
+        e5febd5 Merge branch 'patch-3' of https://github.com/free5lot/qubes-doc into free5lot-patch-3
+        681d94c Update bind-dirs.md
+
+[33mcommit b42486337831e1d39382555536d674b9dd300a17[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 20 09:38:30 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 16ccbbfc68bb15b1cd29302260ab508545e8326f
+        type commit
+        tag adw_16ccbbfc
+        tagger Andrew David Wong <adw@qubes-os.org> 1482223096 -0800
+    
+        Tag for commit 16ccbbfc68bb15b1cd29302260ab508545e8326f
+    
+        16ccbbf Merge branch 'free5lot-patch-2'
+        ab4f1c8 Merge branch 'patch-2' of https://github.com/free5lot/qubes-doc into free5lot-patch-2
+        0df880c Useless word removed
+
+[33mcommit d2e84ca8d5e4c640cee71f67cc226171f92b3a94[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 20 09:34:19 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 852ad690e46067a7d12ae4599a4801e4a1b03d71
+        type commit
+        tag adw_852ad690
+        tagger Andrew David Wong <adw@qubes-os.org> 1482222833 -0800
+    
+        Tag for commit 852ad690e46067a7d12ae4599a4801e4a1b03d71
+    
+        852ad69 Merge branch 'free5lot-patch-1'
+        ce15330 Typo fix: QT->Qt changed
+
+[33mcommit 6801e4ef947967e91d565eb4c4d4d60f740d580c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 19 08:16:02 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 6263370c7681cf0d08f5c3dfb5b8f83fb39f015b
+        type commit
+        tag adw_6263370c
+        tagger Andrew David Wong <adw@qubes-os.org> 1482131748 -0800
+    
+        Tag for commit 6263370c7681cf0d08f5c3dfb5b8f83fb39f015b
+    
+        6263370 Clarify USB qube removal procedure
+
+[33mcommit 19cb79f430310c19f2b327d8ca39c44b27ac53be[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 19 06:54:52 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 5b79a51d762848dd4a8dc67dd5f72d65b83e6c11
+        type commit
+        tag adw_5b79a51d
+        tagger Andrew David Wong <adw@qubes-os.org> 1482126877 -0800
+    
+        Tag for commit 5b79a51d762848dd4a8dc67dd5f72d65b83e6c11
+    
+        5b79a51 Fix broken link
+
+[33mcommit e5930186297986f63e10893a276c87c41d05473b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 19 06:49:11 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object ff20059d677506d15f882369cea4b401dfc6722f
+        type commit
+        tag adw_ff20059d
+        tagger Andrew David Wong <adw@qubes-os.org> 1482126532 -0800
+    
+        Tag for commit ff20059d677506d15f882369cea4b401dfc6722f
+    
+        ff20059 Create instructions for removing USB qube
+
+[33mcommit 11833b225101216a6062078fcd95af429e2d2ce7[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 19 05:59:59 2016 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        object 42aabab534b1dcdf429dedfc716b8d6fcabf0933
+        type commit
+        tag adw_42aabab5
+        tagger Andrew David Wong <adw@qubes-os.org> 1482123586 -0800
+    
+        Tag for commit 42aabab534b1dcdf429dedfc716b8d6fcabf0933
+    
+        42aabab Merge branch 'jpouellet-dom0-copyout'
+        a347379 Add screenshot demonstrating copying out of dom0
+
+[33mcommit ced6f2662c982d8758e65ab3cd3911d1b41463ec[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 19 05:56:38 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object be7630080a73d443fa102279291b86787a6538c6
+        type commit
+        tag adw_be763008
+        tagger Andrew David Wong <adw@qubes-os.org> 1482123385 -0800
+    
+        Tag for commit be7630080a73d443fa102279291b86787a6538c6
+    
+        be76300 Merge branch '3n7r0p1-patch-2'
+        72d816c Merge branch 'patch-2' of https://github.com/3n7r0p1/qubes-doc into 3n7r0p1-patch-2
+        523963f Fix broken link (typo)
+
+[33mcommit cb279caf8153a719b5a5d55e8e57522839df6b16[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 19 05:56:02 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        object 47ffb9a67a808a7de5f5293b2f5be1d30a3237c9
+        type commit
+        tag adw_47ffb9a6
+        tagger Andrew David Wong <adw@qubes-os.org> 1482123327 -0800
+    
+        Tag for commit 47ffb9a67a808a7de5f5293b2f5be1d30a3237c9
+    
+        47ffb9a Merge branch 'jpouellet-copy-docs'
+        f69cba0 Deduplicate dom0 copying info & use canonical links
+
+[33mcommit 63552fad719d8f7860c2b6e6ad3072a26b0a4a2c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 18 12:48:10 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_4712c1cd
+        tagger Andrew David Wong <adw@qubes-os.org> 1482061669 -0800
+    
+        Tag for commit 4712c1cd620654e07c59977f7b849ff4e9d96f1b
+        gpg: Signature made Sun 18 Dec 2016 12:47:49 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4712c1c Press: Interview on The New Screen Savers
+
+[33mcommit 489075a37198077d7f406a01b1d1164bd3b1768e[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 18 03:43:13 2016 -0800
+
+    Create video scripts for posts
+    
+    * Fix typo in preferredQuality variable for existing videos
+    * Add video for recent interview
+
+[33mcommit 6ef3af75cd2aaa5828b20730ecdbf2ecd883be15[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 18 05:57:17 2016 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_63d6994f
+        tagger Andrew David Wong <adw@qubes-os.org> 1482037009 -0800
+    
+        Tag for commit 63d6994f1ee8faeeff747099ff635df326e95088
+        gpg: Signature made Sun 18 Dec 2016 05:56:49 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        63d6994 Create logos with name and slogan
+
+[33mcommit d1f298765878e29d2030b21aff9aff38803213c8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 18 03:58:51 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_8af00728
+        tagger Andrew David Wong <adw@qubes-os.org> 1482029905 -0800
+    
+        Tag for commit 8af007288dd9d8fa037bbcc63fcaf858b5aa57e9
+        gpg: Signature made Sun 18 Dec 2016 03:58:25 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8af0072 Merge branch 'kulinacs-uefi'
+        7e82b24 Clean up text formatting
+        ec97137 Added unrecognized boot device to UEFI troubleshooting
+
+[33mcommit 40d9abaca796be4871a1e3ad8a223c2ca00e46f8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Dec 17 16:49:43 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_f8491fa6
+        tagger Andrew David Wong <adw@qubes-os.org> 1481989762 -0800
+    
+        Tag for commit f8491fa658be18076cebbe2066579c3ff07e3322
+        gpg: Signature made Sat 17 Dec 2016 04:49:23 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f8491fa Update notes on entering fullscreen mode via window manager
+
+[33mcommit c6bf4e2286ce38aff35dbad003d62d413995d902[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Dec 17 16:15:42 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_fd3e197d
+        tagger Andrew David Wong <adw@qubes-os.org> 1481987715 -0800
+    
+        Tag for commit fd3e197d0b616fb521abd30580a84aa6815ff0fd
+        gpg: Signature made Sat 17 Dec 2016 04:15:16 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        fd3e197 Add note about entering fullscreen via window manager
+
+[33mcommit 3578cc751a8a9bc6dd7dc2c7463d6d4f8bb56bf6[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Dec 17 03:50:22 2016 -0800
+
+    Update home page title
+
+[33mcommit 0a05384b4f20059e6531c6203d195a0fb9e1a28e[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Dec 17 03:49:20 2016 -0800
+
+    Update _config.yml
+    
+    * Update meta description
+    * Comment out deprecated onion URL
+    * Add post categories
+
+[33mcommit beb74eee467e9d0678b52bfc29a8a63853a26b25[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Dec 17 02:58:00 2016 -0800
+
+    Update Team page layout
+
+[33mcommit bc5b45825dbe32debacf63c69c9961945dfd8941[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Dec 17 02:57:18 2016 -0800
+
+    Fix post layout on small screens
+
+[33mcommit e3b45a8ab23a3edf9dac374c19a481b6579d691e[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Dec 17 02:47:26 2016 -0800
+
+    Fix news and post layouts on small screens
+
+[33mcommit 4b759dfd6cd4ed933473922f79c3349f2048863d[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Dec 17 02:25:51 2016 -0800
+
+    Add view-by-category and social media buttons to post layout
+
+[33mcommit ac77c7c69b7b47a7da6b30aa4148ee8a1ad963a2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Dec 16 13:40:04 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_7957fdd8
+        tagger Andrew David Wong <adw@qubes-os.org> 1481891979 -0800
+    
+        Tag for commit 7957fdd870b83349807ffa5c5c2a65d4c92db774
+        gpg: Signature made Fri 16 Dec 2016 01:39:40 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7957fdd Add link to Whonix post on DispVMs
+
+[33mcommit 4c1cb2539b63c4c46afd16583e32cc17c1afb08b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Dec 16 12:05:44 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_35661ae1
+        tagger Andrew David Wong <adw@qubes-os.org> 1481886317 -0800
+    
+        Tag for commit 35661ae1b88a1e1b9755c0a7402a42911d0a922f
+        gpg: Signature made Fri 16 Dec 2016 12:05:18 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        35661ae Merge branch 'tasket-patch-9'
+        107bdd7 Fix keywork (again)
+
+[33mcommit 5d6cdc21c5246b5eb4836e20d8d239c3f4c24c01[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Dec 14 14:51:16 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_10009713
+        tagger Andrew David Wong <adw@qubes-os.org> 1481723455 -0800
+    
+        Tag for commit 1000971393d27a818f10c5ceb3f438188a215228
+        gpg: Signature made Wed 14 Dec 2016 02:50:56 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1000971 Security: Qubes Canary 10
+
+[33mcommit 0c53c3b725b78ce4b28fd199f77db1a510ae9bc1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Dec 14 14:44:29 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_1386e109
+        tagger Andrew David Wong <adw@qubes-os.org> 1481723044 -0800
+    
+        Tag for commit 1386e109c4584124c6903a928f33ddb87fd8b2ff
+        gpg: Signature made Wed 14 Dec 2016 02:44:04 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1386e10 Add Canary 10
+
+[33mcommit 486ba87108cfbfe3d0bcbd07ac14a16a4bb5cd8e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 13 07:58:20 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_f1d06447
+        tagger Andrew David Wong <adw@qubes-os.org> 1481612275 -0800
+    
+        Tag for commit f1d06447e876fb6c9193f7a9d624fd35f5263eb7
+        gpg: Signature made Tue 13 Dec 2016 07:57:55 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f1d0644 Add enablerepo reminder; clean up text
+
+[33mcommit 98f5c4c75f7c346adaae42866c9fd366a2e28936[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Dec 12 02:13:14 2016 -0800
+
+    Fix typo
+
+[33mcommit 34de8599b8af6b4c3f2e3e72946e647411164903[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 12 08:33:56 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_95dbf367
+        tagger Andrew David Wong <adw@qubes-os.org> 1481528004 -0800
+    
+        Tag for commit 95dbf367906eb18a3bb53d952e0e404f52ffad9e
+        gpg: Signature made Mon 12 Dec 2016 08:33:23 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        95dbf36 Create Storage Pools documentation
+
+[33mcommit cc4daeab9e307013a743443944bb0bc5711572c0[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 23:21:02 2016 -0800
+
+    Designate Security Info as User Documentation
+
+[33mcommit 8eaba05f681fb8ad5651731e58c16cd91b99af95[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 23:18:33 2016 -0800
+
+    Add and update entries to architecture.yml
+
+[33mcommit 30243177ca3c5926e39f2f2b5f34ad398c663ecb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 11 21:40:25 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_2adda688
+        tagger Andrew David Wong <adw@qubes-os.org> 1481488802 -0800
+    
+        Tag for commit 2adda688d28e48ed455cd671541e6d593a4f8c65
+        gpg: Signature made Sun 11 Dec 2016 09:40:01 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2adda68 Merge branch 'nycatelos-patch-1'
+        eadcc46 Fixed misspelling in archlinux.md
+
+[33mcommit 2cd8e5a9b98806d218c067e21e7aa3a9e3d99866[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 11:58:33 2016 -0800
+
+    Add and update social media icons
+
+[33mcommit ae1dbdf8d0b6b43d4e47896fc2025fcd289deaba[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 11:25:20 2016 -0800
+
+    Add link to Experts page, and add Twitter icons
+
+[33mcommit 2d0a496a715848eed463951ed2a369d6f30aeed5[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 11:24:59 2016 -0800
+
+    Create page for expert endorsements
+
+[33mcommit 13d4a024a94c8ebb7c8a008b0914b2446ea70380[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 11:24:28 2016 -0800
+
+    Update styling for endorsements
+
+[33mcommit 9e4336d5d685d2a81f276ca9b13e483281fcc486[m
+Merge: a4cc0c9 595f066
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 11:23:52 2016 -0800
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit 595f0667eae503b5300d90c860a1604bbaddf86b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 11 20:23:42 2016 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_edd45521
+        tagger Andrew David Wong <adw@qubes-os.org> 1481484199 -0800
+    
+        Tag for commit edd45521b8c9ebc0840846d470894b883c11009e
+        gpg: Signature made Sun 11 Dec 2016 08:23:18 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        edd4552 Add Bill Budington's photo for Experts page
+
+[33mcommit a4cc0c9559f207c3318e49b937a958dccc299278[m
+Merge: ff1e337 a9cf994
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 11:23:40 2016 -0800
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit ff1e3374a96fc4e9dc103f926c9e078f9edbd6ce[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 09:38:25 2016 -0800
+
+    Add icon links to Counter and Twitter
+
+[33mcommit a9cf9942486ea0bd34f71bac6a2d1c507a6d1c43[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 11 18:27:53 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_75f727a9
+        tagger Andrew David Wong <adw@qubes-os.org> 1481477249 -0800
+    
+        Tag for commit 75f727a9f894f43aa05619fd9f5a5327f3c97133
+        gpg: Signature made Sun 11 Dec 2016 06:27:30 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        75f727a Merge branch 'jpouellet-commit-msgs'
+        14dc3f1 Merge branch 'commit-msgs' of https://github.com/jpouellet/qubes-doc into jpouellet-commit-msgs
+        52e8bdb Move git commit guidelines to coding style section
+
+[33mcommit 31389b1bc3960e54aac8dcd2e2ef82c3d3258914[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 11 18:23:41 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_16f12895
+        tagger Andrew David Wong <adw@qubes-os.org> 1481476993 -0800
+    
+        Tag for commit 16f12895d1ceeb608da33037575717c218fc7bdb
+        gpg: Signature made Sun 11 Dec 2016 06:23:13 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        16f1289 Merge branch 'jpouellet-rm-propaganda'
+        a9287aa Merge branch 'rm-propaganda' of https://github.com/jpouellet/qubes-doc into jpouellet-rm-propaganda
+        cb38fda Drop never-used propaganda page
+
+[33mcommit a337a0112baab83f0e497cd8331a9d5ce530a93a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 11 18:22:10 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_a941664f
+        tagger Andrew David Wong <adw@qubes-os.org> 1481476900 -0800
+    
+        Tag for commit a941664ff529e03d3258f2dc952a51b45da862e6
+        gpg: Signature made Sun 11 Dec 2016 06:21:41 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a941664 Merge branch 'jpouellet-wireless-troubleshooting'
+        6c61142 Merge branch 'wireless-troubleshooting' of https://github.com/jpouellet/qubes-doc into jpouellet-wireless-troubleshooting
+        bb1f53e Add troubleshooting for wireless on suspend/resume
+
+[33mcommit db3ce842c840d17e95f295a9adc728290f012fc2[m
+Merge: 28d46f1 a49b2ef
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 09:18:01 2016 -0800
+
+    Merge branch 'jpouellet-rm-freenode'
+
+[33mcommit a49b2ef6b6294b2df887c9f50bb253d393398d47[m
+Merge: 28d46f1 4dddee2
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 09:17:36 2016 -0800
+
+    Merge branch 'rm-freenode' of https://github.com/jpouellet/qubesos.github.io into jpouellet-rm-freenode
+
+[33mcommit 28d46f18bc45e6fb4b260d8d1e5cbf26d7753e2f[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 07:50:25 2016 -0800
+
+    Add additional pages and sections to architecture.yml
+
+[33mcommit fb91505c9853d29a71efde16bbe729dac95810d9[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 07:49:16 2016 -0800
+
+    Fix Join page layout
+
+[33mcommit 1b3528d62fe644ce4b1b18de2eb0dba5a492ea67[m
+Merge: bb062a7 7f935a5
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 07:27:00 2016 -0800
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit bb062a79ed5618990bf3739c728ff30d69e60ba8[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 07:25:05 2016 -0800
+
+    Improve News page layout
+    
+    * Use full column width
+    * Add button to view all news entries by category
+    * Minor: Remove vestigial "black-icon" class from RSS button
+    
+    QubesOS/qubes-issues#2515
+
+[33mcommit 7f935a52caee37b02530aaf85bc9e1b7fe3620c4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 11 16:03:14 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_55c68fc3
+        tagger Andrew David Wong <adw@qubes-os.org> 1481468573 -0800
+    
+        Tag for commit 55c68fc31a50db4baca9d2a008c91b5e4c89f2e3
+        gpg: Signature made Sun 11 Dec 2016 04:02:54 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        55c68fc Fix category casing
+
+[33mcommit b8ad332deeee0936930e3a1150b2e2af8212bc2b[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 06:59:06 2016 -0800
+
+    Turn author and categories into links within each post
+    
+    Closes QubesOS/qubes-issues#2515
+
+[33mcommit d2f5c3971f4f9ca9171b85bde57e29b233552865[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 06:57:35 2016 -0800
+
+    Turn all authors and categories into links on main News page
+    
+    QubesOS/qubes-issues#2515
+
+[33mcommit 1cec4d75e7ad0d055d243881d301fb10be127a4d[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 06:55:55 2016 -0800
+
+    Create News subpage listing all posts by category
+    
+    QubesOS/qubes-issues#2515
+
+[33mcommit 7585a3fbad478e0e2c3e12631e8f23d6362f9735[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 06:45:18 2016 -0800
+
+    Create dedicated layout for News pages
+    
+    Note: This is different from the Post layout. That layout is for
+    individual posts, while this layout is for pages that list multiple
+    posts (/news/ and /news/categories/). It makes more sense to have a
+    dedicated layout for this rater than relying on an ad-hoc exclusion
+    in the Post layout.
+
+[33mcommit 466fc2ae08d12ff69e020a11cb323e888db89028[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 06:35:27 2016 -0800
+
+    Turn all team names and photos into anchor links
+    
+    This allows linking to specific individuals on the Team page.
+
+[33mcommit b07e58d1184813d6736c2db0169de91ff926e6a1[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 06:31:19 2016 -0800
+
+    Improve column balancing code structure
+    
+    This commit counts each group of team members independently, then
+    balances columns within each section based on this independent count,
+    rather than relying on a continous count throughout the page. This
+    allows us to balance columns within the Emeritus section.
+
+[33mcommit 68425c89f91180e6adf6c90410af8d388d87ae28[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Dec 11 02:43:07 2016 -0800
+
+    Fix post category display
+    
+    Fixes QubesOS/qubes-issues#2513
+
+[33mcommit 4dddee24a3bf03a94a8049504da07405ce9a51ee[m
+Author: Jean-Philippe Ouellet <jpo@vt.edu>
+Date:   Sun Dec 11 04:42:03 2016 -0500
+
+    Remove freenode.txt
+    
+    It's only a historical artifact from jekyll's own site which we
+    appear to have pulled in at inception by accident.
+    
+    See https://github.com/jekyll/jekyll/issues/5539
+
+[33mcommit 8073a288dca154a0a693531684c99dd531edc48d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 11 09:08:21 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_011fb06e
+        tagger Andrew David Wong <adw@qubes-os.org> 1481443669 -0800
+    
+        Tag for commit 011fb06e6d342397a7fb931038901a0e629e94da
+        gpg: Signature made Sun 11 Dec 2016 09:07:50 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        011fb06 Add ServiceVM entry
+
+[33mcommit dbadaea7a1a985f72cac2f292c3879a898aa590f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 8 11:58:57 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4751c142
+        tagger Andrew David Wong <adw@qubes-os.org> 1481194717 -0800
+    
+        Tag for commit 4751c14252afcf34eb56077c02877a964d155a36
+        gpg: Signature made Thu 08 Dec 2016 11:58:36 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4751c14 Update examples to fedora-24
+
+[33mcommit 0b30877c092978b26c146c92c5eb12a4b65b1cec[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Dec 8 02:52:54 2016 -0800
+
+    Specify User or Developer doc category in header
+    
+    Fixes QubesOS/qubes-issues#2498
+
+[33mcommit f4e1d3388847c0f55e1fffab9de8fe0f1c442b98[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Dec 8 02:51:56 2016 -0800
+
+    Add categories for User and Developer documentation
+    
+    QubesOS/qubes-issues#2498
+
+[33mcommit d31b6739e6ac1267f31328d24f5a36ea2e7a1a66[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Dec 7 05:40:24 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_8b0d1e6b
+        tagger Andrew David Wong <adw@qubes-os.org> 1481085600 -0800
+    
+        Tag for commit 8b0d1e6b04f495eff8744ed182d52b423af2df0a
+        gpg: Signature made Wed 07 Dec 2016 05:40:01 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8b0d1e6 Merge branch 'evadogstar-patch-1'
+        c3cb47e Update usb.md
+
+[33mcommit 98bedde20e676f707c1464becffcb9d3a3ca1d2a[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Dec 5 21:12:16 2016 -0800
+
+    Add link to commercialization announcement
+
+[33mcommit 3503d7cb655355432529e1c32f2f3aa16efd25a3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 6 06:10:01 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_2ad5a2cf
+        tagger Andrew David Wong <adw@qubes-os.org> 1481000982 -0800
+    
+        Tag for commit 2ad5a2cf4ca89f51c912b21c3dbb8e825c19eda5
+        gpg: Signature made Tue 06 Dec 2016 06:09:43 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2ad5a2c Add commercialization announcement Q&A
+
+[33mcommit b4ffc72baf14e5f9bec2031da2a249632d5d71b2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 5 01:31:30 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_658e02cc
+        tagger Andrew David Wong <adw@qubes-os.org> 1480897867 -0800
+    
+        Tag for commit 658e02cc5090cfc8b7d94d18871a224d8541d3e8
+        gpg: Signature made Mon 05 Dec 2016 01:31:08 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        658e02c Update Xen bug count in sudoers comment
+
+[33mcommit 3b9b48294fa990eeed798739cd4bf5f3ed74caa8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 4 08:51:38 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_044e3d68
+        tagger Andrew David Wong <adw@qubes-os.org> 1480837875 -0800
+    
+        Tag for commit 044e3d6856cb4f4352c72e136bdac8fc02c884bb
+        gpg: Signature made Sun 04 Dec 2016 08:51:16 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        044e3d6 Update command example (QubesOS/qubes-issues#2468)
+
+[33mcommit 25e750d5f8b2a1ef43ae33dd7d05c3bd51b9226a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Dec 3 06:41:05 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_481ca082
+        tagger Andrew David Wong <adw@qubes-os.org> 1480743647 -0800
+    
+        Tag for commit 481ca082df13fdc789c96804e7a19bdc8af46bb3
+        gpg: Signature made Sat 03 Dec 2016 06:40:47 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        481ca08 Update optional post-upgrade steps
+
+[33mcommit f4cbe56ce407f1ef7ab0d512be3c47089a1aaa90[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 1 23:03:36 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_5bb59835
+        tagger Andrew David Wong <adw@qubes-os.org> 1480629782 -0800
+    
+        Tag for commit 5bb59835526ada0cc7b5aa86d90f08c20429a8a5
+        gpg: Signature made Thu 01 Dec 2016 11:03:02 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5bb5983 Fix typo
+
+[33mcommit 981d01b0620f6a1563e4b3672f96727a74ac9796[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 1 14:38:18 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_25cd1f59
+        tagger Andrew David Wong <adw@qubes-os.org> 1480599481 -0800
+    
+        Tag for commit 25cd1f59c3fd4bae2634cc1f0c64054e7ef0de94
+        gpg: Signature made Thu 01 Dec 2016 02:38:02 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        25cd1f5 Add optional post-upgrade steps
+
+[33mcommit 6e5577fe1ff846a82534c183b5e7a270b67acb52[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 1 05:22:26 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_3918733e
+        tagger Andrew David Wong <adw@qubes-os.org> 1480566132 -0800
+    
+        Tag for commit 3918733e29c541ec009ff65cba305dd741088696
+        gpg: Signature made Thu 01 Dec 2016 05:22:12 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3918733 Fix broken link
+
+[33mcommit 8bfb9aca238e0a53c6972f766ced4addc47873c0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 1 05:07:37 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_763cb0b9
+        tagger Andrew David Wong <adw@qubes-os.org> 1480565243 -0800
+    
+        Tag for commit 763cb0b943df29a25239372ba084967e23ce1b32
+        gpg: Signature made Thu 01 Dec 2016 05:07:23 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        763cb0b Merge branch 'lorentrogers-patch-3'
+        61b70c6 Merge branch 'patch-3' of https://github.com/lorentrogers/qubes-doc into lorentrogers-patch-3
+        21656a6 Remove outdated notes
+
+[33mcommit 04839e928ba8b81a85b0514557bd5da12124307c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 1 05:06:47 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_a3d23f70
+        tagger Andrew David Wong <adw@qubes-os.org> 1480565193 -0800
+    
+        Tag for commit a3d23f708fe17d96d975136a119f0e6f79e2ff2c
+        gpg: Signature made Thu 01 Dec 2016 05:06:33 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a3d23f7 Merge branch 'lorentrogers-patch-2'
+        b1bf218 Merge branch 'patch-2' of https://github.com/lorentrogers/qubes-doc into lorentrogers-patch-2
+        ac42284 Fixed a couple grammar / syntax issues
+
+[33mcommit 28c688b557cbce6bf97c853a82fca767312652d5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 1 05:04:46 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_f19d672e
+        tagger Andrew David Wong <adw@qubes-os.org> 1480565071 -0800
+    
+        Tag for commit f19d672e9f8786bd319a35885e8d15f6e6cb2515
+        gpg: Signature made Thu 01 Dec 2016 05:04:31 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f19d672 Merge branch 'lorentrogers-patch-1'
+        e78af02 Update grammar
+
+[33mcommit aa584359d4ee602db8010c81be108708e43593f5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Nov 30 11:10:15 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag joanna_26a88a4c
+        tagger Joanna Rutkowska <joanna@invisiblethingslab.com> 1480500583 +0100
+    
+        Tag for commit 26a88a4c470c1c957e85d940e27d295b11c24fad
+        gpg: Signature made Wed 30 Nov 2016 11:09:45 AM CET using RSA key ID CA74A5C3
+        gpg: Good signature from "Joanna Rutkowska (Qubes Documentation Signing Key) <joanna@invisiblethingslab.com>"
+    
+        26a88a4 New post: Commercialization and Community Funding annoucement
+
+[33mcommit 7048b6d76addff735cca8b8ebd541d5c1c05e18d[m
+Merge: 292cf56 4322d60
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Nov 29 16:34:37 2016 -0800
+
+    Merge branch 'mfc-patch-26'
+
+[33mcommit 4322d60eb47010981c96b6a8c294f250c83b2d92[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Nov 29 16:34:04 2016 -0800
+
+    Wrap lines
+
+[33mcommit 981b5d1f2acc0215538c0151863181c3a1d3e65c[m
+Merge: 292cf56 77294cc
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Nov 29 16:32:28 2016 -0800
+
+    Merge branch 'patch-26' of https://github.com/mfc/qubesos.github.io into mfc-patch-26
+
+[33mcommit 292cf56ad11801f60b9884fbe6ae051cb7924935[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Nov 30 01:31:56 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_b2390b14
+        tagger Andrew David Wong <adw@qubes-os.org> 1480465893 -0800
+    
+        Tag for commit b2390b140a93720c8745a68abf18c15f4fa23d5a
+        gpg: Signature made Wed 30 Nov 2016 01:31:33 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b2390b1 Merge branch 'unman-patch-9'
+        b88ff1d Minor text cleanup
+        86fd16c Update upgrade-8-to-9.md
+
+[33mcommit 77294cc0e41b9e1ef021b107ba9c33aea81ecfe9[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Tue Nov 29 10:48:04 2016 -0500
+
+    make clear that OC uses Stripe
+
+[33mcommit 6349683d10fee84f798bd410741a60723f141fad[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 28 11:36:13 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_8cd05ef8
+        tagger Andrew David Wong <adw@qubes-os.org> 1480329357 -0800
+    
+        Tag for commit 8cd05ef8374a3f9bf8d633d2880706955e5da991
+        gpg: Signature made Mon 28 Nov 2016 11:35:57 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8cd05ef Fix code block formatting
+
+[33mcommit f8a1ee61ec96c91b622b838cf2b3a61b61121a38[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 28 11:30:23 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_de1f58f9
+        tagger Andrew David Wong <adw@qubes-os.org> 1480328730 -0800
+    
+        Tag for commit de1f58f945e5277930ee9226c5cbc61c9298baa7
+        gpg: Signature made Mon 28 Nov 2016 11:25:30 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        de1f58f Merge branch 'jpouellet-book-link'
+        e535198 Use https for Amazon links
+        8616ee7 Update Amazon book link to current edition
+
+[33mcommit f2e56cc7cb65dcb138b8f0467b353ceb38dfb7a6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 28 01:28:50 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_b79b76e1
+        tagger Andrew David Wong <adw@qubes-os.org> 1480292908 -0800
+    
+        Tag for commit b79b76e139967e66c464f019593b3b1653d46090
+        gpg: Signature made Mon 28 Nov 2016 01:28:29 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b79b76e Merge branch 'tasket-patch-8'
+        5e107f5 Merge branch 'patch-8' of https://github.com/tasket/qubes-doc into tasket-patch-8
+        76ecc09 Update vm-sudo.md
+        5dd89f9 Additional step for Whonix
+
+[33mcommit 984b39e64d0b856be12412f4a0df8b109f696c4d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 28 00:52:38 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_72dae152
+        tagger Andrew David Wong <adw@qubes-os.org> 1480290742 -0800
+    
+        Tag for commit 72dae152a5589dddb90e44f465d6cc8fbbc5b351
+        gpg: Signature made Mon 28 Nov 2016 12:52:23 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        72dae15 Note safety of importing installed Fedora signing key
+
+[33mcommit a612a69ee96a26c8efe71595f9503eedd7bd2424[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 28 00:47:13 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_9f58c9c6
+        tagger Andrew David Wong <adw@qubes-os.org> 1480290420 -0800
+    
+        Tag for commit 9f58c9c66ce739ab9f5b0dcb871e0934642c3308
+        gpg: Signature made Mon 28 Nov 2016 12:47:01 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9f58c9c Fix and update broken link
+
+[33mcommit 0daf3992d28deb9e5808b1d63b556329cfcb06e7[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 28 00:30:42 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_7aaf15b1
+        tagger Andrew David Wong <adw@qubes-os.org> 1480289425 -0800
+    
+        Tag for commit 7aaf15b103b532f8c850344df8f97170f879c75d
+        gpg: Signature made Mon 28 Nov 2016 12:30:26 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7aaf15b Reorganize TemplateVM pages
+
+[33mcommit 6b3b8ea9bb6cf5d56f0fb8a3fc0b52145321815f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 26 13:18:32 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_e88a755e
+        tagger Andrew David Wong <adw@qubes-os.org> 1480162701 -0800
+    
+        Tag for commit e88a755e758bfa7ba4f803255af6e8647b33edc9
+        gpg: Signature made Sat 26 Nov 2016 01:18:22 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e88a755 Add custom-install.md to doc index
+        b4f2a1f Write custom installation instructions
+
+[33mcommit 29a1c7c103cc8ca88025fb5fdb48d5192eb213b6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 26 12:58:05 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_99ea91c7
+        tagger Andrew David Wong <adw@qubes-os.org> 1480161145 -0800
+    
+        Tag for commit 99ea91c7ed64ae84c2dc6b4344c2879ea6604ff6
+        gpg: Signature made Sat 26 Nov 2016 12:52:25 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        99ea91c Merge branch 'tezeb-master'
+        eca3cf2 Merge branch 'master' of https://github.com/tezeb/qubes-doc into tezeb-master
+        4ac3ffe Change qubes-builder repo link to official one
+        db3498e Merge branch 'master' of https://github.com/tezeb/qubes-doc into tezeb-master
+        699d546 Update archlinux template building instructions
+
+[33mcommit c503b127da8dd33336bc12fe7959a1da880c7917[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 26 12:57:41 2016 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_311e5940
+        tagger Andrew David Wong <adw@qubes-os.org> 1480161436 -0800
+    
+        Tag for commit 311e5940eff83b583effc5a15ecdf6238d9625b6
+        gpg: Signature made Sat 26 Nov 2016 12:57:16 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        311e594 Merge branch 'tezeb-master'
+        f0f1d28 Merge branch 'master' of https://github.com/tezeb/qubes-attachment into tezeb-master
+        1043967 Change qubes-builder repo link to official one(in screenshot)
+        40894eb Merge branch 'tezeb-master'
+        80e94ed Merge branch 'master' of https://github.com/tezeb/qubes-attachment into tezeb-master
+        d2f1855 Update archlinux template building instructions
+
+[33mcommit f2d72a0f021f420ccc37f851c452f0f61cd68948[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 26 02:17:23 2016 -0800
+
+    Update security entries in architecture.yml
+
+[33mcommit 708adc1b5cd7e005c7438a330fb43de9ac1a6730[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 26 02:16:47 2016 -0800
+
+    Add new security-info directory to doc.yml
+
+[33mcommit 0aa2ebf0c6cefe55dc893741bd3c4db00c68516d[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 26 02:16:24 2016 -0800
+
+    Update links from Security main page
+
+[33mcommit 03b88a866b6c50ea496c8629aa072de2948eba23[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 26 11:15:37 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_1e577ca2
+        tagger Andrew David Wong <adw@qubes-os.org> 1480155314 -0800
+    
+        Tag for commit 1e577ca2729b0ab787a8ad28769de5b5daa8b619
+        gpg: Signature made Sat 26 Nov 2016 11:15:14 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1e577ca Create "Security Information" sections in doc index
+        a16d1e8 Create Qubes Canaries page
+        2380c3d Create QSB template
+        ac832ea Create QSB checklist
+        fbcf95e Move project security pages to separate directory
+
+[33mcommit cb66132a4c9b88b29ff1deb0ccc795aa72b61434[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 26 01:10:55 2016 -0800
+
+    Fix formatting
+
+[33mcommit 3be36e252f3b5879584679d5bc74d5a86fc0e8ba[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 26 01:09:38 2016 -0800
+
+    Update instructions on building the website locally
+
+[33mcommit 3398c336e27bf743b7c0ab2ae025fb14599f7388[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 26 00:14:20 2016 -0800
+
+    Add OpenCollective banners
+
+[33mcommit 11b9747eea9bd0a282186336d09e3970dbfc8308[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Nov 25 19:22:05 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_d1c9bb9f
+        tagger Andrew David Wong <adw@qubes-os.org> 1480098099 -0800
+    
+        Tag for commit d1c9bb9f142df1bdd6e6cf4442606e858a201af5
+        gpg: Signature made Fri 25 Nov 2016 07:21:39 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d1c9bb9 Article: "Qubes OS 3.2" on LWN.net by Nate Drake
+
+[33mcommit a2e490957fbd5137c994786eef568c882b00c772[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Nov 25 14:45:09 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_638fcffc
+        tagger Andrew David Wong <adw@qubes-os.org> 1480081482 -0800
+    
+        Tag for commit 638fcffc51d9fb3ee8524b140fc9516c7b5add06
+        gpg: Signature made Fri 25 Nov 2016 02:44:42 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        638fcff Merge branch 'Natsui31-patch-1'
+        bb135e8 Merge branch 'patch-1' of https://github.com/Natsui31/qubes-doc into Natsui31-patch-1
+        e28c05c Troubleshooting.md fix command typo
+
+[33mcommit 272ab083b7aa296d8ec675fe9c557060296568de[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Nov 25 14:40:06 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_8bf7673e
+        tagger Andrew David Wong <adw@qubes-os.org> 1480081154 -0800
+    
+        Tag for commit 8bf7673e6248ac746dba60d1f9d5c1f21bbe69ae
+        gpg: Signature made Fri 25 Nov 2016 02:39:15 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8bf7673 Merge branch 'lorentrogers-patch-1'
+        cc00dd8 Clarify procedure to back up to a USB mass storage device
+        fbd9b81 Merge branch 'patch-1' of https://github.com/lorentrogers/qubes-doc into lorentrogers-patch-1
+        aac25b7 Clarifies R2 vs R3 language
+
+[33mcommit d96e113ea46107a4d8646489d36a851c9452c919[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Nov 24 15:14:12 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag w_d82e47c4
+        tagger Wojtek Porczyk <woju@invisiblethingslab.com> 1479996730 +0100
+    
+        Tag for commit d82e47c449c707f2edac80d50b6d684c98982f07
+        gpg: Signature made Thu 24 Nov 2016 03:12:10 PM CET using RSA key ID D272F2A8
+        gpg: Good signature from "Wojtek Porczyk (Qubes OS documentation signing key) <woju@invisiblethingslab.com>"
+    
+        d82e47c services/mgmt1: various updates
+
+[33mcommit 663d1eeb78695634c73809cbc2520bbcf94bd311[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Nov 24 00:38:51 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_ab10f7fb
+        tagger Andrew David Wong <adw@qubes-os.org> 1479944303 -0800
+    
+        Tag for commit ab10f7fb60dca1ac1ef37e37d21ec05f369c8d31
+        gpg: Signature made Thu 24 Nov 2016 12:38:23 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ab10f7f Update Fedora version number in examples
+
+[33mcommit 1136af408b90a45c5a67640ccd6cac50898d793b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 22 23:36:18 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_b5aaccb4
+        tagger Andrew David Wong <adw@qubes-os.org> 1479854150 -0800
+    
+        Tag for commit b5aaccb4f30070ea26783de80997b3d628fa6718
+        gpg: Signature made Tue 22 Nov 2016 11:35:50 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b5aaccb Update qubes-secpack page
+
+[33mcommit 88e9e1c9b72eed99e6642924f01770cfdb21aadc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 22 15:09:26 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_c21ea1fc
+        tagger Andrew David Wong <adw@qubes-os.org> 1479823744 -0800
+    
+        Tag for commit c21ea1fc2227a055fe7aa101a1293a772b028458
+        gpg: Signature made Tue 22 Nov 2016 03:09:05 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c21ea1f QSB 27
+
+[33mcommit 03da4141377afa1babe0f8f7d986363cbc7131dc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 22 15:01:08 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_740aa6d4
+        tagger Andrew David Wong <adw@qubes-os.org> 1479823237 -0800
+    
+        Tag for commit 740aa6d4a4efd3b985482f3a1d8e7c00ab382bce
+        gpg: Signature made Tue 22 Nov 2016 03:00:38 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        740aa6d Add QSB 27
+
+[33mcommit e58712a94f16ca37fa54b105ceefdf86e745ad7e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 22 12:11:46 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_eee348c4
+        tagger Andrew David Wong <adw@qubes-os.org> 1479813086 -0800
+    
+        Tag for commit eee348c4ba008b0183b2db0ef23eaf0fce624069
+        gpg: Signature made Tue 22 Nov 2016 12:11:26 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        eee348c Merge branch 'jpouellet-prefer-gtk'
+        7ccc611 Merge branch 'prefer-gtk' of https://github.com/jpouellet/qubes-doc into jpouellet-prefer-gtk
+        3ffc891 Add note to prefer using GTK over Qt for new GUIs
+
+[33mcommit 606b226431e3c9c49f537ee624cfbd8a253ba303[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 22 12:10:54 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_31cac9b3
+        tagger Andrew David Wong <adw@qubes-os.org> 1479813032 -0800
+    
+        Tag for commit 31cac9b3148a9bfbaef7e4df69d6075c5abffd5b
+        gpg: Signature made Tue 22 Nov 2016 12:10:32 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        31cac9b Merge branch 'qubenix-master'
+        f5cec41 Merge branch 'master' of https://github.com/qubenix/qubes-doc into qubenix-master
+        a9a82be Change deprecated `*.cloned-mac-address` to `*.assigned-mac-address`.
+
+[33mcommit 9878e00a8c99fae44b15aba649a2b8b1ed91d3fa[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 22 12:07:40 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_a87b0cd3
+        tagger Andrew David Wong <adw@qubes-os.org> 1479812708 -0800
+    
+        Tag for commit a87b0cd354bdf7754466772194e344aea30ae83e
+        gpg: Signature made Tue 22 Nov 2016 12:05:08 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a87b0cd Merge branch 'jpouellet-safe-remote-ttys'
+        3f7a7e4 Adjust headings for auto-ToC and uniformity
+        ec49fdd Add remote ttys link to master doc index
+        611553d Add header metadata for remote ttys doc
+        0f08f44 Correct serial console device name
+        d89cd3b Add notes on safe remote Dom0 terminals
+
+[33mcommit d37615d0a3d4fd9fb2fb5da8456031208e5dae35[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 20 08:19:21 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_1ff02d4a
+        tagger Andrew David Wong <adw@qubes-os.org> 1479626337 -0800
+    
+        Tag for commit 1ff02d4a0195baf8c4ac9159712b43292f3d3b81
+        gpg: Signature made Sun 20 Nov 2016 08:19:00 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1ff02d4 Add sending/receiving patches to Contributing Code
+
+[33mcommit 66d8655847942bdfd5c9d53a8ed5bb34d0b0fd72[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 20 08:15:59 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_dffe592f
+        tagger Andrew David Wong <adw@qubes-os.org> 1479626136 -0800
+    
+        Tag for commit dffe592fd9cf881871c2f751f58afb3a92cceb64
+        gpg: Signature made Sun 20 Nov 2016 08:15:36 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        dffe592 Update doc index
+
+[33mcommit 8134a3b1b80b38b5bfe532e3ceedbc993b03d7c9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 20 08:09:11 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_0aeeae80
+        tagger Andrew David Wong <adw@qubes-os.org> 1479625730 -0800
+    
+        Tag for commit 0aeeae803d993d9fcfa0343b9d8d19733fc158a4
+        gpg: Signature made Sun 20 Nov 2016 08:08:50 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        0aeeae8 Fix links
+
+[33mcommit ac1ebbe87877d9f4505da7d17f90e318f4bd0b21[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 19 22:56:57 2016 -0800
+
+    Update doc.yml data to reflect current doc organization
+
+[33mcommit 040bd109e2bcca7e20593d0e04dbd7ce8f208bd6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 20 07:56:39 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_a62468d6
+        tagger Andrew David Wong <adw@qubes-os.org> 1479624979 -0800
+    
+        Tag for commit a62468d629b66c35b463f529ba913c6833f44d16
+        gpg: Signature made Sun 20 Nov 2016 07:56:18 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a62468d Create "Releases" section for notes and schedules
+        969400f Link to Contributing Code
+        5245e53 Rewrite Reporting Bugs page
+        c9b06e8 Rewrite Contributing page
+
+[33mcommit 4542584788b85517b9f055e0e9e811acff1817cd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 20 06:30:05 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_7d035ef5
+        tagger Andrew David Wong <adw@qubes-os.org> 1479619784 -0800
+    
+        Tag for commit 7d035ef51841565ab5d79547bae365fdc9ccdceb
+        gpg: Signature made Sun 20 Nov 2016 06:29:44 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7d035ef Update patch submission instructions
+
+[33mcommit 5191e94363fa0c87ed00cc0db9519b1df253d97e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 20 06:05:50 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_94d120f3
+        tagger Andrew David Wong <adw@qubes-os.org> 1479618324 -0800
+    
+        Tag for commit 94d120f3044cbd3c70dbc85ab42f7f1b081287d0
+        gpg: Signature made Sun 20 Nov 2016 06:05:23 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        94d120f Merge branch 'adrianguenter-patch-1'
+        b7c98d2 Add QABS GnuPG dependency for setup script
+
+[33mcommit 77b6e505089b7d6ef81008881923617de754249c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 19 19:16:44 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_5c789585
+        tagger Andrew David Wong <adw@qubes-os.org> 1479579381 -0800
+    
+        Tag for commit 5c78958560ff599a12ba59a04d59d75086b09251
+        gpg: Signature made Sat 19 Nov 2016 07:16:20 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5c78958 Merge branch 'h01ger-master'
+        e112923 qubes-mgmt-salt-admin-tools aint availble for 3.1
+
+[33mcommit 8c05cf84dc05bee9d81701311dda04b572aa0fa5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 19 14:27:13 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_c8b57d86
+        tagger Andrew David Wong <adw@qubes-os.org> 1479562009 -0800
+    
+        Tag for commit c8b57d86fa216a1983ae86098b1cafb69857a3ce
+        gpg: Signature made Sat 19 Nov 2016 02:26:50 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c8b57d8 Use new doc-full layout to prevent table scrolling
+
+[33mcommit 862f9e0c848a19b1f9c65ff1dc491efb72fc8e8e[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 19 05:25:19 2016 -0800
+
+    Create layout for full-size documentation pages
+    
+    QubesOS/qubes-issues#853
+
+[33mcommit f33622325a9a28182777a830234d95b37e2c7761[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 19 05:24:24 2016 -0800
+
+    Tables: Do not limit vertical height or wrap whitespace
+    
+    QubesOS/qubes-issues#853
+
+[33mcommit 67988ddb8015417a49d3ba2e1c20be0d6dcbdeaf[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 19 05:01:57 2016 -0800
+
+    Fix links to Partners and Hardware Certification pages
+
+[33mcommit 06ee95c7d0877184358fa2ca7371130351b2bdc5[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 19 04:59:43 2016 -0800
+
+    Update Hardware Certification page
+    
+    * Clarify that 4.x certification requirements are not minimum
+      requirements
+    * Change contact address to new business address
+
+[33mcommit 3947f0bcc0b6ded71eff56fbf15b787c668c8771[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 19 13:52:11 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_2a39c916
+        tagger Andrew David Wong <adw@qubes-os.org> 1479559911 -0800
+    
+        Tag for commit 2a39c9161e13d09db5689b42e66bb76d5dfe3ddd
+        gpg: Signature made Sat 19 Nov 2016 01:51:51 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2a39c91 Merge branch 'rustybird-mac'
+        4eb23c0 Update MAC address randomization for NetworkManager instructions
+
+[33mcommit 00992d896dae5df8574b4a95a90804f844a1117b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 19 13:41:29 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d8ea9fd6
+        tagger Andrew David Wong <adw@qubes-os.org> 1479559267 -0800
+    
+        Tag for commit d8ea9fd6616f886ab40d9c7a1847a9608fb09fe7
+        gpg: Signature made Sat 19 Nov 2016 01:41:08 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d8ea9fd Clarify Fedora template upgrade process
+
+[33mcommit 78eae0e9be9aadae38a2413b12cd378d472beb39[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 19 13:37:52 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d067df4f
+        tagger Andrew David Wong <adw@qubes-os.org> 1479559045 -0800
+    
+        Tag for commit d067df4f8118148c2177c9f8a1d48878c83f600b
+        gpg: Signature made Sat 19 Nov 2016 01:37:25 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d067df4 Convert h1 headings subsequent to the first to h2 headings
+
+[33mcommit f082241c36c9a2572b40f51471e0e398471be1da[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 19 12:15:50 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_566a3176
+        tagger Andrew David Wong <adw@qubes-os.org> 1479554131 -0800
+    
+        Tag for commit 566a3176d86abeb3f863a4522a089f07fcf978ad
+        gpg: Signature made Sat 19 Nov 2016 12:15:31 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        566a317 Announcement: Qubes at 33C3
+
+[33mcommit 3af2b9956f1ae17f9567b9d6764cf014d0cff387[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 19 10:38:41 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_889a830d
+        tagger Andrew David Wong <adw@qubes-os.org> 1479548296 -0800
+    
+        Tag for commit 889a830d05de10d9e0c89b7182f4a44e32456b5c
+        gpg: Signature made Sat 19 Nov 2016 10:38:17 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        889a830 Clean up table source
+
+[33mcommit b0438f80d98dae77cd7ee99b50f5b5abda095b59[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 19 01:17:08 2016 -0800
+
+    Update article table CSS
+    
+    * Display tables as block elements so they can be scrolled if they
+      overflow
+    * Automatically overflow the X and Y axes
+    * Set the max height of a table to 55% of the vertical height of the
+      viewport
+    * Reduce horizontal cell padding to double the vertical padding
+
+[33mcommit 334f5501fb2eb8ef8674a47d334921d2ed96a867[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 19 10:16:54 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_06b2edcb
+        tagger Andrew David Wong <adw@qubes-os.org> 1479546991 -0800
+    
+        Tag for commit 06b2edcbbff200e1567466d260b3ef2855bc1a92
+        gpg: Signature made Sat 19 Nov 2016 10:16:32 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        06b2edc Remove extra table cells; substitute HTML entity for vbar
+        bb99c1a Convert table to Markdow and remove custom styling
+
+[33mcommit 54b44bca405c236ba02546690266d01e7ec1b66c[m
+Merge: f51eaba 8ab96c3
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 19 00:38:24 2016 -0800
+
+    Merge branch 'mfc-patch-25'
+    
+    Closes QubesOS/qubes-issues#1434
+
+[33mcommit 8ab96c354dfefd2e19d03ad47dbae676275c028e[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 19 00:34:25 2016 -0800
+
+    Redesign Donations page to accommodate Credit Card section
+    
+    * Convert headings to inline HTML
+    * Create links to heading anchors
+    * Add credit card icon
+    * Improve wording
+    * Wrap long lines
+    * Use reference-style links
+
+[33mcommit 9458100232f577eb0b14f36cbecc0dc4849f5cd5[m
+Merge: f51eaba dd2377f
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 19 00:03:36 2016 -0800
+
+    Merge branch 'patch-25' of https://github.com/mfc/qubesos.github.io into mfc-patch-25
+
+[33mcommit f51eaba84e2f94e870f79beb126d771f73395a5e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 19 09:01:53 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_5706da45
+        tagger Andrew David Wong <adw@qubes-os.org> 1479542325 -0800
+    
+        Tag for commit 5706da451cdbdc630ac48db5fee0f9614e2f1f72
+        gpg: Signature made Sat 19 Nov 2016 08:58:44 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5706da4 Merge branch 'rustybird-mac'
+        a810cfb Merge branch 'mac' of https://github.com/rustybird/qubes-doc into rustybird-mac
+        3466bbe Save in conf.d/ instead of modifying NetworkManager.conf
+        91d3aba Also randomize MAC address per Ethernet connection profile
+        82809af [device-scan] -> [device]
+
+[33mcommit b63cccb703495541fe0eb2c8643c21a65143da64[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 19 08:49:06 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_142f3a0b
+        tagger Andrew David Wong <adw@qubes-os.org> 1479541722 -0800
+    
+        Tag for commit 142f3a0b8d6359183bf9d707c6589833822e459a
+        gpg: Signature made Sat 19 Nov 2016 08:48:41 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        142f3a0 Merge branch 'unman-patch-8'
+        b20ab55 Merge branch 'patch-8' of https://github.com/unman/qubes-doc into unman-patch-8
+        ccbb26f Correct typo in vm-sudo.md
+
+[33mcommit 71723076d73c82c5ada5ff56e91713e3dfd3c3ff[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Nov 18 22:43:28 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag w_46d5778b
+        tagger Wojtek Porczyk <woju@invisiblethingslab.com> 1479505247 +0100
+    
+        Tag for commit 46d5778b1902e9037b8ddcbded0c715f9af21367
+        gpg: Signature made Fri 18 Nov 2016 10:40:47 PM CET using RSA key ID D272F2A8
+        gpg: Good signature from "Wojtek Porczyk (Qubes OS documentation signing key) <woju@invisiblethingslab.com>"
+    
+        46d5778 Preliminary management API
+
+[33mcommit dd2377f3f5d72e5f10de2cea45c61e0905afcaae[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Fri Nov 18 13:18:41 2016 -0500
+
+    add mention of OC CC method
+
+[33mcommit b60edc4d057f71eae41104a58ffe0a42bfe9b9ee[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Nov 17 02:43:03 2016 -0800
+
+    Fix first video's menu (fixes QubesOS/qubes-issues#2439)
+
+[33mcommit f308845325e4a2c28f0979fca334f1911749f027[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 15 23:56:56 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_715a1d8d
+        tagger Andrew David Wong <adw@qubes-os.org> 1479250598 -0800
+    
+        Tag for commit 715a1d8d760b8aac857fc7c92e217d6cc7792795
+        gpg: Signature made Tue 15 Nov 2016 11:56:37 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        715a1d8 Announcement: Fedora 24 template available
+
+[33mcommit e3657aa4efc68bad50b033fba9a9b43ec5c6dd11[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 15 09:32:51 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_732ba933
+        tagger Andrew David Wong <adw@qubes-os.org> 1479198748 -0800
+    
+        Tag for commit 732ba9334c4876366a698f446e7e909f3cad8b5d
+        gpg: Signature made Tue 15 Nov 2016 09:32:28 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        732ba93 Add FAQ entry on respecting distros' culture
+
+[33mcommit 82808b7882a361ded0de630a8dd6c92b29ea40e6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 14 18:51:12 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d65904c6
+        tagger Andrew David Wong <adw@qubes-os.org> 1479145843 -0800
+    
+        Tag for commit d65904c68f7c3b422618b0e5ec9e4ce4237468c8
+        gpg: Signature made Mon 14 Nov 2016 06:50:44 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d65904c Merge branch 'mfc-patch-25'
+        435599e fix typo
+
+[33mcommit 940be5cc9f8737527dae83ac12d0baf0afb8d264[m
+Merge: c4d2309 1c4dc2e
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Nov 14 03:59:23 2016 -0800
+
+    Merge branch 'mfc-patch-24'
+
+[33mcommit 1c4dc2eb5004df1fc6192ced88f802abb491917c[m
+Merge: c4d2309 8048917
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Nov 14 03:59:01 2016 -0800
+
+    Merge branch 'patch-24' of https://github.com/mfc/qubesos.github.io into mfc-patch-24
+
+[33mcommit c4d230961efacf521e58dafbbab4d653b30d1028[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 14 12:58:28 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_8570eff5
+        tagger Andrew David Wong <adw@qubes-os.org> 1479124681 -0800
+    
+        Tag for commit 8570eff5a151e30ad0d8dedc76e76de5dac8b63a
+        gpg: Signature made Mon 14 Nov 2016 12:58:02 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8570eff Merge branch 'mfc-patch-24'
+        d77c58b make more inviting, improve language
+
+[33mcommit 804891789912e1996f5b1adc5c8f7cf28f441615[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Sun Nov 13 16:15:42 2016 -0500
+
+    added mention of contributing page
+
+[33mcommit 5fd08faa0bcf95742a0b2d22588057d872c811a5[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Nov 12 12:44:01 2016 -0800
+
+    Fix link to /doc/firewall/
+
+[33mcommit af31a53de3cce7ed5973d1b7cf899bf51c64bb93[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 12 21:40:19 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_2d07f783
+        tagger Andrew David Wong <adw@qubes-os.org> 1478983201 -0800
+    
+        Tag for commit 2d07f7831c9be109f3dbc42165b3e38038f9bee8
+        gpg: Signature made Sat 12 Nov 2016 09:39:59 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2d07f78 Change "/doc/qubes-firewall/" to "/doc/firewall/"
+
+[33mcommit 79fbd67b2283fd489ad857f9e643b1001a582f63[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 12 21:30:04 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_33bd4950
+        tagger Andrew David Wong <adw@qubes-os.org> 1478982583 -0800
+    
+        Tag for commit 33bd4950f2ce9ea3c51d3abfa1359d268b348131
+        gpg: Signature made Sat 12 Nov 2016 09:29:41 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        33bd495 Merge branch 'sprig-florist-master'
+        070b782 Clean up text and formatting; add links
+        9f72eeb Merge branch 'master' of https://github.com/sprig-florist/qubes-doc into sprig-florist-master
+        e91680b Formatted use cases as a table
+        8843982 Re-working the template introduction
+        84a1dd3 Updated the qubes-input-proxy-sender package into another section.
+        a1867f3 Included qubes-input-proxy-sender to the packages
+
+[33mcommit 09ff24b3d5d5bca10bcb85836bad223923d389fe[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 12 01:40:28 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_ee87a5e6
+        tagger Andrew David Wong <adw@qubes-os.org> 1478911206 -0800
+    
+        Tag for commit ee87a5e6d8b77720657bae2aa59c017a904c23b3
+        gpg: Signature made Sat 12 Nov 2016 01:40:07 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ee87a5e Update section link
+
+[33mcommit e5a285b00fa4cbc7c13448c3816c3a0159bf6857[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Nov 11 16:34:02 2016 -0800
+
+    Create Travis email notifications; add self as recipient
+
+[33mcommit bdd7edf0a482f7c6add0af22fb3abce25dae09cc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Nov 11 23:30:45 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_11d78156
+        tagger Andrew David Wong <adw@qubes-os.org> 1478903422 -0800
+    
+        Tag for commit 11d781565c4537e6368cd8ee99a28e84d4f1fc22
+        gpg: Signature made Fri 11 Nov 2016 11:30:21 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        11d7815 Merge branch 'jpouellet-issue-link'
+        6a26f0e Merge branch 'issue-link' of git://github.com/jpouellet/qubes-doc into jpouellet-issue-link
+        6359f87 Fix issue link
+
+[33mcommit c248373a093ae24336123c6ec05459211150c732[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Nov 11 23:28:44 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d9f968e2
+        tagger Andrew David Wong <adw@qubes-os.org> 1478903302 -0800
+    
+        Tag for commit d9f968e2e39bb23a4dfb2038a3444870c429c5ec
+        gpg: Signature made Fri 11 Nov 2016 11:28:21 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d9f968e Merge branch 'unman-patch-6'
+        852212e Remove Known Issues section and update Contributing link
+        e6f34ca Update ubuntu.md
+
+[33mcommit 69ef6500273b2d6243d09246c0abd67c7972ab8f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Nov 10 22:54:27 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d66eda80
+        tagger Andrew David Wong <adw@qubes-os.org> 1478732082 -0800
+    
+        Tag for commit d66eda80bc099864f787683f12a8b70369473af5
+        gpg: Signature made Wed 09 Nov 2016 11:54:46 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d66eda8 Merge branch 'unman-patch-5'
+        28aee1d Fix link and clean up text
+        321e2da Update qubes-firewall.md-include limit on iptables
+
+[33mcommit 2dcbfff0c8f80573b70b5b5a28f2620955051507[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 5 04:31:32 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d8d58192
+        tagger Andrew David Wong <adw@qubes-os.org> 1478316675 -0700
+    
+        Tag for commit d8d58192599ce52bf6b4e128e67ae515cd99fa86
+        gpg: Signature made Sat 05 Nov 2016 04:31:16 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d8d5819 Merge branch 'xet7-master'
+        534c345 Add: Converting VirtualBox VM to HVM
+
+[33mcommit 09b6c1afc0b3e071e1f3ba10e7afda016f953ca8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Nov 3 05:35:34 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_915a1347
+        tagger Andrew David Wong <adw@qubes-os.org> 1478147693 -0700
+    
+        Tag for commit 915a1347c843649a971af35f74e27c85b970badc
+        gpg: Signature made Thu 03 Nov 2016 05:34:56 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        915a134 Remove deprecated section on UEFI boot
+
+[33mcommit e399a42f005bc2ef7c37d543d456df1cd646e74d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Nov 2 12:48:05 2016 +0100
+
+    empty commit: force page rebuild
+
+[33mcommit 7270d664b27bf2117f4bae68618dc3e8cf33e766[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Nov 2 00:58:41 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_87f5804b
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1478044697 +0100
+    
+        Tag for commit 87f5804bed3be3374e928dabf91413c97290b707
+        gpg: Signature made Wed 02 Nov 2016 12:58:17 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        87f5804 Add Fedora 23->24 upgrade instruction
+
+[33mcommit 23641a07f727909dcfb34031417e995421ee1d4d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 1 12:51:19 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_65fc5bc0
+        tagger Andrew David Wong <adw@qubes-os.org> 1478001060 -0700
+    
+        Tag for commit 65fc5bc0c58887333dd08137e5915fb9354e7237
+        gpg: Signature made Tue 01 Nov 2016 12:51:01 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        65fc5bc Clarify wording regarding manual reinstallation option
+
+[33mcommit 88282214802e338fc1edb9c09f389b02375aed6b[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 28 20:17:11 2016 -0700
+
+    Update website footer
+    
+    * Center copyright notice on its own line
+    * Include "Report a problem" link
+
+[33mcommit e1582a8a5f6e5ccc388206a456d21589f63bd177[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Oct 29 03:45:54 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_f38f905b
+        tagger Andrew David Wong <adw@qubes-os.org> 1477705534 -0700
+    
+        Tag for commit f38f905be75ce13ea17366ea791c9b6283a352ed
+        gpg: Signature made Sat 29 Oct 2016 03:45:35 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f38f905 Announcement: New qubes-announce mailing list
+
+[33mcommit 78f77796a0ba368aa004d3104b084a61653779e2[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 28 18:03:57 2016 -0700
+
+    Revert "Fix footer styling"
+    
+    This reverts commit 3ac14723854e97f51f0ecd13ee0871e1fc1873df.
+
+[33mcommit 3ac14723854e97f51f0ecd13ee0871e1fc1873df[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 28 18:01:09 2016 -0700
+
+    Fix footer styling
+
+[33mcommit cdaa5c17c52a74cdc9b0b277c584e08cdf463825[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 28 17:38:34 2016 -0700
+
+    Update website footer
+    
+    * Add copyright notice
+    * Add link to website source code
+    * Add link to sitemap
+    * Make Qubes logo a link to the homepage
+    * Improve layout and spacing
+
+[33mcommit e1aecd12a3a44e29b4ba62e27dbe5932045e75cb[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 28 16:56:09 2016 -0700
+
+    Create robots.txt and specify path to sitemap.xml
+    
+    This makes the sitemap available to search engines.
+    
+    QubesOS/qubes-issues#2396
+
+[33mcommit 9cd20f4040e92a0654ceaaebb86778823b2f57ac[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 28 16:48:16 2016 -0700
+
+    Create sitemap.xml (closes QubesOS/qubes-issues#2396)
+
+[33mcommit 3ad7ebe946bed6331f6907b83db43468cc60a30e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Oct 29 01:35:40 2016 +0200
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag adw_6e4e3800
+        tagger Andrew David Wong <adw@qubes-os.org> 1477697705 -0700
+    
+        Tag for commit 6e4e380070e2cfa66c274dd9f0a48fb01529a27b
+        gpg: Signature made Sat 29 Oct 2016 01:35:06 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6e4e380 Update link to Sony Vaio troubleshooting page
+
+[33mcommit aa3666d76378091b33f97998b1a68e5ac43b6e75[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Oct 27 20:38:12 2016 -0700
+
+    Fix typos (closes QubesOS/qubes-issues#2401)
+
+[33mcommit fff1e19d3230f53824afdd553ce5610ebcf67638[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Oct 27 16:48:51 2016 -0700
+
+    Add entry for qubes-announce
+    
+    QubesOS/qubes-issues#2395
+
+[33mcommit 98b084f35917cd99cd7bf1ce86b233ac5c78285a[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Oct 27 16:05:54 2016 -0700
+
+    Update Versions section heading
+
+[33mcommit 348c7a199f4ac51c3333f4e35ca67e2866f4e674[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Oct 27 16:04:37 2016 -0700
+
+    Refine page styling and layout
+    
+    QubesOS/qubes-issues#2401
+
+[33mcommit 05dd003092d29badd7b18c6c6b731f7c95660f20[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Oct 27 15:36:45 2016 -0700
+
+    Update Travis url-ignore list
+
+[33mcommit a72eecae778129696c9777d9ea403da1fe326b75[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Oct 27 15:27:00 2016 -0700
+
+    Redesign downloads page
+    
+    QubesOS/qubes-issues#2401
+
+[33mcommit 806657efe158823b4e0319af1587d1eb6a7f7214[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Oct 27 15:25:58 2016 -0700
+
+    Add entries for torrents on mirrors.kernel.org
+    
+    QubesOS/qubes-issues#2401
+
+[33mcommit e61a438dcdce8e4e3c7485582ac919dbdc9ea164[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Oct 27 14:00:09 2016 -0700
+
+    Add Mirrors section
+    
+    QubesOS/qubes-issues#2401
+
+[33mcommit 2d5d3599dbf95fa5b2d48ef2602bff0f2c17fe47[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Oct 27 11:16:59 2016 -0700
+
+    Add data for ftp.halifax.rwth-aachen.de mirrors
+    
+    QubeOS/qubes-issues#2401
+
+[33mcommit a810050b1350b6598e69836f9c95dfbb9fd155cd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 27 07:04:57 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_9698d02c
+        tagger Andrew David Wong <adw@qubes-os.org> 1477544679 -0700
+    
+        Tag for commit 9698d02c4fe2f973816f6d1b1ec972675a146a52
+        gpg: Signature made Thu 27 Oct 2016 07:04:39 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9698d02 Merge branch 'thomwiggers-patch-3'
+        6665014 Format instructions
+
+[33mcommit 2d102bfcf8be166aeb3dd0325a3503f462046dcd[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Oct 26 22:02:18 2016 -0700
+
+    Add Mailing Lists icon
+
+[33mcommit 5dd99777081fd93848c8aec39377eedecb310b9f[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Oct 26 21:13:29 2016 -0700
+
+    Update mailing list guidelines
+
+[33mcommit 20634ce27dc0b11adbaf271d20f7e56c4ebaf358[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Oct 25 21:50:39 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_c4b8166f
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1477425024 +0200
+    
+        Tag for commit c4b8166ffe2b9534a1d26ed984d3c8364154e394
+        gpg: Signature made Tue 25 Oct 2016 09:50:24 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        c4b8166 backup format v4: add backup_id field
+
+[33mcommit 2b825d7f71cfbe0448a886771a7c8ad71e4fc40f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Oct 25 07:50:19 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_1cf04660
+        tagger Andrew David Wong <adw@qubes-os.org> 1477374597 -0700
+    
+        Tag for commit 1cf04660426fc6d9e6359a0e9f763a61a0fa542d
+        gpg: Signature made Tue 25 Oct 2016 07:49:57 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1cf0466 Empty commit to test build checks
+
+[33mcommit b2973ca74503066a62ef6635a061456c8eb0abc0[m
+Merge: 4a7ad59 94c0031
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 07:29:24 2016 -0700
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit 4a7ad5903a418d6d0796026af1d2097459880e8f[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 07:28:38 2016 -0700
+
+    Generate favicons for all browsers and platforms
+    
+    Closes QubesOS/qubes-issues#1959
+
+[33mcommit 94c00312bc66c8811c35218e173450cf72e54136[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 24 16:28:28 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_9fa8bdfb
+        tagger Andrew David Wong <adw@qubes-os.org> 1477319268 -0700
+    
+        Tag for commit 9fa8bdfb76f05b56655c46477179a30c806bf151
+        gpg: Signature made Mon 24 Oct 2016 04:27:49 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9fa8bdf Remove old favicons
+
+[33mcommit 3247b13b33deb327546c49e2987b804a0fc37b01[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 02:24:34 2016 -0700
+
+    Apply styling to new player
+
+[33mcommit 52e83e200ae1777674f6e554850eed3be94a62bf[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 02:16:22 2016 -0700
+
+    Fix page layout
+
+[33mcommit 04141cb285e572a3ac8a69a07d7380e75c56e43a[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 02:14:24 2016 -0700
+
+    Fix typo
+
+[33mcommit e6c74af5f286cacb1a76a3a2562b18d5471ed8b9[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 02:09:31 2016 -0700
+
+    Fix player menu
+
+[33mcommit 098abf1352839cc93e7fb92500b78c443937f16f[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 02:05:45 2016 -0700
+
+    Add video menu and description
+
+[33mcommit 570441986a122828336ff839f56440d16aa3b543[m
+Merge: 5f47556 d0d4c39
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 01:43:06 2016 -0700
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit 5f47556c768f3dc611636c746f1a5960414a284a[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 01:42:31 2016 -0700
+
+    Use video ID without list ID
+
+[33mcommit fc6a68bf6fd473a256fc37576084db6ac40a9f93[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 01:42:15 2016 -0700
+
+    Update _doc
+
+[33mcommit d0d4c3976758a37959ac6dc6925088a3a8e8ba15[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 24 10:42:06 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_f879771e
+        tagger Andrew David Wong <adw@qubes-os.org> 1477298492 -0700
+    
+        Tag for commit f879771e241d40747f919b61640cf4e52cb993c3
+        gpg: Signature made Mon 24 Oct 2016 10:41:32 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f879771 Remove index entry for kde-dom0 page
+        3f5c670 Remove deprecated portion on KDE
+
+[33mcommit f139ccfd2aaa57b8e4743f95d0dbf607c686055a[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 01:37:54 2016 -0700
+
+    Add French videos by Paf LeGeek
+
+[33mcommit d15418ddab42b300e4d7c6ae7df218814a421a1b[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 01:17:08 2016 -0700
+
+    Update _doc
+
+[33mcommit 9fcb0f46461e129e24a3137c603920db0c8b6649[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 01:08:07 2016 -0700
+
+    Empty commit for rebuild
+
+[33mcommit a7d445a6bce72263aea7d81a47b10d32105a1985[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 00:58:45 2016 -0700
+
+    Update _doc
+
+[33mcommit 4f8d6f2c2d7f9ee4007681702075625ab6404f34[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 00:57:27 2016 -0700
+
+    Add additional important pages to architecture.yml
+
+[33mcommit 61b4b408ae585b29028d2ac63abca7839a9af533[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 00:48:03 2016 -0700
+
+    Fix links
+
+[33mcommit 22e157e3be41ea321c6b2c590571a501267504dd[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 24 00:45:33 2016 -0700
+
+    Create "Help and Support" and "About Qubes OS" sections
+
+[33mcommit 358f534d545dceab0a91892c7840168065c46dac[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 23 05:28:08 2016 -0700
+
+    Use normal link color for better distinguishability
+
+[33mcommit 758d8706d8d474208cb0270e10a6d894c89e8601[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 23 05:23:50 2016 -0700
+
+    Replace bullets with relevant icons
+
+[33mcommit e44bcc5cbf09ffb818c7239316afd3c478db6715[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 23 05:14:53 2016 -0700
+
+    Add links to Partners and Hardware Cert; fix headers
+
+[33mcommit 4a256b3e99c7097ee688fcf5d2babeb7babe6161[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 23 05:04:30 2016 -0700
+
+    Update design of Team page
+    
+    QubesOS/qubes-issues#1833
+    QubesOS/qubes-issues#2152
+    QubesOS/qubes-issues#2305
+
+[33mcommit 61f438f666b5f85c9b1d4d5d91d4c0ba7cf67c48[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 23 00:59:02 2016 -0700
+
+    Minor: Clarify and reorder Team links
+
+[33mcommit 56474fc74094111eb1243f303975c9e92ab8ca64[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 23 00:47:32 2016 -0700
+
+    Add links to reporting security issues and bugs
+    
+    QubesOS/qubes-issues#1833
+
+[33mcommit 1e080571361dece10c32eecad6b3f51576dfbeb9[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 23 00:35:36 2016 -0700
+
+    Add important pages to architecture.yml
+    
+    QubesOS/qubes-issues#1833
+
+[33mcommit a41947b3e1ce3dba9056a7c25c632e388261636f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 20 09:03:22 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_7ec64614
+        tagger Andrew David Wong <adw@qubes-os.org> 1476946967 -0700
+    
+        Tag for commit 7ec64614bca643e11986c1c956355cbb57adb014
+        gpg: Signature made Thu 20 Oct 2016 09:02:45 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7ec6461 Merge branch 'jpouellet-PVUSB'
+        a478ed0 Remove outdated no-PVUSB claim
+
+[33mcommit c3bfc4bc83520fc434dc646f55d043c1897f7e2c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 20 01:45:28 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_2d930782
+        tagger Andrew David Wong <adw@qubes-os.org> 1476920709 -0700
+    
+        Tag for commit 2d93078274c81aaadb2b36b8d69df13475001f52
+        gpg: Signature made Thu 20 Oct 2016 01:45:08 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2d93078 Add Hardware Certification page to Doc index
+
+[33mcommit 15179b2cf447a0badfaf7ddf6631a4bb153ef730[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Oct 19 16:39:18 2016 -0700
+
+    Merge Help into Docs
+    
+    Closes QubesOS/qubes-issues#1833
+    Closes QubesOS/qubes-issues#1841
+
+[33mcommit 0ca47dcfff482f76bcd3f38d84e931fea4719c59[m
+Merge: 90857cd 7a1626d
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Oct 19 16:39:06 2016 -0700
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit 7a1626d6a8c1c2f86fa3153d7664441e1e398758[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 20 01:38:59 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_63afba63
+        tagger Andrew David Wong <adw@qubes-os.org> 1476920317 -0700
+    
+        Tag for commit 63afba639fa1ad65d8e10536b242206b8cc87737
+        gpg: Signature made Thu 20 Oct 2016 01:38:36 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        63afba6 Merge Help into Docs
+
+[33mcommit 90857cda17c35b2366f623517b1478cd1b428ad3[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Oct 19 16:31:42 2016 -0700
+
+    Update and organize architecture.yml
+
+[33mcommit 1fc14d7a32ef6d3f9016fe5ca5d528a8848f10f2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 20 01:31:28 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_7be7715f
+        tagger Andrew David Wong <adw@qubes-os.org> 1476919862 -0700
+    
+        Tag for commit 7be7715fb5bf79362039b308b88dbeb165628b69
+        gpg: Signature made Thu 20 Oct 2016 01:31:00 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7be7715 Update and organize Doc index
+        31a9ccd Update CONTRIBUTING.md
+        749ce71 Redirect old System Doc to new Developer Docs section
+
+[33mcommit 9d7fb1ad5e6eceb91bde52a967b5fd1107bbf7ed[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Oct 19 15:39:31 2016 -0700
+
+    Remove "Debian template maintainer" from Join page
+    
+    QubesOS/qubes-issues#1700
+
+[33mcommit d8ab8bd277ccc4ab97332cfbd423e20177802cf5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 17 23:25:17 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_e06cafc3
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1476739501 +0200
+    
+        Tag for commit e06cafc33f1c57a3b5e63fdbc94ff4c45a1b2bf2
+        gpg: Signature made Mon 17 Oct 2016 11:25:01 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        e06cafc Fix formatting
+
+[33mcommit 1690ba56fcf3e4ccef229943ad12d23dfa94bc43[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 16 19:44:24 2016 -0700
+
+    Exclude /video-tours/ from Travis check
+
+[33mcommit 6c8588d72aeb7a36ac5801e2abc2ffa0d40bb1a9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Oct 16 23:22:42 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_05e81abf
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1476652949 +0200
+    
+        Tag for commit 05e81abf273348abbf85b11498826fe3c0639477
+        gpg: Signature made Sun 16 Oct 2016 11:22:29 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        05e81ab Testing repository no longer needed for R3.2 upgrade
+
+[33mcommit e7f05ef6b94b8ded2d1a67d39062b1974e9cec1b[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 22:07:29 2016 -0700
+
+    Make footer headings hyperlinks
+
+[33mcommit e27b3c5bea98161662e4b15a826ebbaa4c4a8b7c[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 21:58:03 2016 -0700
+
+    Fix Intro button link
+
+[33mcommit 6201adf0859978516e8d194da94f5459e3f7d803[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 20:31:42 2016 -0700
+
+    Fix permalink for tour videos
+
+[33mcommit 6b692d67c7f9a980211db15913463412a2e13e3f[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 20:27:35 2016 -0700
+
+    Fix button spacing
+
+[33mcommit deb52e83a5398d4422b9c95adf5685e95282e1ff[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 20:23:30 2016 -0700
+
+    Redesign Tour/Intro experience
+    
+    QubesOS/qubes-issues#1833
+    QubesOS/qubes-issues#1841
+
+[33mcommit 253f90a8f2de2faf5756cdeabf25933f33cf1dd8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Oct 16 04:09:56 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_0c953aa3
+        tagger Andrew David Wong <adw@qubes-os.org> 1476583774 -0700
+    
+        Tag for commit 0c953aa394dab372d7d85effa2b34b5920e3da11
+        gpg: Signature made Sun 16 Oct 2016 04:09:34 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        0c953aa Merge branch 'unman-patch-4'
+        08b6cff Merge branch 'patch-4' of git://github.com/unman/qubes-doc into unman-patch-4
+        7a79975 Update managing-vm-kernel.md
+
+[33mcommit 371ade91c9a6242a1f1bb3aa15f18cfc559da83c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Oct 16 04:07:51 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_7c11ec01
+        tagger Andrew David Wong <adw@qubes-os.org> 1476583631 -0700
+    
+        Tag for commit 7c11ec01856c1c21d1bc42f6f86dfe68615175c1
+        gpg: Signature made Sun 16 Oct 2016 04:07:11 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7c11ec0 Merge branch 'unman-2327'
+        425d885 Merge branch '2327' of git://github.com/unman/qubes-doc into unman-2327
+        88122ca Note that cron uses bind-dirs setup
+        b6cf85b Make reference to using bind-dirs with cron
+
+[33mcommit 55a6f67643c70439b563541372940d736502adc4[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 19:00:26 2016 -0700
+
+    Uncomment qubes-os.org download mirror for R3.2
+
+[33mcommit 85b062264bfacf558a53eb5dbf2d9b01435e01e5[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 18:57:05 2016 -0700
+
+    Redesign Downloads page (fixes QubesOS/qubes-issues#2081)
+
+[33mcommit 9bcda93791e3fd0eaafdfe6f02ec4cee38e61315[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Oct 16 02:21:01 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_be5e0df5
+        tagger Andrew David Wong <adw@qubes-os.org> 1476577242 -0700
+    
+        Tag for commit be5e0df56cdaff6010da611d0861a4dcfc2f66c2
+        gpg: Signature made Sun 16 Oct 2016 02:20:41 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        be5e0df Remove page-specific style block for article table
+
+[33mcommit 590fd7a194b3a9e78adb7bbbeecf9b8108cd4b40[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 17:14:27 2016 -0700
+
+    Move custom CSS after Bootstrap imports
+
+[33mcommit b3cc464965f5a0727bc5475e0ba56d96d2005436[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 17:04:06 2016 -0700
+
+    Add site-wide CSS for article tables
+    
+    Fixes QubesOS/qubes-issues#1534
+
+[33mcommit db6d32e7cf565b6474a3f087d37ead2cecd420d1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Oct 16 02:03:56 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_1cc6fe48
+        tagger Andrew David Wong <adw@qubes-os.org> 1476576211 -0700
+    
+        Tag for commit 1cc6fe48ac64ffded7eb52a8be558e067af96ad9
+        gpg: Signature made Sun 16 Oct 2016 02:03:30 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1cc6fe4 Remove page-specific style blocks for article tables
+
+[33mcommit ee2c708ea0edd1bbf17c6a0f5ce8e212f3685dcd[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 16:02:45 2016 -0700
+
+    Update Mailing Lists link
+
+[33mcommit a119e491fe6e827edcc6dec401187e7cdb0f40a1[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 15:50:08 2016 -0700
+
+    Create RSS button for News feed
+    
+    Closes QubesOS/qubes-issues#1638
+
+[33mcommit 2bca9a3628da85b48c2c296fa3b13f70161ab80b[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 15:36:30 2016 -0700
+
+    Remove "Go" from Download links
+
+[33mcommit b11bb75837d37670d40d73dd5c7b612b19138706[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 15:17:07 2016 -0700
+
+    Fix black icon colors
+
+[33mcommit e157ed9732784b011e9775b7718895a899d876d2[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Oct 15 15:14:16 2016 -0700
+
+    Revise home page text
+
+[33mcommit 2cef019b696f5f66ef200167fb0fa9e75ec44177[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 14 22:07:26 2016 -0700
+
+    Update Research data
+    
+    * Create section for secure software development
+    * Add Joanna's post: "Security challenges for the Qubes build process"
+    * Add Joanna's post: "Thoughts on the 'physically secure' ORWL computer"
+
+[33mcommit b6c50fd1ad1591ef9862ac8c6523fb5f9bd262e9[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 14 22:06:54 2016 -0700
+
+    Clarify that the Research page includes blog posts
+
+[33mcommit aa4c64dd0ab2a2540c2bd4532dfb277dd6be10de[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 14 21:56:00 2016 -0700
+
+    Add custom colors for social media icons
+
+[33mcommit 083f39164fe87429a82df09e2221c1665c84bc80[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 14 21:53:35 2016 -0700
+
+    Create "Get Involved" section with social media icons
+    
+    Replaces the "Participate & Engage" section
+    
+    Closes QubesOS/qubes-issues#2306
+
+[33mcommit 9beec14ad50f44923496ce98784bd706e9ce5423[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 14 20:59:36 2016 -0700
+
+    Remove Certified Laptops section
+    
+    QubesOS/qubes-issues#2306
+
+[33mcommit 5f63bedd52d482444de16537f362d068726ec7df[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 14 20:51:56 2016 -0700
+
+    Remove redundant "Q" logo and center main text
+    
+    QubesOS/qubes-issues#2306
+
+[33mcommit 06e9591f402b4b6034703562c40ab63a555dd9e3[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Oct 14 20:39:55 2016 -0700
+
+    Replace "Qubes-certified laptops" with "Watch a Video Tour"
+    
+    Closes #41
+    
+    QubesOS/qubes-issues#2306
+
+[33mcommit cc01f6f48c9a64678e1dc0fee50c0ccef697cfde[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Oct 15 05:33:42 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_5743ca1b
+        tagger Andrew David Wong <adw@qubes-os.org> 1476502399 -0700
+    
+        Tag for commit 5743ca1bfa533b427e389c1c25bea2db2d852119
+        gpg: Signature made Sat 15 Oct 2016 05:33:17 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5743ca1 Merge branch 'tasket-patch-6'
+        af4b8ac Fix formatting
+        36c3d9c Merge branch 'patch-6' of git://github.com/tasket/qubes-doc into tasket-patch-6
+        0fb17b6 Change section titles to match macchanger
+        27dcc6f Update anonymizing-your-mac-address.md
+        bd8765f Add section for Network Manager on Debian 9
+
+[33mcommit 943e21ffe5eb701442323a12aed801ad3deeae9a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Oct 15 05:20:15 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_e3607e8b
+        tagger Andrew David Wong <adw@qubes-os.org> 1476501566 -0700
+    
+        Tag for commit e3607e8bcc1c9f33252a709e72e89f15ac0bcb2a
+        gpg: Signature made Sat 15 Oct 2016 05:19:29 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e3607e8 Merge branch 'unman-patch-4'
+        de5e1d6 Clarify purpose of OS-specific subsections
+        787c1d3 Merge branch 'unman-patch-4'
+        0fe2ff2 Update resize-disk-image.md
+
+[33mcommit 9953dc109796d23e965cd38427fff4ddfbc24b60[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Oct 14 10:19:53 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_b7368ed6
+        tagger Andrew David Wong <adw@qubes-os.org> 1476433165 -0700
+    
+        Tag for commit b7368ed6cfc20a1389eab9286b24adec6b28d50d
+        gpg: Signature made Fri 14 Oct 2016 10:19:23 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b7368ed Merge branch 'tasket-patch-7'
+        365714a Clean up language, formatting, and content
+        dd1ae97 Update reinstall-template.md
+
+[33mcommit 3124ab8e2c4abf1d23ee5a7efafb55e0f12596f8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Oct 11 10:23:03 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_e99c9f85
+        tagger Andrew David Wong <adw@qubes-os.org> 1476174168 -0700
+    
+        Tag for commit e99c9f85c1409b177902092a54c64bb3d50619e1
+        gpg: Signature made Tue 11 Oct 2016 10:22:49 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e99c9f8 Make the image a link
+
+[33mcommit e5783772243ff375415a45b264161480acc2da73[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Oct 11 10:20:23 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_3eb94fe7
+        tagger Andrew David Wong <adw@qubes-os.org> 1476173936 -0700
+    
+        Tag for commit 3eb94fe7cef3d18eed8b3ddff600b9bd923e1d4a
+        gpg: Signature made Tue 11 Oct 2016 10:18:57 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3eb94fe Talk: Marek to present at Security PWNing Conference 2016
+
+[33mcommit b9e3e1920c73c04c192ea0ab315ac8ce7b2c2fb4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Oct 11 10:17:20 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_0c4f8d82
+        tagger Andrew David Wong <adw@qubes-os.org> 1476173819 -0700
+    
+        Tag for commit 0c4f8d82972cc672dadfb6e79fa761859a687777
+        gpg: Signature made Tue 11 Oct 2016 10:17:00 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        0c4f8d8 Add Security PWNing Conference 2016 image
+
+[33mcommit afe094e3b3efd71fca4266eaac0c8b5a1d3352d2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Oct 11 09:48:28 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d94929e2
+        tagger Andrew David Wong <adw@qubes-os.org> 1476172089 -0700
+    
+        Tag for commit d94929e24872d2eed7cc264b2dcb798cdda5793e
+        gpg: Signature made Tue 11 Oct 2016 09:48:05 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d94929e Add `user=root` to qubes.InputKeyboard example policy
+
+[33mcommit 589201f4e2ca414d0ac1510b005e031cb5ff12a8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Oct 11 09:40:53 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_aea661c8
+        tagger Andrew David Wong <adw@qubes-os.org> 1476171633 -0700
+    
+        Tag for commit aea661c81973b3df4d015e30e1775b57229b9aa6
+        gpg: Signature made Tue 11 Oct 2016 09:40:33 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        aea661c Note that qubesctl method hides USB controllers from dom0
+
+[33mcommit 1c47196ce00ad76f192f7a43e9e807f1f467ee9d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Oct 11 09:31:04 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_dd99a852
+        tagger Andrew David Wong <adw@qubes-os.org> 1476171040 -0700
+    
+        Tag for commit dd99a8527511fca75205ddb72a857d57ce44e5e0
+        gpg: Signature made Tue 11 Oct 2016 09:30:41 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        dd99a85 Troubleshooting: ThinkPads with Intel HD 3000 graphics
+        7d3acd9 Generalize ThinkPad Troubleshooting page
+
+[33mcommit 6a314c21bcac9ec659a0594ffa20929210ac6497[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 10 14:01:48 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_39819567
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1476100881 +0200
+    
+        Tag for commit 39819567a93a45ce23adac789b530530d2bb97c1
+        gpg: Signature made Mon 10 Oct 2016 02:01:21 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        3981956 Emergency backup restore v4
+
+[33mcommit ae0fdbee1a272065970c8f04457855eae9dcdbf0[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 9 03:09:32 2016 -0700
+
+    Add link to Developer Documentation
+
+[33mcommit cce3094bb453199c15097a6f6d282141240dc95f[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 9 03:05:31 2016 -0700
+
+    Move Downloads to nav bar; combine Tour & Getting Started
+    
+    QubesOS/qubes-issues#1841
+
+[33mcommit 47cc188a2006e3d6eae6bfc7f54c7a1a686fb868[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 9 02:48:44 2016 -0700
+
+    Remove `prepend: site.url` from nav logo and link
+
+[33mcommit 90d059c9b4645c67bdb25531c8d0a1e25e04f778[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Oct 5 15:38:20 2016 -0700
+
+    Add text and video tours to architecture.yml
+    
+    Closes QubesOS/qubes-issues#2366
+
+[33mcommit 28475d9865c5cb577ffef9e387331e09849bc44b[m
+Merge: 25f2ff9 5158ed9
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Oct 5 15:31:49 2016 -0700
+
+    Merge branch 'endorsements-update'
+
+[33mcommit 5158ed983017ab5489de32fc4dd2ff020d2ab530[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Oct 5 15:28:09 2016 -0700
+
+    Restore Lee's quotation; remove Soghoian's
+
+[33mcommit 243653ba0b235fe82d2ef8c1402260a98c6a00f6[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 3 19:52:16 2016 -0700
+
+    Reduce to four quotations
+
+[33mcommit dcfa6450a94e3f76a59a626ab24bcc277ed63cab[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Oct 3 19:44:11 2016 -0700
+
+    Shorten Snowden quotation and move to first position
+
+[33mcommit 070b0c2cb761d3db9fb3a5907d9aca537824c02d[m
+Merge: 233eeeb f4d0971
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 2 15:31:32 2016 -0700
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io into endorsements-update
+
+[33mcommit f4d0971413271cdcc4079906f979895f65271884[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 3 00:30:55 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_2a4eb299
+        tagger Andrew David Wong <adw@qubes-os.org> 1475447395 -0700
+    
+        Tag for commit 2a4eb2994e91e032a24a25cbe9dea3802b422710
+        gpg: Signature made Mon 03 Oct 2016 12:29:55 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2a4eb29 Add Todd's picture
+        78462a3 Add Soghoian's picture
+
+[33mcommit 233eeebeed74c8d178eccddbbd5ce82db19dc386[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 2 15:23:57 2016 -0700
+
+    Replace "QubesOS" with "Qubes OS"
+    
+    "QubesOS" results from taking the "@QubesOS" Twitter handle and dropping
+    the "@". Since these aren't embedded tweets, and since it doesn't change
+    the meaning of any of the quotations, we should also add the space
+    between "Qubes" and "OS" in keeping with our naming conventions. See:
+    https://www.qubes-os.org/doc/glossary/#qubes-os
+
+[33mcommit f4967ad2db732e4c54ff332e86e6bb4870c6bac3[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 2 15:22:10 2016 -0700
+
+    Add Todd quotation
+
+[33mcommit af1b5782216833ef036eafc2f51bcd3dc17a5785[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 2 15:14:27 2016 -0700
+
+    Add Soghoian quotation
+
+[33mcommit 29767a92f036dd418713fc89f4bf3e662c3bfec3[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Oct 2 15:08:37 2016 -0700
+
+    Update Snowden quotation
+
+[33mcommit 25f2ff9bf9c0bf4c941325b2f47f084442fc4e01[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Oct 2 23:36:49 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4dddf93f
+        tagger Andrew David Wong <adw@qubes-os.org> 1475444189 -0700
+    
+        Tag for commit 4dddf93f508d25671d64033fdc3d35c38bb4634b
+        gpg: Signature made Sun 02 Oct 2016 11:36:29 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4dddf93 Add Fedora 24 and Debian stretch to R3.2 TemplateVMs
+
+[33mcommit a2c8816356ff91fec4b5e8bb3da7dd9d5750a4ca[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Oct 2 04:23:48 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_e4887a2b
+        tagger Andrew David Wong <adw@qubes-os.org> 1475375002 -0700
+    
+        Tag for commit e4887a2b3f31138eeef9f17629fa16833cf4eb1b
+        gpg: Signature made Sun 02 Oct 2016 04:23:22 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e4887a2 Update my photo
+
+[33mcommit e657f3beda8af88503e4a8361cbbe43ef0bab4b3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Oct 1 21:43:35 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_be74d8ae
+        tagger Andrew David Wong <adw@qubes-os.org> 1475350995 -0700
+    
+        Tag for commit be74d8ae2197dbc138cd448d30863563077b8e77
+        gpg: Signature made Sat 01 Oct 2016 09:43:16 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        be74d8a Update Verifying Signatures for R3.2
+        cf6a2a3 Remove old thread link
+        7fb60a6 Note that digests are an alternative verification method
+
+[33mcommit 4a335fa6f77dc25ba6c9f0e40dd37687ac9ded0b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Sep 30 11:22:11 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_e74696ca
+        tagger Andrew David Wong <adw@qubes-os.org> 1475227279 -0700
+    
+        Tag for commit e74696ca9609e9e0179a19124f4292d98693549e
+        gpg: Signature made Fri 30 Sep 2016 11:21:19 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e74696c Merge branch 'mfc-patch-2'
+        5ef11a9 improve language
+
+[33mcommit 44675c0fed41dd333cf982741be075b679ed4d41[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Sep 30 11:20:19 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_a2cbc7d5
+        tagger Andrew David Wong <adw@qubes-os.org> 1475227197 -0700
+    
+        Tag for commit a2cbc7d5d24c8665c67120bc7171402ec155823b
+        gpg: Signature made Fri 30 Sep 2016 11:19:57 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a2cbc7d Merge branch 'redfish64-patch-1'
+        e2bce03 Update upgrade-to-r3.2.md
+
+[33mcommit 0053b309564d044aa0df8fa35ba203f628ce59aa[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Sep 29 06:45:00 2016 -0700
+
+    Update version on "Download & Install" button
+
+[33mcommit 4cd20ab5e7ea1ad0fd36270839227bfe8ed7d4f8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 29 15:27:36 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_29289c59
+        tagger Andrew David Wong <adw@qubes-os.org> 1475155643 -0700
+    
+        Tag for commit 29289c59c8db65f430569929fc2f6ec3d53c1104
+        gpg: Signature made Thu 29 Sep 2016 03:27:23 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        29289c5 Remove outdated configuration section
+
+[33mcommit 3303846b71195488b9ca600964707cbf29f3040f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 29 13:09:52 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_92436058
+        tagger Andrew David Wong <adw@qubes-os.org> 1475147376 -0700
+    
+        Tag for commit 92436058ffcec1ab9457f08dd968e359500b8af4
+        gpg: Signature made Thu 29 Sep 2016 01:09:36 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9243605 Update Supported Versions for R3.2
+
+[33mcommit 30955914ec790a6d367fc6aeee78f98f2348097c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 29 13:05:05 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag joanna_5a141a40
+        tagger Joanna Rutkowska <joanna@invisiblethingslab.com> 1475147087 +0200
+    
+        Tag for commit 5a141a4042787f69b9d3138be338d92a6f50dbc7
+        gpg: Signature made Thu 29 Sep 2016 01:04:51 PM CEST using RSA key ID CA74A5C3
+        gpg: Good signature from "Joanna Rutkowska (Qubes Documentation Signing Key) <joanna@invisiblethingslab.com>"
+    
+        5a141a4 Minor edit in the last post title
+
+[33mcommit bb664fd91300117a8e6307f2672581087188503d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 29 13:01:02 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag joanna_1e0ca49a
+        tagger Joanna Rutkowska <joanna@invisiblethingslab.com> 1475146844 +0200
+    
+        Tag for commit 1e0ca49a047aad6771b0b28e4191ad7ffbb6b956
+        gpg: Signature made Thu 29 Sep 2016 01:00:48 PM CEST using RSA key ID CA74A5C3
+        gpg: Good signature from "Joanna Rutkowska (Qubes Documentation Signing Key) <joanna@invisiblethingslab.com>"
+    
+        1e0ca49 Qubes 3.2 release announcement
+
+[33mcommit 1b4b8744c4800c43e9ed7a1d271b8f651bb0892b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 29 12:57:52 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_3869fd87
+        tagger Andrew David Wong <adw@qubes-os.org> 1475146653 -0700
+    
+        Tag for commit 3869fd8731efb13dbc6346dfeaa78e35fb26f885
+        gpg: Signature made Thu 29 Sep 2016 12:57:33 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3869fd8 Add R3.2 upgrade guide to list
+
+[33mcommit 6e70054e4fa2b900f92e6fcc3e28c894e6e006c3[m
+Merge: 88fe0c9 f0113fc
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Sep 29 03:50:27 2016 -0700
+
+    Merge branch 'r3.2-release'
+
+[33mcommit f0113fc9e8d31d81c9146645ea1ffabea362d89d[m
+Merge: d4d861c 88fe0c9
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Sep 29 03:49:48 2016 -0700
+
+    Merge branch 'master' into r3.2-release
+
+[33mcommit 88fe0c9b12c5887dcbc6c0c79dee063d3beeb81c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 29 12:48:05 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag joanna_de547fd2
+        tagger Joanna Rutkowska <joanna@invisiblethingslab.com> 1475146046 +0200
+    
+        Tag for commit de547fd250bfab57f15bd5c64d06a9897f6e7461
+        gpg: Signature made Thu 29 Sep 2016 12:47:30 PM CEST using RSA key ID CA74A5C3
+        gpg: Good signature from "Joanna Rutkowska (Qubes Documentation Signing Key) <joanna@invisiblethingslab.com>"
+    
+        de547fd Merge pull request #197 from QubesOS/r3.2-release
+        4e87379 Add final 3.2 release to schedule
+        fb483bf R3.2 release
+
+[33mcommit 0795cde390aea3e81b75a56c4a06c4b1454bd5fd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 29 05:02:10 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_35a0572b
+        tagger Andrew David Wong <adw@qubes-os.org> 1475118111 -0700
+    
+        Tag for commit 35a0572b8a3eb8b8b55b8c7471572d43265145ef
+        gpg: Signature made Thu 29 Sep 2016 05:01:50 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        35a0572 Merge branch 'jpouellet-elaborate-nvme-boot'
+        50545a0 Merge branch 'elaborate-nvme-boot' of git://github.com/jpouellet/qubes-doc into jpouellet-elaborate-nvme-boot
+        c638ee8 Elaborate on setting UEFI boot partition.
+
+[33mcommit 97a386b80460ff882d888c216003e900f0ce0e2b[m
+Merge: 5a2fdf5 757043d
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Sep 28 19:59:49 2016 -0700
+
+    Merge branch 'adrelanos-patch-1'
+
+[33mcommit d4d861ced7c1dd6a8511587a3c49c6a44d99f8f7[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 29 01:29:52 2016 +0200
+
+    downloads: final Qubes 3.2
+
+[33mcommit 757043d0d6c77b830476715a19ee1d1db70d8b2e[m
+Author: Patrick Schleizer <adrelanos@riseup.net>
+Date:   Wed Sep 28 23:00:41 2016 +0200
+
+    update Patrick team e-mail
+
+[33mcommit 5a2fdf5b9a0dab466580b600ccf135829760c35d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Sep 28 13:06:39 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_6d4d9452
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1475060788 +0200
+    
+        Tag for commit 6d4d94524383be4d2ae44920a34824b2049238e6
+        gpg: Signature made Wed 28 Sep 2016 01:06:28 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        6d4d945 fix formatting
+
+[33mcommit 7d3da837565f467dd56cc3bc45e503ce315319ea[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Sep 28 13:03:37 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_e5cc989e
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1475060605 +0200
+    
+        Tag for commit e5cc989e1e6b0dd80a6180bb0ff49e4871ec8291
+        gpg: Signature made Wed 28 Sep 2016 01:03:25 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        e5cc989 Add error messages to `pci_strictreset` description
+
+[33mcommit 81fd6c8f6e14b03a72171b87516e104daa55f938[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 27 20:04:28 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_e03416d2
+        tagger Andrew David Wong <adw@qubes-os.org> 1474999448 -0700
+    
+        Tag for commit e03416d287580194b82c20cddcd0aaa6f2ce727e
+        gpg: Signature made Tue 27 Sep 2016 08:04:08 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e03416d HVM templates have been implemented
+
+[33mcommit a87410e941d4612c65e0fd978b4afadcd1a8aa36[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 27 01:27:50 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_b64f4b99
+        tagger Andrew David Wong <adw@qubes-os.org> 1474932454 -0700
+    
+        Tag for commit b64f4b9950cd4c16b07e234d85d418aeecc88118
+        gpg: Signature made Tue 27 Sep 2016 01:27:35 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b64f4b9 Add considerations on choosing a backup passphrase
+
+[33mcommit 5c898104c76e87970a20b62291a20a58c098ced0[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Sep 26 14:42:43 2016 -0700
+
+    Add note about the spam filter
+
+[33mcommit 4f1e9ea487022fa175042f1deef173b807241ac5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Sep 26 23:37:52 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4399f869
+        tagger Andrew David Wong <adw@qubes-os.org> 1474925849 -0700
+    
+        Tag for commit 4399f8698a0d570fe2e2403677bef5d7a300aeef
+        gpg: Signature made Mon 26 Sep 2016 11:37:29 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4399f86 Merge branch 'jpouellet-uefi-symptom'
+        c091be3 Explicitly list another UEFI symptom on troubleshooting page.
+
+[33mcommit 39b6bc92f50828b5854c7895726a4afb58a0a546[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 25 23:06:16 2016 +0200
+
+    Add travis build status icon
+
+[33mcommit 12e63ac24bfc5bbdd5e1cfda95ff7246f9241c32[m
+Merge: 478f402 0921fb0
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Sep 25 13:48:09 2016 -0700
+
+    Merge branch 'travis'
+    
+    Closes QubesOS/qubes-issues#1989
+
+[33mcommit 0921fb0612bed7eb2c4b713e4470e1cc97b19c95[m
+Merge: 42d4587 478f402
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Sep 25 13:41:07 2016 -0700
+
+    Merge branch 'master' into travis
+
+[33mcommit 478f402b30e837766ca66479deeb373017f322bd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 25 15:11:25 2016 +0200
+
+    Revert "Update unman's entry"
+    
+    This reverts commit 148cf27a558d99d6942edfca36ff582e39a8bf0d.
+
+[33mcommit 14d8e1c8a735df3e036755d062a25aec03cf59e8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 25 14:59:31 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_6d8b2926
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1474808358 +0200
+    
+        Tag for commit 6d8b29262126bbd546fddc8bcba24fb1655e81e9
+        gpg: Signature made Sun 25 Sep 2016 02:59:18 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        6d8b292 upgrade-to-r3.1: add note about USB VM and pci_strictreset.
+
+[33mcommit 1590c43fce6094ad1e6ed827fe6784a99a893598[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 25 02:59:42 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_7fefbce8
+        tagger Andrew David Wong <adw@qubes-os.org> 1474765169 -0700
+    
+        Tag for commit 7fefbce868db48bc91d479a768de526348bcf5ac
+        gpg: Signature made Sun 25 Sep 2016 02:59:29 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7fefbce Merge branch 'master' of github.com:QubesOS/qubes-doc
+        c0b33b4 Merge branch 'JoeThielen-patch-1'
+        b3f4255 Clean up text and fix formatting
+        688a658 Merge branch 'patch-1' of git://github.com/JoeThielen/qubes-doc into JoeThielen-patch-1
+        efa0d8a Add fix for Linux HVM kernel error on bootup:   BUG: soft lockup - CPU#0 stuck for 23s! [systemd-udevd:244]
+
+[33mcommit 42d4587de8c2055fa4e5a30fedd839aa69485278[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 25 01:28:50 2016 +0200
+
+    travis: ignore some errors
+    
+    Don't check for:
+     - alt attributes on images
+     - tour page (links generated dynamically)
+     - /qubes-issues/
+     - torrent link hack on downloads page
+
+[33mcommit 4a6efed834d968d26c54c2ca46cb938d76bbad12[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 25 01:28:13 2016 +0200
+
+    Add direct link (id) to specific release on downloads page
+
+[33mcommit 8d9ec1315ce71e537ec2f3749393df406684bd28[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 25 01:27:55 2016 +0200
+
+    Fix links
+
+[33mcommit e9e89e35fad1c9ae54ca4fc8706548e8829bb365[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 25 00:43:39 2016 +0200
+
+    Reuse existing "id" elements in ToC links
+    
+    Do not replace existing (human friendly) names with "tocAnchor-x-y-x".
+    There are two benefits from this:
+     - ToC links are nicer
+     - section links are the same regardless of JS enabled/disabled in
+       browser
+    But there is at least one downside: existing ToC links will stop working
+    ("tocAnchor..." ids are no longer set).
+
+[33mcommit 195a92f64d27b16d3aae53c585324235cbafe9f4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 18 05:01:02 2016 +0200
+
+    Add basic .travis.yml
+
+[33mcommit 8bc716da0d2de3ae233c12c87071b5c9c9bd0431[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 25 01:27:17 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_758a398f
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1474759626 +0200
+    
+        Tag for commit 758a398f31ac731d78d4487e3287b5c9ae918eb7
+        gpg: Signature made Sun 25 Sep 2016 01:27:06 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        758a398 Fix link
+
+[33mcommit df49427a8f98a6cb010071a0ac2f5ed4618e82d6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 25 01:26:49 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_d1e71ebe
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1474759597 +0200
+    
+        Tag for commit d1e71ebefbed3b9e2403c4d6e677a6e71b57e36a
+        gpg: Signature made Sun 25 Sep 2016 01:26:37 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        d1e71eb Drop obsolete hint (no more multiple kernels)
+        e020301 Fix internal links
+
+[33mcommit c17ecf535257e11127f72062b3e46a0154d78d68[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Sep 24 22:13:25 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_f32bf856
+        tagger Andrew David Wong <adw@qubes-os.org> 1474747988 -0700
+    
+        Tag for commit f32bf85689605f1c27f0fe9e7fa3f0682d671788
+        gpg: Signature made Sat 24 Sep 2016 10:13:08 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f32bf85 Fix table of contents (QubesOS/qubes-issues#1941)
+
+[33mcommit 238cf4165a473b205057dd21e03ef60cd0484919[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Sep 23 01:46:16 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_939b0f38
+        tagger Andrew David Wong <adw@qubes-os.org> 1474587957 -0700
+    
+        Tag for commit 939b0f3874d7c974989fec3c268209bd212e807f
+        gpg: Signature made Fri 23 Sep 2016 01:45:57 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        939b0f3 Merge branch 'null0x0-patch-1'
+        50a55ae Merge branch 'patch-1' of git://github.com/null0x0/qubes-doc into null0x0-patch-1
+        a5dc677 Fix typo
+
+[33mcommit e349b7df4e3b406aee222f00ef78674f8e8a268f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Sep 23 01:43:48 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_a1c79ab6
+        tagger Andrew David Wong <adw@qubes-os.org> 1474587812 -0700
+    
+        Tag for commit a1c79ab62f169f91751ac4af342d7584f1e0c817
+        gpg: Signature made Fri 23 Sep 2016 01:43:32 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a1c79ab Merge branch 'i7u-patch-2'
+        7afc65a Merge branch 'patch-2' of git://github.com/i7u/qubes-doc into i7u-patch-2
+        288f092 Update signal.md
+
+[33mcommit 4c1ac39d3ed578612e35b043b0af0ffe74cd8c8c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 22 03:11:12 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_7c2c6a79
+        tagger Andrew David Wong <adw@qubes-os.org> 1474506650 -0700
+    
+        Tag for commit 7c2c6a79f33957a277fe6261faeaf101e92ff2cd
+        gpg: Signature made Thu 22 Sep 2016 03:10:51 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7c2c6a7 Correct "PVH" to "PVHVM"
+        51d6be4 Add entry for "TemplateBasedHVM"
+
+[33mcommit f5b53aaa4c9814328e939c4979ec23247490791c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Sep 21 19:57:44 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d3f1a137
+        tagger Andrew David Wong <adw@qubes-os.org> 1474480624 -0700
+    
+        Tag for commit d3f1a137189a68de75bcb988c99f7518aeab1da1
+        gpg: Signature made Wed 21 Sep 2016 07:57:06 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d3f1a13 Add QSB 26
+
+[33mcommit 0dd671f5cb2e433b18dc6953a07c8dc7fc5aaad4[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Sep 20 05:22:23 2016 -0700
+
+    Add Simon's photo
+
+[33mcommit b1f44960fd7083a1fb0901dbbcad89ce00c8a11b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 20 14:22:17 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_c5cf3518
+        tagger Andrew David Wong <adw@qubes-os.org> 1474374104 -0700
+    
+        Tag for commit c5cf351861c4d83ef59faa7050fb86697646b63b
+        gpg: Signature made Tue 20 Sep 2016 02:21:44 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c5cf351 Add Simon's photo
+
+[33mcommit e6a4f062bc9a6a8f613c296bceed456f521f842e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Sep 19 01:53:20 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_dae8dfda
+        tagger Andrew David Wong <adw@qubes-os.org> 1474242782 -0700
+    
+        Tag for commit dae8dfda68813ef7f0106e1d0c08d34f995f90f0
+        gpg: Signature made Mon 19 Sep 2016 01:53:03 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        dae8dfd Fix code blocks
+        9d1211a Merge branch 'kewde-patch-3'
+        46b1680 Merge branch 'patch-3' of git://github.com/kewde/qubes-doc into kewde-patch-3
+        6595b07 Fix formatting
+
+[33mcommit 386198c20dbf5170e62de89fabe2823bb11f5025[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Sep 19 01:49:45 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_aeb12c20
+        tagger Andrew David Wong <adw@qubes-os.org> 1474242559 -0700
+    
+        Tag for commit aeb12c20c81b6d455b067c3b35025552f36a815f
+        gpg: Signature made Mon 19 Sep 2016 01:49:20 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        aeb12c2 Merge branch 'kewde-patch-2'
+        f404e16 Merge branch 'patch-2' of git://github.com/kewde/qubes-doc into kewde-patch-2
+        3db5623 More language fixes
+        6a5ed72 Fixed typos and language errors
+
+[33mcommit aabad240e81bb8125dd200aff12bde077927227f[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Sep 18 16:44:30 2016 -0700
+
+    Remove Joanna's email address
+
+[33mcommit 2f8e07c9f9c1c5e42f69f80c5cd04e33931d94de[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Sep 18 16:44:07 2016 -0700
+
+    Make core team email address display optional
+
+[33mcommit 148cf27a558d99d6942edfca36ff582e39a8bf0d[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Sep 18 16:39:10 2016 -0700
+
+    Update unman's entry
+
+[33mcommit 7f3cdfd8b1610d272206a497a999a9596615ca24[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Sep 18 16:37:55 2016 -0700
+
+    Update order of Emeritus entries
+
+[33mcommit ab060d01456f9c02038304ffe22e15fd244599c9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Sep 19 01:37:22 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_893ec2bb
+        tagger Andrew David Wong <adw@qubes-os.org> 1474241805 -0700
+    
+        Tag for commit 893ec2bb6aa9f3e291f3cb2ee1fe97d814e806a2
+        gpg: Signature made Mon 19 Sep 2016 01:36:46 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        893ec2b Add Nvidia troubleshooting guide to index
+
+[33mcommit 573134f2e7e5e7830b20064bdd288c5c6223c7fa[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 18 02:24:06 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_73309552
+        tagger Andrew David Wong <adw@qubes-os.org> 1474158191 -0700
+    
+        Tag for commit 733095528a0e0f7d331a7d41a034b309f72fa9b0
+        gpg: Signature made Sun 18 Sep 2016 02:23:12 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7330955 Merge branch 'bkerlin-patch-1'
+        3ec3970 Merge branch 'patch-1' of git://github.com/bkerlin/qubes-doc into bkerlin-patch-1
+        1a62109 Update hvm.md
+
+[33mcommit b97c979cbbe52f9384861b209dc6000c3e881008[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 18 02:20:38 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_9d515d54
+        tagger Andrew David Wong <adw@qubes-os.org> 1474158011 -0700
+    
+        Tag for commit 9d515d54917c15d88a0016afd1b61d9db683f875
+        gpg: Signature made Sun 18 Sep 2016 02:20:11 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9d515d5 Merge branch 'kewde-patch-1'
+        1a828a1 Fix formatting throughout
+        222020c Merge branch 'patch-1' of git://github.com/kewde/qubes-doc into kewde-patch-1
+        a4d1c56 Update nvidia-troubleshooting.md
+        8762fba Bring more structure to the page
+        e00b3e3 Update nvidia-troubleshooting.md
+        ddc59df Add nouveau disable instructions
+
+[33mcommit c9ff7af0f74538335051407943bac2162107abcc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Sep 17 23:01:38 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_3a9cbd7b
+        tagger Andrew David Wong <adw@qubes-os.org> 1474146077 -0700
+    
+        Tag for commit 3a9cbd7b8a39c22a261c051b8d24bf0818cf91ec
+        gpg: Signature made Sat 17 Sep 2016 11:01:17 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3a9cbd7 Add QSB 25
+
+[33mcommit 93907421fe8cf5d5b91c9a8de1582e864f79491b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Sep 17 11:50:24 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_fbbe1394
+        tagger Andrew David Wong <adw@qubes-os.org> 1474105803 -0700
+    
+        Tag for commit fbbe1394320117f4d6ac7d2c047b4e209d49f915
+        gpg: Signature made Sat 17 Sep 2016 11:50:03 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        fbbe139 Fix code block and image
+
+[33mcommit edc8269034f4e239f141eeafc901a6d4da44c30c[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Sep 16 15:01:49 2016 -0700
+
+    Add Simon's entry
+
+[33mcommit d548cebcdc8b55fc3b697e1d5cdbb31d06e9a3d3[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Sep 16 15:01:18 2016 -0700
+
+    Add description of Emeritus group
+
+[33mcommit 4ab9adc87269bd41c7c922347d9dbee1d5879db1[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Sep 16 15:01:02 2016 -0700
+
+    Update Brennan's entry
+
+[33mcommit 72233990895cc544d2f15f9e825493d383feda6f[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Sep 16 14:27:24 2016 -0700
+
+    List Community Contributors in alphabetical order
+
+[33mcommit 4ffc765c0428dc31c2d3d0f35e0dfb28f0fd3888[m
+Merge: feef19a 4580c30
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Sep 16 14:19:57 2016 -0700
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit feef19a1a8d5468d20ee5357cec919e3e957a6d9[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Sep 16 14:18:58 2016 -0700
+
+    Add press and business group contact addresses
+    
+    QubesOS/qubes-issues#2305
+
+[33mcommit 4580c30e514dba1c25dbd97d8f684ff7f66f8538[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Sep 16 23:09:54 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_ebe7c067
+        tagger Andrew David Wong <adw@qubes-os.org> 1474060124 -0700
+    
+        Tag for commit ebe7c067fe3ee956d2f3404f0e8cc705a39a18a5
+        gpg: Signature made Fri 16 Sep 2016 11:08:44 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ebe7c06 Merge branch 'tasket-patch-4'
+        77c6bf3 Merge branch 'patch-4' of git://github.com/tasket/qubes-doc into tasket-patch-4
+        abfdb29 Update vpn.md
+        93f0211 Update vpn.md
+
+[33mcommit caa67b21223ab60a42b384238f94efd8a9022890[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 15 22:25:52 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_728b45d6
+        tagger Andrew David Wong <adw@qubes-os.org> 1473970984 -0700
+    
+        Tag for commit 728b45d6de50f720766fc9d27e27d1098b8314c3
+        gpg: Signature made Thu 15 Sep 2016 10:23:05 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        728b45d Merge branch 'bind-dirs'
+        28ec000 Fix discussion link
+        ed11064 Fix Markdown formatting
+        f1e091e Add title and fix heading levels
+        437ea38 bind-dirs: move to customization, add to main index
+        fcdfccf bind-dirs: adjust title
+        9e8daab Add bind dirs documentation
+
+[33mcommit 284f6d7e6948f41880564f112cb6f4377b1dd24f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 15 11:10:21 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_932dc330
+        tagger Andrew David Wong <adw@qubes-os.org> 1473930588 -0700
+    
+        Tag for commit 932dc330f54974aa68f3174f2c0b59d411e78ca2
+        gpg: Signature made Thu 15 Sep 2016 11:09:49 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        932dc33 Clarify UEFI system requirement for R3.x
+
+[33mcommit f27d874a9f3ad5c07466d32930a5b4a3744b4612[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 15 10:52:44 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_1448c1e7
+        tagger Andrew David Wong <adw@qubes-os.org> 1473929528 -0700
+    
+        Tag for commit 1448c1e7ab8ba17c7a9b9fdd53fcdefb0f1b329b
+        gpg: Signature made Thu 15 Sep 2016 10:52:09 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1448c1e Add link to rustybird's Split dm-crypt
+
+[33mcommit e1f2cd5abb1a51133b2eaaebe6b1a8780fcb958d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 15 01:23:42 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_f07119c7
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1473895409 +0200
+    
+        Tag for commit f07119c7168ef89590f19362ff2f5682298a49fd
+        gpg: Signature made Thu 15 Sep 2016 01:23:29 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        f07119c Add link to Debian wiki about Qubes
+        027f5c7 vm-interface: in the end new meminfo-writer use the same key as the old one
+        22439b4 Clarification/update for vm-interface - firewall
+
+[33mcommit d7cc59450747b414c00024ccac824807a20c9578[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Sep 10 10:23:58 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag zrubi_6603a347
+        tagger Zrubi <mail@zrubi.hu> 1473495765 +0200
+    
+        Tag for commit 6603a347feebef05c49503d590893cf53d5d7eaf
+        gpg: Signature made Sat 10 Sep 2016 10:22:45 AM CEST using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        6603a34 correcting some formatting glitches
+
+[33mcommit 5a0dcb7d411452138d8bf3201b3d43d8731c7b4d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Sep 10 09:50:04 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag zrubi_6f9f3d1e
+        tagger Zrubi <mail@zrubi.hu> 1473493720 +0200
+    
+        Tag for commit 6f9f3d1e7616ac528c30199a1edc2a2ce5b1e0e3
+        gpg: Signature made Sat 10 Sep 2016 09:48:40 AM CEST using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        6f9f3d1 correcting some formatting glitches
+
+[33mcommit afe59badd9f4d87db895c85d0bcb8f4c00931b05[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Sep 9 22:15:50 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_6cf98dda
+        tagger Andrew David Wong <adw@qubes-os.org> 1473452132 -0700
+    
+        Tag for commit 6cf98ddad2ba1f926e24e96d8c6e0ad989f22653
+        gpg: Signature made Fri 09 Sep 2016 10:15:32 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6cf98dd Add note regarding safety of EOL base OS in dom0
+        ab1ce56 KDE default login manager
+
+[33mcommit c8472215af55c150bbbf2b9cfe73c922139a6161[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Sep 9 00:43:53 2016 -0700
+
+    Fix release entry order
+
+[33mcommit 923f165e0b724bd8eec9f1c599a411c013c08d8f[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Sep 9 00:43:22 2016 -0700
+
+    Change R3.0 status to unsupported
+
+[33mcommit 7b9982465737121bb29d5732faa2b52db23c8721[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Sep 9 09:38:42 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_7c67ef65
+        tagger Andrew David Wong <adw@qubes-os.org> 1473406702 -0700
+    
+        Tag for commit 7c67ef6517b663e1b86dda9428db2714a33da620
+        gpg: Signature made Fri 09 Sep 2016 09:38:22 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7c67ef6 Change R3.0 status to unsupported
+
+[33mcommit bff45e2ef1ef43d30d9069a028084a64891808f1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 8 09:05:54 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_95750c53
+        tagger Andrew David Wong <adw@qubes-os.org> 1473318315 -0700
+    
+        Tag for commit 95750c535d79a615290a1742bd5ce94c3bcac931
+        gpg: Signature made Thu 08 Sep 2016 09:05:15 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        95750c5 Merge branch 'i7u-patch-1'
+        7a637ca Fix Signal page link
+        1201017 Update managing-appvm-shortcuts.md
+
+[33mcommit debd9a98e8b8dee022ce08465cfc09a8b150108f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 6 18:59:52 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_7a5c8306
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1473181157 +0200
+    
+        Tag for commit 7a5c830646c3e458f74930fdb004fa7508a93e1e
+        gpg: Signature made Tue 06 Sep 2016 06:59:17 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        7a5c830 Add missing step to R3.1->R3.2 upgrade instruction
+        e99688b Add missing step to R3.0->R3.1 upgrade instruction
+        66134b8 vm-interface: firewall interface for R4.0+
+        a17d9bf vm-interface: new memory/prefmem interface for qmemman
+        b3cf466 vm-interface: Add info about qubes-primary-dns entry in R3.2+
+        1edfcd2 Describe firewall interface in Qubes 3.x
+        3147679 Update QubesDB key names
+
+[33mcommit a65af633b2b3a2cbc7f2042e223842b232bd7eb8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Sep 2 20:48:21 2016 +0200
+
+    autoupdate: _doc _posts
+    
+    _doc:
+        tag adw_45f249f0
+        tagger Andrew David Wong <adw@qubes-os.org> 1472841239 -0700
+    
+        Tag for commit 45f249f028a90d633b3f641f094711a5e2f2f975
+        gpg: Signature made Fri 02 Sep 2016 08:33:59 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        45f249f Update System Requirements page in advance of 4.x
+    
+    _posts:
+        tag adw_b35d0580
+        tagger Andrew David Wong <adw@qubes-os.org> 1472842031 -0700
+    
+        Tag for commit b35d0580fe3d4bc29f36d80d9c32a0f9f6e7d4ee
+        gpg: Signature made Fri 02 Sep 2016 08:47:11 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b35d058 Announcement: R3.0 EOL on 2016-09-09
+        1d84a12 Announcement: Min reqs for 4.x & extended support for 3.2
+
+[33mcommit f5540ef9ad9b2b03637cc1f5c055ef71b263a14a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 1 03:10:32 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_343d9328
+        tagger Andrew David Wong <adw@qubes-os.org> 1472692195 -0700
+    
+        Tag for commit 343d932889c6fd79557f6f025b5f826bc45b2225
+        gpg: Signature made Thu 01 Sep 2016 03:09:56 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        343d932 Merge branch 'omeg-master'
+        c50dc03 Update link to Windows Tools 3 page
+        9f173ad Merge branch 'master' of git://github.com/omeg/qubes-doc into omeg-master
+        5c1c4f9 QWT installation: add note about pvdriver popups
+        cb9db6d QWT installation: update uninstallation info
+        f8787d2 QWT installation: update log file information
+        8192057 QWT: update state of disk PV drivers
+        ce665ef Windows templates: don't encourage totally disabling updates
+        49b57d6 QWT: add note about full desktop being the default mode
+        3d8346f QWT installation: small clarification
+        3755c5a QWT installation: add note about multiple reboots
+        12c36a0 QWT installation: add explicit instructions for disabling driver signature enforcement
+        04b6bbc QWT installation: change order of operation to be more natural
+
+[33mcommit ea1f1dd2daba29b676d92eeab042f1c14fb3a3fc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 31 22:09:56 2016 +0200
+
+    enable kernel.org mirror for R3.2-rc3
+
+[33mcommit 1621dd12a65c4257c0fcc0efe67c94c9c531a238[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 31 18:02:16 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_9b909893
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1472659319 +0200
+    
+        Tag for commit 9b9098932b8596601336eea28b626decb6ea0d6b
+        gpg: Signature made Wed 31 Aug 2016 06:01:59 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        9b90989 Document qubes.ResizeDisk service.
+
+[33mcommit b992574d80870f608cca104270b76d8ec8f7705d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 31 18:01:24 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_ff92813e
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1472659270 +0200
+    
+        Tag for commit ff92813e577dab163abedaa54159fa82b817d3b6
+        gpg: Signature made Wed 31 Aug 2016 06:01:10 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        ff92813 Update R3.2 release notes
+
+[33mcommit c26ce070bd29f548da8feb56d767f5548cbcb4fb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 31 16:34:52 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_958f29ad
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1472654035 +0200
+    
+        Tag for commit 958f29ad2791cfe9c7e1b1594bd4dd980e043186
+        gpg: Signature made Wed 31 Aug 2016 04:33:56 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        958f29a R3.2-rc3 announcement
+
+[33mcommit a3bd0b9af2c43b4fea919136e1e8f97f0639f71b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 31 16:32:15 2016 +0200
+
+    R3.2-rc3 download links
+
+[33mcommit 49649005442ab43d819bbb5e2bc5141a8cce94e6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 31 12:00:21 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_c2a78ccb
+        tagger Andrew David Wong <adw@qubes-os.org> 1472362190 -0700
+    
+        Tag for commit c2a78ccbe2279971fbb6ecf9db9e4ed13000fe26
+        gpg: Signature made Sun 28 Aug 2016 07:29:50 AM CEST using RSA key ID 8CE137352A019A17
+        gpg: Good signature from "Andrew David Wong (Qubes Documentation Signing Key)" [unknown]
+        gpg: WARNING: This key is not certified with a trusted signature!
+        gpg:          There is no indication that the signature belongs to the owner.
+        Primary key fingerprint: E11D 15C6 D204 3576 9FFA  A456 8CE1 3735 2A01 9A17
+    
+        c2a78cc Update GRUB menu step
+        f9b89af Merge branch 'crat0z-master'
+        55aa8be Strengthen disclaimer; clean up text and formatting
+        5cacc4a Merge branch 'master' of git://github.com/crat0z/qubes-doc into crat0z-master
+        4e4ecad Add Dom0 prompt for root in Debian/Whonix VMs
+
+[33mcommit 057fe2492f5fe50154f99dc1a87b2b949e8d9be8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Aug 25 00:02:25 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_2bf9ae2a
+        tagger Andrew David Wong <adw@qubes-os.org> 1472076124 -0700
+    
+        Tag for commit 2bf9ae2aec8f278ef3db331c10f013dfbe20fd8b
+        gpg: Signature made Thu 25 Aug 2016 12:02:04 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2bf9ae2 Fix typo
+
+[33mcommit 0a879ae49a858284795f606d4ae4eccbcb566966[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Aug 25 00:00:42 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_642098d4
+        tagger Andrew David Wong <adw@qubes-os.org> 1472075995 -0700
+    
+        Tag for commit 642098d4ac994f9488bdd38710a1266e9125c086
+        gpg: Signature made Wed 24 Aug 2016 11:59:56 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        642098d Add Signal guide to index
+        045cc66 Create Signal guide
+
+[33mcommit 817920038a339d61bd9ac492fc9f4aaa22c4df37[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 24 00:55:07 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d7e25541
+        tagger Andrew David Wong <adw@qubes-os.org> 1471992876 -0700
+    
+        Tag for commit d7e255412cea269802697898ff4c6c3941bc0994
+        gpg: Signature made Wed 24 Aug 2016 12:54:38 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d7e2554 Merge branch 'timove-patch-1'
+        bfec50e fixed a typo in reinstall-template.md
+
+[33mcommit c95d264262e766f1a6e111b38f20cc4832d22b46[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Aug 21 07:13:22 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d30bc4a2
+        tagger Andrew David Wong <adw@qubes-os.org> 1471756369 -0700
+    
+        Tag for commit d30bc4a2ec95b42caf8d3b39966ada98229aa239
+        gpg: Signature made Sun 21 Aug 2016 07:12:50 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d30bc4a Merge branch 'JeremyRand-encryption-config-typo-fix'
+        000997d Fix typo in "encryption config" docs.
+
+[33mcommit 10c8a22c3a7dda5828ce9413e3a0e178ddb453ea[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Aug 19 20:03:30 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_de24de47
+        tagger Andrew David Wong <adw@qubes-os.org> 1471629766 -0700
+    
+        Tag for commit de24de4770f6982c32e088fdf1bcdc49808edfac
+        gpg: Signature made Fri 19 Aug 2016 08:02:46 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        de24de4 Merge branch 'ProgVal-patch-1'
+        182d1df Use instructions for latest stable, supported template
+        d8634ac Fix broken link to “Compacting templates root.img”.
+
+[33mcommit ce2cfc03f873b1091409c792ac0dcecf808346c6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 17 01:02:34 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_cce10079
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1471388539 +0200
+    
+        Tag for commit cce10079b322f8e898cb2b4e23b48c4886aac4d9
+        gpg: Signature made Wed 17 Aug 2016 01:02:19 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        cce1007 qrexec: add info about new DispVM options in Qubes 4.0
+
+[33mcommit 041517a47f42e688c7ceb34fe70fac6120c6ebd5[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Aug 15 19:10:03 2016 -0700
+
+    Add Reddit link
+
+[33mcommit aaf3b7a8a2a738aa31c5215d197f68a17438df1b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Aug 16 03:43:44 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_c46cd728
+        tagger Andrew David Wong <adw@qubes-os.org> 1471311786 -0700
+    
+        Tag for commit c46cd728cc71706b6c3e867331255c0e1a52f9e8
+        gpg: Signature made Tue 16 Aug 2016 03:43:06 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c46cd72 Update with link to Windows-based AppVMs page
+
+[33mcommit 62dc0a4a2d5da555e4f55839f55a8f8c6a9a6aaa[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Aug 16 03:25:47 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_c381ba26
+        tagger Andrew David Wong <adw@qubes-os.org> 1471310722 -0700
+    
+        Tag for commit c381ba2696abde7d7a94f467683d9600d3692e39
+        gpg: Signature made Tue 16 Aug 2016 03:25:22 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c381ba2 Merge branch 'ailijic-patch-1'
+        94bdfff Merge branch 'patch-1' of git://github.com/ailijic/qubes-doc into ailijic-patch-1
+        315ce7b Same issue for thinkpad x200
+
+[33mcommit 64ab1dc6c53771a9894655fe27a137b2c2fdae11[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Aug 16 03:24:38 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_aa7889d1
+        tagger Andrew David Wong <adw@qubes-os.org> 1471310644 -0700
+    
+        Tag for commit aa7889d11ad3012abde9eac5af12c880fc58d69a
+        gpg: Signature made Tue 16 Aug 2016 03:24:01 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        aa7889d Merge branch 'rasnauf-master'
+        45b2ccc Fix broken link
+
+[33mcommit dd3e8e8daa9d8bd00a28506ee11a0b6e6b175de8[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Aug 13 08:00:29 2016 -0700
+
+    Update mailing list guidelines
+    
+    * Keep the list CCed
+    * Quote selectively
+
+[33mcommit 42bd8070145f0b4387416263416a9ff02738282a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 10 19:10:53 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d900d3b4
+        tagger Andrew David Wong <adw@qubes-os.org> 1470849038 -0700
+    
+        Tag for commit d900d3b4b888499e605e3c9845bd403c942712de
+        gpg: Signature made Wed 10 Aug 2016 07:10:36 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d900d3b Add section on installing KDE (R3.2 and later)
+
+[33mcommit 1bf7b5312f6c5c42a7cd25c4487eec90beefcea9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 10 18:55:38 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_bfc64fd5
+        tagger Andrew David Wong <adw@qubes-os.org> 1470848123 -0700
+    
+        Tag for commit bfc64fd5cfcd72b4c150e1b68864aa266f2006d1
+        gpg: Signature made Wed 10 Aug 2016 06:55:24 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        bfc64fd Merge branch 'acarlisle28-patch-1'
+        ad048f1 Update archlinux.md
+
+[33mcommit e3b99fdbf97341abe33a1b24ac12397f3a43b84a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 10 10:52:54 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_4c025ee6
+        tagger Andrew David Wong <adw@qubes-os.org> 1470819160 -0700
+    
+        Tag for commit 4c025ee6af5ab35f3da9f2f9e1625b56aaf19a4a
+        gpg: Signature made Wed 10 Aug 2016 10:52:38 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4c025ee Add entry for video of Marek's talk from RMLL 2016
+        702e671 Add link to video
+
+[33mcommit e986c5dc35b37fd17432dc25db6d1def53b9f2fa[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 10 10:08:34 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_c923c29b
+        tagger Andrew David Wong <adw@qubes-os.org> 1470816494 -0700
+    
+        Tag for commit c923c29b3aa961cd82a3d72c4ea7d40524386362
+        gpg: Signature made Wed 10 Aug 2016 10:08:14 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c923c29 Merge branch 'master' of github.com:QubesOS/qubes-doc
+        43b6abb Revise text
+        073f12f Add table showing dom0 OS used in each release
+
+[33mcommit 35f8a27e302acdb30aff929306137532ab2159fd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Aug 9 20:40:35 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_a1b244d1
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1470767991 +0200
+    
+        Tag for commit a1b244d17071eafd5d5770b1c11b781fe9d7b320
+        gpg: Signature made Tue 09 Aug 2016 08:39:53 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        a1b244d upgrade-to-r3.2: one more package to download manually on Debian updatevm
+
+[33mcommit e8f107f4413132f86bd88a4c9738f19adedc0bf2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Aug 9 19:31:59 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_bc2ac360
+        tagger Andrew David Wong <adw@qubes-os.org> 1470763903 -0700
+    
+        Tag for commit bc2ac3609e8b0a31fc8c158d40290939e98666a5
+        gpg: Signature made Tue 09 Aug 2016 07:31:44 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        bc2ac36 Add Release 3.2 entry
+
+[33mcommit 0940e7b498133883a7ce0ab37adcc528c00cac1a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Aug 6 17:11:57 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_1cc40df1
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1470496306 +0200
+    
+        Tag for commit 1cc40df1c08930d997eaa9e2e911345a6f34b2c4
+        gpg: Signature made Sat 06 Aug 2016 05:11:46 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        1cc40df Update vm-interface page
+
+[33mcommit e9384377ec399af701ff96b9ab2c1334a4d3013e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Aug 6 05:39:03 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_e0f787f0
+        tagger Andrew David Wong <adw@qubes-os.org> 1470454714 -0700
+    
+        Tag for commit e0f787f0cb651382a8d214ad7f0be149bcb2b240
+        gpg: Signature made Sat 06 Aug 2016 05:38:33 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e0f787f Fix links to devel and user key messages
+        0ae2e72 Use long form PGP key IDs and reference-style links
+        83bd0ec Wrap lines and fix typo
+        627e84a Explain how to verify hashes with *sum programs
+
+[33mcommit ac1743d40e0b96b2583d9356d0de79ede995b787[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Aug 6 01:17:47 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_76904074
+        tagger Andrew David Wong <adw@qubes-os.org> 1470439055 -0700
+    
+        Tag for commit 76904074ec63ff2df8cb7f37b615caf537766e0d
+        gpg: Signature made Sat 06 Aug 2016 01:17:34 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7690407 Merge branch 'thomwiggers-patch-2'
+        13e5ede Merge branch 'patch-2' of git://github.com/thomwiggers/qubes-doc into thomwiggers-patch-2
+        99566ff Explicitly install required dependencies
+
+[33mcommit 42caa2127c33c05eff5f88edf9463a8e0c6e8108[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Aug 5 21:36:11 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_ca6bdb34
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1470425755 +0200
+    
+        Tag for commit ca6bdb34b1e16d606dc048ffd1283aeaf3539b40
+        gpg: Signature made Fri 05 Aug 2016 09:35:55 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        ca6bdb3 r3.2: update schedule
+
+[33mcommit 5bc08ba3913b6493581d5f629484f0d4f54b4a87[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Aug 5 20:23:10 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_67c3e186
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1470421375 +0200
+    
+        Tag for commit 67c3e186768adde02cc175dbfef4918545a8cd0b
+        gpg: Signature made Fri 05 Aug 2016 08:22:55 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        67c3e18 upgrade-to-r3.2: add additional step for Debian-based UpdateVM
+
+[33mcommit 24842d7c7ec120a72dd241f120d29028a6fc9fb1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Aug 5 04:26:02 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_a859dced
+        tagger Andrew David Wong <adw@qubes-os.org> 1470363935 -0700
+    
+        Tag for commit a859dcedd171ce6f5786db8cc1bc6d5461c64e55
+        gpg: Signature made Fri 05 Aug 2016 04:25:35 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a859dce Add note about upgrading to non-repo kernels
+
+[33mcommit 5afeeb90df080c9acfbc96e91b4e3067ed867590[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Aug 4 12:56:05 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_704f9548
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1470308113 +0200
+    
+        Tag for commit 704f95484aecb3bebb74451a34fcd487d15a1c93
+        gpg: Signature made Thu 04 Aug 2016 12:55:13 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        704f954 Fix ToC in managing-vm-kernel
+
+[33mcommit c696eaff4edd9d72a30bb510749e9bed2f849a54[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Aug 3 20:58:27 2016 -0700
+
+    Revise Introduction to Qubes OS
+    
+    * Change terminology from "VM" to "qube"
+    * Mention more Qubes features:
+      * DispVMs
+      * GUI virtualization
+      * Colored window borders
+      * NIC & USB isolation
+      * USB device management
+      * Firewall
+      * File copy/paste
+      * Clipboard copy/paste
+      * TemplateVM system
+      * PDF & image file santiziation
+      * Qubes-Whonix/Tor
+      * AEM
+    * Other small fixes and improvements
+
+[33mcommit d99fbb50125293ff69c8cee9bb4e2454074fa694[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Aug 3 01:34:02 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_81083f5e
+        tagger Andrew David Wong <adw@qubes-os.org> 1470180811 -0700
+    
+        Tag for commit 81083f5e794a27355e6a1073c7048ae3b87b3c6e
+        gpg: Signature made Wed 03 Aug 2016 01:33:32 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        81083f5 Merge branch 'thomwiggers-patch-1'
+        9c0a942 There is in fact a progress indicator in 3.2-rc2
+
+[33mcommit 860113d7441e151a9f38d81a66a746ad3e7ce2ec[m
+Merge: 7555315 d7f4ad9
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Aug 1 16:35:25 2016 -0700
+
+    Merge branch 'mfc-patch-22'
+
+[33mcommit d7f4ad9df83400fb13fd02115d9c0f63a43907b2[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Mon Aug 1 19:17:31 2016 +0200
+
+    updated pgp key
+    
+    new key signed by old key.
+
+[33mcommit 75553153d77559be80c304867b5adc98eefaa858[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jul 31 23:55:15 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_a4ff57fa
+        tagger Andrew David Wong <adw@qubes-os.org> 1470002091 -0700
+    
+        Tag for commit a4ff57fa980b58c33605ef2d27e1ee39c8e5f07a
+        gpg: Signature made Sun 31 Jul 2016 11:54:50 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a4ff57f Clarify hiding USB controllers from dom0
+
+[33mcommit 5dc9dad1341e250e3ef413cacaf1e4d774e71b4e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jul 31 23:43:57 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_15d418b7
+        tagger Andrew David Wong <adw@qubes-os.org> 1470001404 -0700
+    
+        Tag for commit 15d418b778a8879323091c79fdc1084decb890cb
+        gpg: Signature made Sun 31 Jul 2016 11:43:23 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        15d418b Explain hiding USB devices from dom0
+
+[33mcommit fbfa4a6a5b560169241200d4f2bdb21df61ba8aa[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jul 31 12:59:59 2016 +0200
+
+    R3.2-rc2: fix file size one more time
+
+[33mcommit b1b6215fadc828405d953a273d38881b563a01e5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jul 31 12:59:21 2016 +0200
+
+    enable kernel.org mirror for R3.2-rc2
+
+[33mcommit 6e88c117e734cd21938d0561349e2fabdc0dde89[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jul 31 01:58:20 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4f5adaf9
+        tagger Andrew David Wong <adw@qubes-os.org> 1469923083 -0700
+    
+        Tag for commit 4f5adaf94d73227d27882507fbf12e792efc63b2
+        gpg: Signature made Sun 31 Jul 2016 01:58:01 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4f5adaf Provide location of XML file containing firewall rules
+
+[33mcommit b117cf0c06d7e2d1d101f415caa685563c169a20[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jul 31 00:43:28 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_1922c94b
+        tagger Andrew David Wong <adw@qubes-os.org> 1469918578 -0700
+    
+        Tag for commit 1922c94b7be73ad0670d7875644bcfaf5af51050
+        gpg: Signature made Sun 31 Jul 2016 12:42:58 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1922c94 Merge branch 'xloem-xloem-patch-1'
+        8b48823 Fix for #2206
+
+[33mcommit df84cd34576ecc8d0bbd42f9053e8ec7b8d1464c[m
+Author: Wojtek Porczyk <woju@invisiblethingslab.com>
+Date:   Sat Jul 30 18:42:28 2016 +0200
+
+    team: woju's key, descr and photo
+
+[33mcommit 6cc83392e86979988cb27b189dc70f97d99d9395[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jul 30 18:41:19 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag w_d17b890b
+        tagger Wojtek Porczyk <woju@invisiblethingslab.com> 1469896753 +0200
+    
+        Tag for commit d17b890bb352009088b962f6e6aa5c9f1a53552b
+        gpg: Signature made Sat 30 Jul 2016 06:39:13 PM CEST using RSA key ID D272F2A8
+        gpg: Good signature from "Wojtek Porczyk (Qubes OS documentation signing key) <woju@invisiblethingslab.com>"
+    
+        d17b890 Add woju's photo
+
+[33mcommit b0ea03879d2a92d3bceb3c7fb4d9ae42f6b3ef2c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jul 29 16:47:51 2016 +0200
+
+    fix file size for R3.2-rc2
+
+[33mcommit a399a10d9dac588990d82fb9efc88a1461b28a31[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jul 28 14:41:19 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_70d39293
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1469709665 +0200
+    
+        Tag for commit 70d39293ef5a2255959bc3554bb486db925725d5
+        gpg: Signature made Thu 28 Jul 2016 02:41:05 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        70d3929 R3.2-rc2 announcement
+
+[33mcommit db16d0871c10cab6b8f41d4076112d708e70b738[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jul 28 14:37:58 2016 +0200
+
+    R3.2-rc2 download links
+
+[33mcommit 72cb7dccf7cb6352cbdd9ef632891ac5697c1fdc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jul 27 22:52:24 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4e745b37
+        tagger Andrew David Wong <adw@qubes-os.org> 1469652707 -0700
+    
+        Tag for commit 4e745b374eb5364193e7f95aa38455e626a76e1f
+        gpg: Signature made Wed 27 Jul 2016 10:51:48 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4e745b3 Add QSB 24 to Security Bulletins page
+
+[33mcommit 6b5d273a77af2de615545828fc76c9607e576eec[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Jul 25 03:37:11 2016 -0700
+
+    Add section for hardware certification requirements
+
+[33mcommit 4e1b122b62fd476007e397c282a9801408faa23f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jul 25 12:36:11 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_61ce38bb
+        tagger Andrew David Wong <adw@qubes-os.org> 1469442951 -0700
+    
+        Tag for commit 61ce38bb6d2a499978efb1ecb8c03208300ca3b1
+        gpg: Signature made Mon 25 Jul 2016 12:35:53 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        61ce38b Organize certified laptops by release branch
+
+[33mcommit 0509355fbb7788b0669c3d7702c3dfa45ed6391d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jul 22 00:12:34 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_e1e9ec79
+        tagger Andrew David Wong <adw@qubes-os.org> 1469139094 -0700
+    
+        Tag for commit e1e9ec798e4f3c47a95695b3a43cb236df4d9b07
+        gpg: Signature made Fri 22 Jul 2016 12:11:35 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e1e9ec7 Merge branch 'clayt0nk-edit'
+        859af9b Fix formatting and orthography
+        3c8bc88 Merge branch 'edit' of git://github.com/clayt0nk/qubes-doc into clayt0nk-edit
+        602bcf9 No content changes -- hard wrap excessively long Markdown lines only.
+        e259037 more /rw/config/ script tweaks
+        2bd320c Merge branch 'master' into edit
+        c44b8a1 Add a specific note about where to put iptables in /rw/config/
+
+[33mcommit 0396411c8106d21303575168a44befd8ecca514b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jul 22 00:03:19 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4485a457
+        tagger Andrew David Wong <adw@qubes-os.org> 1469138585 -0700
+    
+        Tag for commit 4485a457e53d7d229cbd074525e607df677449d8
+        gpg: Signature made Fri 22 Jul 2016 12:03:06 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4485a45 Fix (presumable) typo: "Jul" -> "Aug"
+
+[33mcommit f7adc9251fe6534091639acd7267457f6f2201f6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jul 22 00:01:29 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_a44b1928
+        tagger Andrew David Wong <adw@qubes-os.org> 1469138473 -0700
+    
+        Tag for commit a44b1928fd96ac91f4bda6ddcdf2f745c5efde53
+        gpg: Signature made Fri 22 Jul 2016 12:01:13 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a44b192 Merge branch 'master' of github.com:QubesOS/qubes-doc
+        d97b936 Add link to Corridor doc in Whonix wiki
+
+[33mcommit c1effd2202755a77a4acbe6bdac781a88c36bb48[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jul 21 10:18:40 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag joanna_bdd7eebd
+        tagger Joanna Rutkowska <joanna@invisiblethingslab.com> 1469089061 +0200
+    
+        Tag for commit bdd7eebd751609ea4886545deb8544b2b86bf66f
+        gpg: Signature made Thu 21 Jul 2016 10:18:02 AM CEST using RSA key ID CA74A5C3
+        gpg: Good signature from "Joanna Rutkowska (Qubes Documentation Signing Key) <joanna@invisiblethingslab.com>"
+    
+        bdd7eeb New post: new h/w certification reqs for Qubes 4
+
+[33mcommit 99c738c773f575bed64993b08a4597c9dd560517[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jul 20 23:45:25 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_90c142db
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1469012841 +0200
+    
+        Tag for commit 90c142db2c452c0ad668d27f8b6f04d21225dece
+        gpg: Signature made Wed 20 Jul 2016 01:07:21 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        90c142d Describe how to generate initramfs and build u2mfn on Debian VM
+
+[33mcommit 63dc24e41854cf2e15f8f539f1979ba8a54cdbe3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jul 17 00:42:24 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_deec6ad5
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1468708932 +0200
+    
+        Tag for commit deec6ad508164eed35b5d883af86aeb0ce3a47a7
+        gpg: Signature made Sun 17 Jul 2016 12:42:12 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        deec6ad Adjust R3.2 release schedule
+
+[33mcommit d430e2c3daa1c938da68b1b767bfa5ab29dc95b9[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jul 15 14:58:13 2016 -0700
+
+    Display file sizes for all visible downloads
+    
+    Closes QubesOS/qubes-issues#2164
+
+[33mcommit c8e9b2c40d62f1bd1cda0265b68e9ce282fca35e[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jul 15 14:56:38 2016 -0700
+
+    Add file sizes for all downloads
+    
+    QubesOS/qubes-issues#2164
+
+[33mcommit 9253de25c3e4b9c109a3b50132b7df2c417d1996[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jul 15 20:42:31 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_45cffd68
+        tagger Andrew David Wong <adw@qubes-os.org> 1468608080 -0700
+    
+        Tag for commit 45cffd68543447c81d9922572d52e408b7ff5e65
+        gpg: Signature made Fri 15 Jul 2016 08:41:23 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        45cffd6 Create "What is a DMA attack?" entry (Marek's answer)
+
+[33mcommit 43b2983e158839efec4a3ee020a06a5602aeece2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jul 14 16:30:29 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_fdac1721
+        tagger Andrew David Wong <adw@qubes-os.org> 1468506579 -0700
+    
+        Tag for commit fdac17216b2ca6ed7a2aa43a374146ac8af56d46
+        gpg: Signature made Thu 14 Jul 2016 04:29:39 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        fdac172 Fix typo
+
+[33mcommit e19ef643f7d196c875a72bb5dbc186e7d83b089d[m
+Merge: 3b6f55e 2e98bd6
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jul 13 05:33:25 2016 -0700
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit 3b6f55e80c91af8c57622b906c6d7b2086a72e13[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jul 13 05:31:12 2016 -0700
+
+    Update Donation page
+    
+    * Add section on the decentralized nature of the fund
+    * Improve headings
+    * Fix typos
+
+[33mcommit 2e98bd65c1daec9151b5eb324c43861ad14a4df8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jul 13 14:23:46 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_2cee8479
+        tagger Andrew David Wong <adw@qubes-os.org> 1468412565 -0700
+    
+        Tag for commit 2cee84796fd483fd6fd7ffbd7ae2feb05e559187
+        gpg: Signature made Wed 13 Jul 2016 02:22:45 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2cee847 Fix typos
+
+[33mcommit 2be6f85b99c3345386ae05f5bbd3ee20b4031b9a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jul 13 14:12:48 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag joanna_2ad47653
+        tagger Joanna Rutkowska <joanna@invisiblethingslab.com> 1468411881 +0200
+    
+        Tag for commit 2ad476530b9b86144469dccfc06b76c791eb6170
+        gpg: Signature made Wed 13 Jul 2016 02:11:39 PM CEST using RSA key ID CA74A5C3
+        gpg: Good signature from "Joanna Rutkowska (Qubes Documentation Signing Key) <joanna@invisiblethingslab.com>"
+    
+        2ad4765 New post: decentralized Qubes bitcoin fund annoucement
+
+[33mcommit 42a9a78dfa990202801ddd239fd9a8345f91cbfd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jul 13 13:37:08 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d32a0133
+        tagger Andrew David Wong <adw@qubes-os.org> 1468409783 -0700
+    
+        Tag for commit d32a01330165be69b987e47c93ec36284275bfe6
+        gpg: Signature made Wed 13 Jul 2016 01:36:23 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d32a013 Avoid implying that the fund is only for donations
+
+[33mcommit 7a507a149df96b2726e8d9c058db0be79c21a4c9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jul 13 13:29:43 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_ab15b144
+        tagger Andrew David Wong <adw@qubes-os.org> 1468409323 -0700
+    
+        Tag for commit ab15b144f89156c1a81de54ddf2f456313208d56
+        gpg: Signature made Wed 13 Jul 2016 01:28:44 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ab15b14 Revise and update Qubes Security Pack page
+
+[33mcommit 5813352a58609600fefbe91e5b86a4791a7c78b9[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jul 13 03:50:48 2016 -0700
+
+    Clean up text, wrap lines, and use ref links
+
+[33mcommit dd7717d4ad1093fa682e6286546fa1cfaa593cc6[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jul 13 03:47:31 2016 -0700
+
+    Update Bitcoin donation address and link to secpack
+
+[33mcommit b14455a3ccca6aa21d0206f5686706aa035a8049[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jul 12 05:20:28 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_14b8144f
+        tagger Andrew David Wong <adw@qubes-os.org> 1468293573 -0700
+    
+        Tag for commit 14b8144fb7b431e59e3b9d7280005aab032f1394
+        gpg: Signature made Tue 12 Jul 2016 05:19:34 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        14b8144 Add entry for building Qubes-supported templates
+
+[33mcommit c14a13b6b65df874b1fd6c539fc97c48c712cc96[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jul 9 05:40:40 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_fabb7b17
+        tagger Andrew David Wong <adw@qubes-os.org> 1468035586 -0700
+    
+        Tag for commit fabb7b17d33a57b0bbf1b869c1769c4e069b0916
+        gpg: Signature made Sat 09 Jul 2016 05:39:45 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        fabb7b1 Add notes regarding private and public key management
+
+[33mcommit 5e9ef02fbbb1dfe5774bef93423dcee701862c43[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jul 6 09:02:05 2016 -0700
+
+    Add link to Funding page
+    
+    QubesOS/qubes-issues#1701
+
+[33mcommit 42784f2bc50d195423e6a438f719090e8b630b37[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jul 6 09:01:28 2016 -0700
+
+    Add link to Funding page and fix link to Donations page
+    
+    QubesOS/qubes-issues#1701
+
+[33mcommit c9edb25864f8ede97edac17397b2b9b340d120cb[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jul 6 09:00:45 2016 -0700
+
+    Add link to Partners page
+    
+    QubesOS/qubes-issues#1701
+
+[33mcommit 98409816d70946bfe98c5a421d633457cd5ea6f5[m
+Merge: f3a8eac 627b231
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Jul 5 15:18:56 2016 -0700
+
+    Merge branch 'mfc-patch-21'
+
+[33mcommit 627b23127fe90631d2e4ba3180714057bc1705bd[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Tue Jul 5 16:10:47 2016 +0000
+
+    added small blurbs
+    
+    added small blurbs to each funder.
+    
+    re: ITL, weird to list only one owner of the company since they are both on the team (and team page), fixed that.
+
+[33mcommit f3a8eac4789dbf1725ea98d0cb70adf60c83408b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jul 5 15:56:05 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_176d9394
+        tagger Andrew David Wong <adw@qubes-os.org> 1467726923 -0700
+    
+        Tag for commit 176d9394df62e2c5c49aeda4b667c620f6c4c8f4
+        gpg: Signature made Tue 05 Jul 2016 03:55:23 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        176d939 Add Split Bitcoin page to ToC
+
+[33mcommit f3e16a1f664f158ca6b727058bdd888117644a77[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jul 5 14:20:26 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_35232700
+        tagger Andrew David Wong <adw@qubes-os.org> 1467721166 -0700
+    
+        Tag for commit 3523270064290510909f9f3d0a36252f1b4817d9
+        gpg: Signature made Tue 05 Jul 2016 02:19:27 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3523270 Merge branch 'mfc-patch-20'
+        b4ade41 added content
+
+[33mcommit acebe9cbb5b5c362dd1edf583982a3408d4829fb[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue Jul 5 05:05:36 2016 -0700
+
+    Add brief explanation of ITL's funding role
+
+[33mcommit be627a4de5252ffc84ab2b134ad42be2e3f5d6c5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jul 5 12:25:20 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_bbbcb419
+        tagger Andrew David Wong <adw@qubes-os.org> 1467714278 -0700
+    
+        Tag for commit bbbcb41980b2a168b16e579251a1b41abfcbab10
+        gpg: Signature made Tue 05 Jul 2016 12:24:38 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        bbbcb41 Add entry for Marek's presentation at RMLL 2016
+
+[33mcommit 10e9ffb3f808cca8c232eeee9986f910917b6359[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jul 5 12:12:14 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_ba353058
+        tagger Andrew David Wong <adw@qubes-os.org> 1467713493 -0700
+    
+        Tag for commit ba35305883a3ee2c05a370d830f549b4c927e021
+        gpg: Signature made Tue 05 Jul 2016 12:11:33 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ba35305 Add Marek's RMLL 2016 slides
+
+[33mcommit 9569466ec297057070bb1a7e236be9e779909a18[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jul 5 12:09:17 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_ea2dbb2d
+        tagger Andrew David Wong <adw@qubes-os.org> 1467713310 -0700
+    
+        Tag for commit ea2dbb2d197713d3d8b239e00b7aeda7100f9fc0
+        gpg: Signature made Tue 05 Jul 2016 12:08:30 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ea2dbb2 Add Marek's RMLL 2016 slides
+
+[33mcommit 321ec4ab8e4761b3612f46164fd477801d162bc2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jul 4 14:03:28 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_1f123524
+        tagger Andrew David Wong <adw@qubes-os.org> 1467633766 -0700
+    
+        Tag for commit 1f12352489d89e28402bb17f99403e6388f9f228
+        gpg: Signature made Mon 04 Jul 2016 02:02:46 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1f12352 Add FAQ entry explicitly stating that Qubes uses FDE
+
+[33mcommit df690791402851f0b8ea1a8305a35ca351b91a19[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jul 4 13:48:59 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_0f917b3e
+        tagger Andrew David Wong <adw@qubes-os.org> 1467632891 -0700
+    
+        Tag for commit 0f917b3ee3f77d45cce2b4e80f361344f66590bf
+        gpg: Signature made Mon 04 Jul 2016 01:48:11 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        0f917b3 Clarify that Qubes uses FDE by default
+
+[33mcommit d906ac2c6d2b1020ba27f8eb8c3ef5c427408681[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jul 3 17:06:13 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_b5930686
+        tagger Andrew David Wong <adw@qubes-os.org> 1467558319 -0700
+    
+        Tag for commit b593068687b77fa8a81156ae4d86767c60e4a3e4
+        gpg: Signature made Sun 03 Jul 2016 05:05:20 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b593068 Merge branch 'tomck-patch-1'
+        91bf798 Update upgrade-to-r3.2 w/ solution to screensaver
+
+[33mcommit d847c9e82dff0f52e546d93ddf14332c1f6f5a92[m
+Merge: 378de96 8fc4d63
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jul 1 18:32:37 2016 -0700
+
+    Merge pull request #52 from unman/unman
+    
+    Add unman to team
+
+[33mcommit 378de96ebf0ba12946c96166e39509a1a3bb5d42[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jul 2 00:59:54 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_2956651d
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1467413982 +0200
+    
+        Tag for commit 2956651dc11499e28c574916a728b0466afb2ff8
+        gpg: Signature made Sat 02 Jul 2016 12:59:42 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        2956651 Update 3.2 schedule
+
+[33mcommit ff4abd7cb272d34ec944d3d93445d06c6f81d1f8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jul 1 20:15:17 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_d864239c
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1467396904 +0200
+    
+        Tag for commit d864239cde6c4d5cf6dc2fd2cf50ebf426a98a5d
+        gpg: Signature made Fri 01 Jul 2016 08:15:04 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        d864239 Fix Xfce installation instruction
+
+[33mcommit 13235856fe81bbbdb2d0738ca4378a32ae4f42c2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jul 1 10:33:11 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_c1dc6f0d
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1467361980 +0200
+    
+        Tag for commit c1dc6f0d6ebaa946db62e9355d8175532fd5261d
+        gpg: Signature made Fri 01 Jul 2016 10:33:00 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        c1dc6f0 usb: add note about requiring USB VM for USB passthrough
+
+[33mcommit 1ac9d198febe1e6a047e6346947f4702186c3f17[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Jun 30 21:40:46 2016 -0700
+
+    Add ITL to list of funding sources
+
+[33mcommit eb862c56550c0b37f2b3ecf396b9a709edaf2f37[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jul 1 06:38:56 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_8c24a9e3
+        tagger Andrew David Wong <adw@qubes-os.org> 1467347895 -0700
+    
+        Tag for commit 8c24a9e32f66a5983c41086f897466898f6292af
+        gpg: Signature made Fri 01 Jul 2016 06:38:14 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8c24a9e Add ITL logo
+
+[33mcommit 8fc4d63d857b9a3c8f2ce19859c10bcc54d70913[m
+Author: unman <unman@thirdeyesecurity.org>
+Date:   Fri Jul 1 01:40:59 2016 +0100
+
+    Add unman to team
+
+[33mcommit 06eecfccf899cfd37d751f174f68bcdd1e7ac1be[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jun 30 05:21:42 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_7f2dee59
+        tagger Andrew David Wong <adw@qubes-os.org> 1467256850 -0700
+    
+        Tag for commit 7f2dee59f05a4ea33e2ff9c31a5833fcc28ec591
+        gpg: Signature made Thu 30 Jun 2016 05:20:53 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7f2dee5 Merge pull request #168 from jonosterman/patch-1
+        c495fbc missing 'sudo' in documentation
+
+[33mcommit bc3c7acb1aae18563d17a334f78b3aa84e622425[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jun 29 00:15:52 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_5fcaf5be
+        tagger Andrew David Wong <adw@qubes-os.org> 1467152100 -0700
+    
+        Tag for commit 5fcaf5be0c6bbd9f3359cc69516926c4227b8f97
+        gpg: Signature made Wed 29 Jun 2016 12:15:00 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5fcaf5b Merge branch 'adrelanos-master'
+        185547f refine Whonix logo
+
+[33mcommit ac443abb1c5eb8a7038a93c571571994c1a9e625[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jun 28 14:44:13 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_92b985d0
+        tagger Andrew David Wong <adw@qubes-os.org> 1467117814 -0700
+    
+        Tag for commit 92b985d07941b05be1204ae8aa38d5b9e5190631
+        gpg: Signature made Tue 28 Jun 2016 02:43:34 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        92b985d Replace "sudo" with root prompt for consistency
+
+[33mcommit 7c9e7491a015462bb66c2b027893d12dac894abc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jun 28 14:40:04 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_2d144c81
+        tagger Andrew David Wong <adw@qubes-os.org> 1467117563 -0700
+    
+        Tag for commit 2d144c81e161ad3f91908f994d4ed87b9cae69ce
+        gpg: Signature made Tue 28 Jun 2016 02:39:23 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2d144c8 Add Manual Encryption Configuration page to ToC
+        8208258 Create Manual Encryption Configuration page
+
+[33mcommit 90c53594941eed3518e1727f9ad540e0b114141f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jun 27 21:25:50 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_49603789
+        tagger Andrew David Wong <adw@qubes-os.org> 1467055499 -0700
+    
+        Tag for commit 49603789d29339c405d96032288ffa38cd65bd66
+        gpg: Signature made Mon 27 Jun 2016 09:25:01 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4960378 Clarify how to add parameters to xen.cfg
+
+[33mcommit ce0fcc5b12f8791f2b87c8d4ea63f15c4aa403dc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jun 27 21:10:30 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_97696026
+        tagger Andrew David Wong <adw@qubes-os.org> 1467054583 -0700
+    
+        Tag for commit 97696026f3830a72c78a1f34117132c0b46bbaee
+        gpg: Signature made Mon 27 Jun 2016 09:09:45 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9769602 Update links from Pentesting page to all subpages
+        808852b Update links from PTF page to other pentesting pages
+        f34b145 Update links from BlackArge page to other pentesting pages
+        878ca47 Update links from Kali page to other pentesting pages
+        8dd4aed Fix broken link to PTF page
+        3dd6701 Fix broken link to BlackArch page
+        8205de0 Fix broken link to Kali page
+        c24fdbe Merge branch 'Jeeppler-master'
+        cb72465 Merge branch 'master' of git://github.com/Jeeppler/qubes-doc into Jeeppler-master
+        4db5ca5 layout fixes, indentation and small typo fixes
+        02c2621 Dark Theme layout fixes
+        a14e5f0 merge
+        c93414f merge
+        8f176f1 merge
+        08d0d6a Qubes OS as hacking laboratory host
+        c4dd886 legal notice and general remainder
+        4e74611 Merge remote-tracking branch 'upstream/master'
+        eb62b13 linked pentesting
+        8ce887c Warning for manual Kali linux installation added
+        7000514 merge with upstream
+        b514a50 dark-theme finished; kali and ptf images paths adjusted; articles linked to doc.md
+        808df85 added image to PTF
+        4f7ce41 added reason in PTF for installing Debian testing first
+        b4b3d28 pentesting
+
+[33mcommit c56bd4fad6592c69dba377c90d6dfa8af07e3116[m
+Merge: 8041a5d c880159
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Jun 27 11:14:45 2016 -0700
+
+    Merge branch 'Jeeppler-master'
+
+[33mcommit c88015962beea028838e6e2f4430ef57de602a8f[m
+Merge: 8041a5d dcc4c0c
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Jun 27 11:14:27 2016 -0700
+
+    Merge branch 'master' of git://github.com/Jeeppler/qubesos.github.io into Jeeppler-master
+
+[33mcommit 8041a5dc8d6ec77206c5388a32ff814e29292e6e[m
+Merge: 19ea6c7 63b14df
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Jun 26 08:23:02 2016 -0700
+
+    Merge branch 'mfc-patch-20'
+
+[33mcommit 63b14df2327b3e31d0d1dac9208bf1fab8c3bf77[m
+Merge: 19ea6c7 beddcb2
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Jun 26 08:22:00 2016 -0700
+
+    Merge branch 'patch-20' of git://github.com/mfc/qubesos.github.io into mfc-patch-20
+
+[33mcommit dcc4c0c4bf7766fd16da2400eb561b69d43fdce9[m
+Author: Jeepler <jeremias.eppler@mailbox.org>
+Date:   Sun Jun 26 06:08:26 2016 -0500
+
+    adding GitHub Pages Gem (https://github.com/github/pages-gem)
+
+[33mcommit 19ea6c7c1a55d438969214be40304437009685bc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jun 26 12:31:39 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b5ff9c06
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1466937084 +0200
+    
+        Tag for commit b5ff9c06452054175ccd8a453bbdaf4c9da6b7b9
+        gpg: Signature made Sun 26 Jun 2016 12:31:24 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b5ff9c0 Include R3.1->R3.2 upgrade instruction in release notes
+        edf1bf9 Minor clarification for pvgrub instruction
+        7ee58d2 Upgrade R3.1->R3.2 instruction
+
+[33mcommit b532bd0f4132473d24e836075cab11fbe42d0a13[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jun 26 04:16:45 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_45e77292
+        tagger Andrew David Wong <adw@qubes-os.org> 1466907367 -0700
+    
+        Tag for commit 45e772924605b2f0c21aca844a167441dafdf930
+        gpg: Signature made Sun 26 Jun 2016 04:16:07 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        45e7729 Merge pull request #9 from Jeeppler/master
+        cd423de Merge branch 'master' of https://github.com/Jeeppler/qubes-attachment
+        675e618 Kali and PTF images moved
+        c42c6ec added image to PTF
+        c5aef84 Kali images
+
+[33mcommit 67a4ac92d6c2436516849ab7cddbd8cfd614b697[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jun 26 04:10:34 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_cc9d6db5
+        tagger Andrew David Wong <adw@qubes-os.org> 1466906991 -0700
+    
+        Tag for commit cc9d6db51f8a6d4dd783ca0950e36769d9bdea86
+        gpg: Signature made Sun 26 Jun 2016 04:09:51 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        cc9d6db Replace Access Now logo
+
+[33mcommit a1a8a797f2018342b05eae734f1edc78d3b9ef70[m
+Author: Jeepler <jeremias.eppler@mailbox.org>
+Date:   Sat Jun 25 19:42:54 2016 -0500
+
+    Gemfile for bundler
+
+[33mcommit beddcb26efbd3db1f0108c1846d40ff7dc6d8624[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Sat Jun 25 10:16:49 2016 +0000
+
+    reordered awards & grants to be chronological
+
+[33mcommit fec8fa30913088bf193e3021dad2d3e2a43e6674[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jun 24 19:07:54 2016 -0700
+
+    Add Bitcoin logo
+
+[33mcommit 58b6562fa30f3bd91710cc5aa82b817d2ccc297a[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jun 24 19:06:55 2016 -0700
+
+    Add NLnet 2016 grant
+    
+    QubesOS/qubes-issues#2080
+
+[33mcommit 5ac10d049101eca39828cc50067e921cd0b6867e[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jun 24 19:05:55 2016 -0700
+
+    Replace text links with logos
+    
+    For the following funding sources:
+    * Bitcoin donations
+    * Open Technology Fund (OTF)
+    * NLnet
+    
+    QubesOS/qubes-issues#2080
+
+[33mcommit c2d8e2a5e950aca9156ca7077cbfaa6f23caaf95[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Jun 24 19:04:09 2016 -0700
+
+    Replace text links with logos
+    
+    For the following partners:
+    * NLnet
+    * Open Technology Fund (OTF)
+    * Access Now
+    
+    QubesOS/qubes-issues#2080
+
+[33mcommit bd4b09a983c33bf1d3858cbc3b7733690839f166[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 25 04:03:58 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_0c104159
+        tagger Andrew David Wong <adw@qubes-os.org> 1466820189 -0700
+    
+        Tag for commit 0c1041595e729ea332db75a79bfaa013b8236c46
+        gpg: Signature made Sat 25 Jun 2016 04:03:07 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        0c10415 Add BTC logo
+        8f25ed7 Add NLnet logo
+        279ec1f Add Access Now logo
+
+[33mcommit 6e60ec63f682213ac553a53300f66687cadcee4c[m
+Merge: adbbf86 68e529d
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Jun 23 22:55:24 2016 -0700
+
+    Merge branch 'mfc-patch-19'
+    
+    QubesOS/qubes-issues#2080
+
+[33mcommit 68e529dd6756ffea7e2b8154ba476a769cccf7de[m
+Merge: adbbf86 4c1926d
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Jun 23 22:54:44 2016 -0700
+
+    Merge branch 'patch-19' of git://github.com/mfc/qubesos.github.io into mfc-patch-19
+
+[33mcommit adbbf8692cbee991440a6499030d33c74ab0d15b[m
+Merge: 0c74dd1 97da590
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu Jun 23 22:54:09 2016 -0700
+
+    Merge branch 'mfc-patch-18'
+    
+    QubesOS/qubes-issues#2080
+
+[33mcommit 4c1926d2ef7083d16520f2d639c9d394d9774300[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Thu Jun 23 23:18:22 2016 +0000
+
+    added nlnet
+
+[33mcommit 97da590b2cbcfeaaccdfa2b4d5aa1e90456545d8[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Thu Jun 23 23:13:58 2016 +0000
+
+    added nlnet, 2016 otf
+
+[33mcommit 0c74dd180c320f509710b435fc89d87a47120c9c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jun 20 22:58:12 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_aadb35d6
+        tagger Andrew David Wong <adw@qubes-os.org> 1466456249 -0700
+    
+        Tag for commit aadb35d62f38bff08c96820eb75cb033325b309e
+        gpg: Signature made Mon 20 Jun 2016 10:57:31 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        aadb35d Move all developer documentation to main index
+
+[33mcommit 7414a2f8f8cd6a32542cf2c6f0852ba54769974e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 18 17:36:48 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_a5f6c928
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1466264172 +0200
+    
+        Tag for commit a5f6c928f57f8d26fdd165ab5a5280558103a076
+        gpg: Signature made Sat 18 Jun 2016 05:36:13 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        a5f6c92 Minor fixes to R3.2-rc1 announcement
+
+[33mcommit 5a4196e65fa2c4fc1509ef3e364ff4c420e6a596[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Jun 18 08:06:47 2016 -0700
+
+    Fix broken links to R3.1-rc1 torrent hash and sig
+
+[33mcommit 7e531cc40e068a600c1148450560977dfc5e014c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 18 10:42:17 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_7adcbfc6
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1466239301 +0200
+    
+        Tag for commit 7adcbfc622272b4d997f501342c4dbaf558407e1
+        gpg: Signature made Sat 18 Jun 2016 10:41:41 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        7adcbfc Qubes 3.2-rc1 announcement
+
+[33mcommit 8620cdc0094c8d6d0765f16fbb876e3cea2e0945[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 18 10:41:23 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_254f5e71
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1466239269 +0200
+    
+        Tag for commit 254f5e71a0cc4f225f53f070d9d838236ba94f36
+        gpg: Signature made Sat 18 Jun 2016 10:41:09 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        254f5e7 Update 3.2 release schedule
+
+[33mcommit 3dfe28163ffdac1ea772f21f364de571ef7072d4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 18 10:39:59 2016 +0200
+
+    Add Qubes 3.2-rc1 download links
+
+[33mcommit 31d3ccb773e2aa58179d64ea5b03f01410f7e751[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 18 01:29:07 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b18cbeac
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1466206132 +0200
+    
+        Tag for commit b18cbeacbe9065587ec02c73dd8d6b2a863a1ea7
+        gpg: Signature made Sat 18 Jun 2016 01:28:52 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b18cbea Add USB passthrough documentation
+
+[33mcommit 0e219aa1a583cd6ae1e063d3eb4cfd2c37cf9bb9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jun 17 10:47:13 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_eac3ca27
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1466153221 +0200
+    
+        Tag for commit eac3ca277b0265b6e063717c2bc80b1d83f206a8
+        gpg: Signature made Fri 17 Jun 2016 10:47:01 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        eac3ca2 releases/3.2: add draft release notes and preliminary schedule
+        f3f9657 releases: R3.1 is released some time ago
+
+[33mcommit fcfc79e3d623490fbab6275d9ad44d179c0adb54[m
+Merge: 55d18c1 67ca838
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Mon Jun 13 15:56:53 2016 -0700
+
+    Merge pull request #47 from unman/patch-1
+    
+    Update getting-started.md
+
+[33mcommit 67ca838e9a2622ce02f9a2b51a93f67e4c135ec2[m
+Author: unman <unman@thirdeyesecurity.org>
+Date:   Mon Jun 13 00:57:28 2016 +0000
+
+    Update getting-started.md
+    
+    Changed to use "qube(s)" throughout. Some minor clarifications and rewrites.
+
+[33mcommit 55d18c17dbfcb5044ced6ea6d7e11bab8fd3c459[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jun 12 20:42:31 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_5189bb00
+        tagger Andrew David Wong <adw@qubes-os.org> 1465756917 -0700
+    
+        Tag for commit 5189bb00394d762922196848ac07083829cb9fde
+        gpg: Signature made Sun 12 Jun 2016 08:41:58 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5189bb0 Clarify that testing repos can be enabled or disabled
+        4f0aad9 Create section on VM testing repos
+        3abcd57 Use full repo names
+        1585c5c Fix formatting
+        c664629 Create section on dom0 testing repos
+
+[33mcommit e5516cc24260073b8eacefc303028fc243d26db6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jun 12 19:57:00 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_652409c5
+        tagger Andrew David Wong <adw@qubes-os.org> 1465754188 -0700
+    
+        Tag for commit 652409c5818b42eba802ab73210523403adc8239
+        gpg: Signature made Sun 12 Jun 2016 07:56:28 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        652409c Merge branch 'reinstall-template'
+        4a50b01 Add ToC entry for new Reinstall page
+        485bd1d Remove link to old Reinstall page
+        9677652 Add link to Reinstall page
+        61407ae Set permalink
+        b633b72 Remove old Whonix-specific sentence
+        8741932 Generalize whonix-reinstall to apply to all templates
+
+[33mcommit 784a8ea74b84920fd9ee78820d3cd500e3d42d10[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jun 12 16:47:39 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_85c5eda8
+        tagger Andrew David Wong <adw@qubes-os.org> 1465742826 -0700
+    
+        Tag for commit 85c5eda80c0b61795fa75516f68948ceef1a62f7
+        gpg: Signature made Sun 12 Jun 2016 04:47:04 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        85c5eda Update manual USB qube creation instructions
+
+[33mcommit 92728a30967781481e956df1bc568363703fa998[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jun 12 15:46:03 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_1b0bec29
+        tagger Andrew David Wong <adw@qubes-os.org> 1465739128 -0700
+    
+        Tag for commit 1b0bec296b5059751f9683150d271867dacbedcb
+        gpg: Signature made Sun 12 Jun 2016 03:45:29 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1b0bec2 Merge pull request #165 from WillMorrison/patch-1
+        a8d09e7 Spelling and grammatical changes in live-usb.md
+
+[33mcommit 2ce6a6e726d747888f42adcdecb4bbe95e2afab7[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jun 9 12:38:34 2016 +0200
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag adw_f2816764
+        tagger Andrew David Wong <adw@qubes-os.org> 1465468654 -0700
+    
+        Tag for commit f2816764097dc37d5af02b0d0d01f1644c89cb5e
+        gpg: Signature made Thu 09 Jun 2016 12:37:33 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f281676 Merge branch 'tomck-tomck-patch-l702x'
+        dab2c98 Complete and fix entry
+        73be868 Add HCL report for Dell XPS L702X
+
+[33mcommit f3f6dbd944b9e754c9b88b494d1b64d9e73ea772[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jun 9 12:03:17 2016 +0200
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag adw_8ccd3c13
+        tagger Andrew David Wong <adw@qubes-os.org> 1465466551 -0700
+    
+        Tag for commit 8ccd3c13ccb525d33a94171ed5d13e06c7d4c633
+        gpg: Signature made Thu 09 Jun 2016 12:02:30 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8ccd3c1 Add Lenovo ThinkPad T450s entry
+
+[33mcommit f9211dde78ddacf1908ef4391d9938c688051fbb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jun 9 11:23:03 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4fadbec0
+        tagger Andrew David Wong <adw@qubes-os.org> 1465464142 -0700
+    
+        Tag for commit 4fadbec0c9bcde79fa6b720491c04e1e17388b11
+        gpg: Signature made Thu 09 Jun 2016 11:22:24 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4fadbec Document qvm-revert-template-changes
+
+[33mcommit 87ef89fb13c523cc2f74ce2cd1d92824858e7a5a[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed Jun 8 09:26:22 2016 -0700
+
+    Add Gmane links
+
+[33mcommit 40bb9b38652d71d88f19877a30d454b5e8551cdb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jun 8 17:33:58 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_71e03102
+        tagger Andrew David Wong <adw@qubes-os.org> 1465399999 -0700
+    
+        Tag for commit 71e03102eb090d6678fa5baad80fa0cf0bd19fb8
+        gpg: Signature made Wed 08 Jun 2016 05:33:21 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        71e0310 Standardize list formatting
+
+[33mcommit d4105468e4e90ea51b08187ab081bcb399812f87[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jun 8 17:20:04 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_e2ad0cc2
+        tagger Andrew David Wong <adw@qubes-os.org> 1465399155 -0700
+    
+        Tag for commit e2ad0cc20693d618ca3b4c9f1079e1f9f56fec87
+        gpg: Signature made Wed 08 Jun 2016 05:19:17 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e2ad0cc Merge branch 'crypt0beard-patch-1'
+        a730179 Clean up text
+        7aa10c4 Adding USB Install Instructions
+
+[33mcommit cd0e3e04439e36c877e10f0717ab1f708c691209[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jun 7 12:35:59 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_9ab0bb9a
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1465295747 +0200
+    
+        Tag for commit 9ab0bb9ac2fa7e37b51f3f0062e6bfcbbfe9db88
+        gpg: Signature made Tue 07 Jun 2016 12:35:47 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        9ab0bb9 Update UEFI workaround for Qubes 3.2
+
+[33mcommit 5067690d6aee7c3003b22b9017560931456513a7[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jun 7 00:59:35 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_ffbe63ac
+        tagger Andrew David Wong <adw@qubes-os.org> 1465253944 -0700
+    
+        Tag for commit ffbe63ac8c6fa3feb06ab78ac88455cc90fb746a
+        gpg: Signature made Tue 07 Jun 2016 12:59:04 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ffbe63a Create "Reinstall Whonix" page
+
+[33mcommit 99be256b7cc38fc6a5e50c71d0e8daea5fc67164[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jun 6 11:40:39 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_a0bee729
+        tagger Andrew David Wong <adw@qubes-os.org> 1465206006 -0700
+    
+        Tag for commit a0bee729e147fd19cd32bf2a840ffbe37e6409b6
+        gpg: Signature made Mon 06 Jun 2016 11:40:06 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a0bee72 Clean up text and fix formatting (closes #162)
+
+[33mcommit be1177be00cb9bd1f225e3aa5475252a58f7bb20[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jun 6 11:33:54 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_9b2ce97f
+        tagger Andrew David Wong <adw@qubes-os.org> 1465205596 -0700
+    
+        Tag for commit 9b2ce97fe8102885c8077aec92c43fe59063ecd8
+        gpg: Signature made Mon 06 Jun 2016 11:33:16 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9b2ce97 Fix code block formatting (closes #161)
+
+[33mcommit ac8fcdf9582cf7b344e18758fccc8de976351ab0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jun 5 22:18:36 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_fab1c304
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1465157903 +0200
+    
+        Tag for commit fab1c3043c80989d52e615591e30569fc2a183c5
+        gpg: Signature made Sun 05 Jun 2016 10:18:23 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        fab1c30 quotes
+        9f512be fedora needs `PATH` assignment
+        88b4097 Switch to 'su -' envs, quote vars, rm --dport 53
+        a09ec96 Automatic; No manual coding of IP addresses.
+
+[33mcommit 976bc91950d191e2984c76e0828da7c11c93e71e[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Jun 5 03:20:50 2016 -0700
+
+    Change Michael's email address
+
+[33mcommit 9e85323fc1662050ad40d5a28d17dfb09fc1a1cb[m
+Merge: a24fb9c f7e9f54
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Jun 5 03:19:49 2016 -0700
+
+    Merge pull request #46 from mfc/patch-16
+    
+    changed ITL email to qubes-os
+
+[33mcommit a24fb9cdae5c9dcbc3683592a4428aa23d4f66aa[m
+Merge: 676fe53 8ce3715
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun Jun 5 03:19:01 2016 -0700
+
+    Merge pull request #45 from mfc/patch-15
+    
+    changed ITL email to qubes-os
+
+[33mcommit f7e9f54923d928e652ddc1de4dc5a700ead9efb9[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Sun Jun 5 10:10:08 2016 +0000
+
+    changed ITL email to qubes-os
+
+[33mcommit 8ce3715f9ba68534a29c028f7dcd0d2208741e07[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Sun Jun 5 10:08:25 2016 +0000
+
+    changed ITL email to qubes-os
+
+[33mcommit 676fe53fcf8e794ec983def6c8c822ce429981dc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jun 5 01:57:42 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4d9a505b
+        tagger Andrew David Wong <adw@qubes-os.org> 1465084630 -0700
+    
+        Tag for commit 4d9a505bea379a5eb7c02a82f9f283221ec9597f
+        gpg: Signature made Sun 05 Jun 2016 01:57:12 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4d9a505 Add link to Feature Development Tracker
+
+[33mcommit 4eeba3f5ec48d21fbee378987c91dd2688a1f278[m
+Merge: 524db68 2d3ffd4
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Jun 4 16:16:21 2016 -0700
+
+    Merge branch 'dumbl3d0re-add-gmane-info'
+
+[33mcommit 2d3ffd46b92073d554aa7d3dbbef2d18505cbc8f[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Jun 4 16:14:44 2016 -0700
+
+    Clean up text
+
+[33mcommit 019e1241962d75a09ecab5993a52677f2a5f6543[m
+Merge: 524db68 baca5d4
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat Jun 4 15:57:06 2016 -0700
+
+    Merge branch 'add-gmane-info' of git://github.com/dumbl3d0re/qubesos.github.io into dumbl3d0re-add-gmane-info
+
+[33mcommit 524db68850a30fcf3daa59c6e26ecdc493614806[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 4 00:36:22 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_1943a549
+        tagger Andrew David Wong <adw@qubes-os.org> 1464993312 -0700
+    
+        Tag for commit 1943a5499f5d03dcea623841a020d4ba563f575b
+        gpg: Signature made Sat 04 Jun 2016 12:35:13 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1943a54 Merge branch 'mfc-patch-19'
+        4c5c275 Merge branch 'patch-19' of git://github.com/mfc/qubes-doc into mfc-patch-19
+        aa858ba improve readability
+
+[33mcommit e68497510cf0c2e117940c6c4f1360978ac38028[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 4 00:28:12 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_9de28f5e
+        tagger Andrew David Wong <adw@qubes-os.org> 1464992863 -0700
+    
+        Tag for commit 9de28f5e38603e7d9885989cc0e515d3f658576f
+        gpg: Signature made Sat 04 Jun 2016 12:27:43 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9de28f5 Change dd example device
+
+[33mcommit 1d536f831d12b2976601e9fc33dfabfc99322d08[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 4 00:19:07 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_e6b28ff4
+        tagger Andrew David Wong <adw@qubes-os.org> 1464992317 -0700
+    
+        Tag for commit e6b28ff459b952b8f875b02c85d85eb4ef45a620
+        gpg: Signature made Sat 04 Jun 2016 12:18:38 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e6b28ff Merge branch 'ttasket-patch-1'
+        762f4f6 Minor formatting
+        27de8f2 Merge branch 'patch-1' of git://github.com/ttasket/qubes-doc into ttasket-patch-1
+        d032507 Add instructions for re-install package
+
+[33mcommit 0f9229d12646ed8f4aaaba19aca8d514929f5d17[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 4 00:14:30 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_64406671
+        tagger Andrew David Wong <adw@qubes-os.org> 1464991967 -0700
+    
+        Tag for commit 64406671391cf145be58b5848fe16ae022dbdaad
+        gpg: Signature made Sat 04 Jun 2016 12:12:48 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6440667 Merge branch 'dcame-patch-1'
+        97a8e60 Restore PGP header
+        82f91af Modernize all examples from R2 to R3.1
+
+[33mcommit 60606c9077d3ef060b245019fe00d7eaac6e810b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jun 3 01:16:41 2016 +0200
+
+    Clarify positions description on /join/
+
+[33mcommit baca5d49817de942fe7082b239fdf82a6e63d3f3[m
+Author: Albin Ludvig Otterhäll <Albin@Otterhall.com>
+Date:   Thu Jun 2 19:09:10 2016 +0000
+
+    Add information about Gmane
+
+[33mcommit bc29cadae0ed752ff98bed23d7c16544a7b6ca16[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jun 2 06:47:59 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_5ea43806
+        tagger Andrew David Wong <adw@qubes-os.org> 1464842849 -0700
+    
+        Tag for commit 5ea4380647763291c32b3704b1ff2522f6d96091
+        gpg: Signature made Thu 02 Jun 2016 06:47:29 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5ea4380 Merge branch 'unman-patch-2'
+        aef0f16 Update usb.md
+
+[33mcommit 52ffc65674db25e6bc4fb4a1f34d1d2c14771fd6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue May 31 04:44:12 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_834a461d
+        tagger Andrew David Wong <adw@qubes-os.org> 1464662625 -0700
+    
+        Tag for commit 834a461dfa2ec6247c5134b6cbbf5e84332f1ba5
+        gpg: Signature made Tue 31 May 2016 04:43:45 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        834a461 Merge branch 'unman-patch-2'
+        6c00912 Merge branch 'patch-2' of git://github.com/unman/qubes-doc into unman-patch-2
+        9b12e77 Update user-faq.md
+
+[33mcommit 63bd555bd613bd382d5fbb43a7db0c69eca442ba[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue May 31 04:39:52 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_2adbae83
+        tagger Andrew David Wong <adw@qubes-os.org> 1464662364 -0700
+    
+        Tag for commit 2adbae839de41be2691edee0904229070f5457fe
+        gpg: Signature made Tue 31 May 2016 04:39:24 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2adbae8 Merge branch 'unman-patch-1'
+        c6e6a9c Add Tails entry
+        c82e892 Fix formatting and typo
+        452c04f Rename file and page
+        0136304 Create running-tails.md
+
+[33mcommit dd78afed9ed39db72bcf3c7514c4cfc36702cee6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon May 30 22:49:09 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_56ed2bac
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1464641334 +0200
+    
+        Tag for commit 56ed2bac0575db061221b4cd4ded210e07f21195
+        gpg: Signature made Mon 30 May 2016 10:48:54 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        56ed2ba i3 installation from testing repository
+
+[33mcommit 15e970edd5a813d546599981a21a07bca126cde6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon May 30 11:09:51 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag joanna_6e308e1c
+        tagger Joanna Rutkowska <joanna@invisiblethingslab.com> 1464599347 +0200
+    
+        Tag for commit 6e308e1c55f5f110a38af6183c61b9d17ffa3b9d
+        gpg: Signature made Mon 30 May 2016 11:09:22 AM CEST using RSA key ID CA74A5C3
+        gpg: Good signature from "Joanna Rutkowska (Qubes Documentation Signing Key) <joanna@invisiblethingslab.com>"
+    
+        6e308e1 Fix link to Xen critique in the recent post
+        dae4224 Add proper categories for the recent post
+
+[33mcommit f4cdbf39444325877931141132c7f4113a673dce[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon May 30 09:24:03 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag joanna_e27f0f21
+        tagger Joanna Rutkowska <joanna@invisiblethingslab.com> 1464592380 +0200
+    
+        Tag for commit e27f0f21c78872077807db1567868421cec3bf34
+        gpg: Signature made Mon 30 May 2016 09:13:05 AM CEST using RSA key ID CA74A5C3
+        gpg: Good signature from "Joanna Rutkowska (Qubes Documentation Signing Key) <joanna@invisiblethingslab.com>"
+    
+        e27f0f2 New post: Qubes Build security challanges
+
+[33mcommit 7310d37ac5ab305c47e6553238584d24559b02ee[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 29 23:05:36 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_bbf8e43e
+        tagger Andrew David Wong <adw@qubes-os.org> 1464555693 -0700
+    
+        Tag for commit bbf8e43e9d1e982a187bb98259cfe228ea37858c
+        gpg: Signature made Sun 29 May 2016 11:01:33 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        bbf8e43 Merge branch 'PeterDaveHelloKitchen-optimize-images'
+        c1bf040 optimize jpg images losslessly using jpegoptim
+        c3c043b optimize png images losslessly using zopflipng
+
+[33mcommit 2b26a66c4940cdc28d2ab7cebf8679e6cb4a0b1b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 29 22:49:28 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4b33f24e
+        tagger Andrew David Wong <adw@qubes-os.org> 1464554940 -0700
+    
+        Tag for commit 4b33f24edf4e7c46d16d84b6a718e41741f82df6
+        gpg: Signature made Sun 29 May 2016 10:49:00 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4b33f24 Merge branch 'john-david-r-smith-patch-2'
+        c9891aa Merge branch 'patch-2' of git://github.com/john-david-r-smith/qubes-doc into john-david-r-smith-patch-2
+        c6da0b0 now using systemd to start openvpn
+        a9ae590 removed unnecessary + dangerous iptables rule
+        bed89b7 fixed typo
+        bccd955 how to setup an openvpn connection using iptables
+
+[33mcommit 2f85a1eb450cd0768eb923fd47995db6fc73d8c0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 29 04:20:25 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_c1f7414f
+        tagger Andrew David Wong <adw@qubes-os.org> 1464488380 -0700
+    
+        Tag for commit c1f7414f8db543b06abdedd4221a0af9d1b857a9
+        gpg: Signature made Sun 29 May 2016 04:19:40 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c1f7414 Merge branch 'unman-patch-1'
+        834a10b Update copying-files.md
+
+[33mcommit ab91214759d819599617efafe0dd57828b539401[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat May 28 10:04:29 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_753e8cf3
+        tagger Andrew David Wong <adw@qubes-os.org> 1464422636 -0700
+    
+        Tag for commit 753e8cf3315a6a299b5795eeea60d6edf37c2159
+        gpg: Signature made Sat 28 May 2016 10:03:56 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        753e8cf Add entry for article in _Linux Journal_
+
+[33mcommit 809455687d0a06f92e68a8e46c96e84df5872e85[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri May 27 14:11:18 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_830b4444
+        tagger Andrew David Wong <adw@qubes-os.org> 1464351049 -0700
+    
+        Tag for commit 830b4444d9238c654577f7c159875eba12c7e734
+        gpg: Signature made Fri 27 May 2016 02:10:49 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        830b444 Merge branch 'mfc-patch-18'
+        38a799e fixed typo, added hyperlink
+
+[33mcommit 48406474cc7eaf1ade5a91eb0b54de0bba9c7c7a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu May 26 06:56:07 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_145e99a5
+        tagger Andrew David Wong <adw@qubes-os.org> 1464238537 -0700
+    
+        Tag for commit 145e99a564a216ff60a0ae194eb87cc7ac3e1b38
+        gpg: Signature made Thu 26 May 2016 06:55:36 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        145e99a Add entry for Lenovo Thinkpad X201 page
+        23b2b73 Merge branch 'nielsk-master'
+        2f75d74 Fix formatting and clean up text
+        b4475dc Add Markdown file extension
+        3708817 Merge branch 'master' of git://github.com/nielsk/qubes-doc into nielsk-master
+        db3236b Update thinkpad_x201
+        86eb73a Merge pull request #1 from nielsk/nielsk-thinkpad_x201
+        8e32817 Some stuff about the Thinkpad X201
+
+[33mcommit 2304930c8d8abc6316b747a9bbee7753aed576ab[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu May 26 03:22:30 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_ee87784e
+        tagger Andrew David Wong <adw@qubes-os.org> 1464225721 -0700
+    
+        Tag for commit ee87784e6e640ea68628d6c33acb569397b4135a
+        gpg: Signature made Thu 26 May 2016 03:22:01 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ee87784 Merge pull request #148 from agutl/patch-1
+        76bba93 Update kali.md
+
+[33mcommit 99a2fe2176d0f6b9a3fbfa189df4e666f3328357[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 25 10:53:44 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_c120d004
+        tagger Andrew David Wong <adw@qubes-os.org> 1464166395 -0700
+    
+        Tag for commit c120d0043f5ced72c0dc344287cacf92ebdedf73
+        gpg: Signature made Wed 25 May 2016 10:53:15 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c120d00 Update Glossary
+
+[33mcommit c307eeb4776be6a0760953957d1aff6f3edfeb14[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 25 10:17:06 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_fdeab1e4
+        tagger Andrew David Wong <adw@qubes-os.org> 1464164197 -0700
+    
+        Tag for commit fdeab1e4785cb288d5591f56b0a5fb1c6940c05b
+        gpg: Signature made Wed 25 May 2016 10:16:36 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        fdeab1e Merge pull request #146 from kulinacs/split-git
+        c785d37 Fixed Style in Split Git Documentation
+
+[33mcommit 682cc6d7c796f8adbea2e41cb1a8561f56423680[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 25 10:04:38 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4e091781
+        tagger Andrew David Wong <adw@qubes-os.org> 1464163448 -0700
+    
+        Tag for commit 4e09178199808420b56792da9dcfc49a14867e5c
+        gpg: Signature made Wed 25 May 2016 10:04:08 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4e09178 Update heading of configuration section
+        9ebcfd1 Change heading and heading level of Thunderbird section
+
+[33mcommit 7c8b9e17d6c2e66dcf1f3c91f6bd5dffd0a15fc5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 25 10:00:32 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_e4b660f3
+        tagger Andrew David Wong <adw@qubes-os.org> 1464163197 -0700
+    
+        Tag for commit e4b660f30b32290e9cb955ec3e29817efce159e3
+        gpg: Signature made Wed 25 May 2016 09:59:57 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e4b660f Change heading and heading level of Git section
+
+[33mcommit 6653d05df8785b4fb8434703ed40952cb5cdff46[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed May 25 00:45:22 2016 -0700
+
+    Add Join button to Team page
+    
+    QubesOS/qubes-issues#1700
+
+[33mcommit 092e339072b28d62b099fab9cbeaa4b272f147f1[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed May 25 00:34:20 2016 -0700
+
+    Add Join page to _data/architecture.yml
+    
+    QubesOS/qubes-issues#1700
+
+[33mcommit 13592ceec7581bbd5438e5674db6b2af66692136[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed May 25 00:29:02 2016 -0700
+
+    Direct interested parties to email Marek
+    
+    QubesOS/qubes-issues#1700
+
+[33mcommit 39bed60ad2fc0036bfc6d53c2e641bad091ca195[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed May 25 00:25:13 2016 -0700
+
+    Replace literal URLs with hyperlinks
+    
+    QubesOS/qubes-issues#1700
+    QubesOS/qubes-issues#1932
+
+[33mcommit 75b84848cfd551a6b9b6005ce2f285d5a796bd2c[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed May 25 00:20:33 2016 -0700
+
+    Change to doc layout (QubesOS/qubes-issues#1700)
+
+[33mcommit 08faa1804e45192c5300d9f0961be647c72a59d2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 25 06:49:49 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_3239b9c4
+        tagger Andrew David Wong <adw@qubes-os.org> 1464151744 -0700
+    
+        Tag for commit 3239b9c4e5719cd15e9a9003da23f114b55933b7
+        gpg: Signature made Wed 25 May 2016 06:49:04 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3239b9c Merge branch 'ryanchapman-patch-2'
+        e06dc32 Remove duplicate command and specify testing repo
+        98cde9a Merge branch 'patch-2' of git://github.com/ryanchapman/qubes-doc into ryanchapman-patch-2
+        2b4fa6a Typo
+        3359c4f Add note to try testing repo if stable does not work
+        87a9c20 Remove ref to qubes-windows-tools in current repo
+
+[33mcommit e59aca78feef3ed5e7f86d1ff22ce46e3b044d77[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 25 02:39:55 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4cad1f08
+        tagger Andrew David Wong <adw@qubes-os.org> 1464136756 -0700
+    
+        Tag for commit 4cad1f085dda21ff125de7d6c8e19353a3aa2f0f
+        gpg: Signature made Wed 25 May 2016 02:39:16 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4cad1f0 Merge branch 'kulinacs-split-git'
+        5aa7b55 Explain usage of git tag aliases
+        3d9c2d1 Don't hardcode my initials into your git tag alias :)
+        f6ee88b Added Split-GPG for Git documentation
+
+[33mcommit 908372c9f6b50b31a6d0995005d58438503fef30[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue May 24 01:32:46 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_c822b8b2
+        tagger Andrew David Wong <adw@qubes-os.org> 1464046338 -0700
+    
+        Tag for commit c822b8b28d7cb1e0f5f6ecf005fd39bedae1fc45
+        gpg: Signature made Tue 24 May 2016 01:32:17 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c822b8b Merge branch 'kulinacs-deb-stretch'
+        23a1779 Updated Upgrading Debian 8 with sound fix
+
+[33mcommit 770aef0ec5523d5dba6e85dcc8a2633f98d4990f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue May 24 00:53:11 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_db3d6a11
+        tagger Andrew David Wong <adw@qubes-os.org> 1464043873 -0700
+    
+        Tag for commit db3d6a113416c87dd6f4a5087194a71a44ea80a7
+        gpg: Signature made Tue 24 May 2016 12:51:13 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        db3d6a1 Merge branch 'SietsevanderMolen-i3-qubes'
+        ebe38e9 Add warning, fix links, and fix formatting
+        0261b55 link to i3 page on main page
+        fdab6ce Add page on installing and configuring i3wm
+
+[33mcommit 692ec986e00e59303588261af7425742341b8a7e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 22 10:50:59 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_b0523866
+        tagger Andrew David Wong <adw@qubes-os.org> 1463907033 -0700
+    
+        Tag for commit b0523866824892401ce16b55db901ababd331ad5
+        gpg: Signature made Sun 22 May 2016 10:50:33 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b052386 Merge branch 'kulinacs-patch-1'
+        4f406d2 Merge branch 'patch-1' of git://github.com/kulinacs/qubes-doc into kulinacs-patch-1
+        856e4db Updated main page
+        b983d89 Added configuration file information
+        a95c670 Spelling fixes
+        681f7cb Style fixes
+        cd77785 Added documentation for upgrade Debian 8 to Debian 9
+
+[33mcommit 8ab4ba86b5b820861bc059b5ab7cad4df44afe0c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 22 06:06:51 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_f981ba4f
+        tagger Andrew David Wong <adw@qubes-os.org> 1463889986 -0700
+    
+        Tag for commit f981ba4fd90f24f321d4a11c38e2fc40d37978f7
+        gpg: Signature made Sun 22 May 2016 06:06:26 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f981ba4 Merge branch 'john-david-r-smith-patch-1'
+        686a83b Merge branch 'patch-1' of git://github.com/john-david-r-smith/qubes-doc into john-david-r-smith-patch-1
+        25e3a0c now using markdown linebreaks
+        9466d57 ubuntu linkt moved + added some linebreaks
+        0b51ef4 how to avoid creating an ubuntu 14.4 LTS template
+
+[33mcommit d20099b455ac10b5b592b573518b79fa6b9ad5e1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat May 21 16:49:34 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_7102bfed
+        tagger Andrew David Wong <adw@qubes-os.org> 1463842150 -0700
+    
+        Tag for commit 7102bfeda8d3b08226d17d0177d165c51bcdaefe
+        gpg: Signature made Sat 21 May 2016 04:49:10 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7102bfe Add "/doc" prefix
+
+[33mcommit 44b034aed74f5449270a17aa457d8ca74eb05957[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat May 21 16:48:22 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_4886f1d6
+        tagger Andrew David Wong <adw@qubes-os.org> 1463842078 -0700
+    
+        Tag for commit 4886f1d6c5f2e0698cde3b2856fc2f038394f9c6
+        gpg: Signature made Sat 21 May 2016 04:47:58 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4886f1d Add redirects to catch accidentally excluding "/templates"
+
+[33mcommit a8706e20440d0b8e92d5af4eaab48805ec565039[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat May 21 16:43:56 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_bbdd7634
+        tagger Andrew David Wong <adw@qubes-os.org> 1463841811 -0700
+    
+        Tag for commit bbdd763426ea6223d5e866ea2a52545a52e9a1da
+        gpg: Signature made Sat 21 May 2016 04:43:31 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        bbdd763 Clean up text
+        d08c122 Merge branch 'clayt0nk-mods'
+        7750965 Mention option for upgrading latest Debian stable template to stretch.
+
+[33mcommit ec898f12eec8a29445e5ce651912a41325ca945a[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat May 21 03:55:27 2016 -0700
+
+    Update StackExchange links and descriptions to proposal
+
+[33mcommit 76192f64f5d4fbe2bc8fbdcd319e007ad1d34367[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri May 20 23:18:26 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_0865bda4
+        tagger Andrew David Wong <adw@qubes-os.org> 1463779077 -0700
+    
+        Tag for commit 0865bda4720ea7d0e5eecae980fe3458a2dff9be
+        gpg: Signature made Fri 20 May 2016 11:17:57 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        0865bda Start Split Bitcoin page (QubesOS/qubes-issues#1966)
+
+[33mcommit fb728a410272fd43b231755955b64fbaed6b5cd5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 18 16:15:28 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_d0afd52c
+        tagger Andrew David Wong <adw@qubes-os.org> 1463580777 -0700
+    
+        Tag for commit d0afd52cba9eceff996826288a0fe623bb5d6eb2
+        gpg: Signature made Wed 18 May 2016 04:12:56 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d0afd52 Merge branch 'louy2-patch-2'
+        ab2fadf Add rEFInd info
+
+[33mcommit e74df85786d7694c8f7d43dabcc49733f19e654e[m
+Merge: c136c45 f7c1d16
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue May 17 17:42:42 2016 -0700
+
+    Merge branch 'kalkin-master'
+
+[33mcommit f7c1d1698d0d7a8cf3f57300b0a6e4a1544a2960[m
+Merge: c136c45 c9e0a3f
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Tue May 17 17:40:40 2016 -0700
+
+    Merge branch 'master' of git://github.com/kalkin/qubesos.github.io into kalkin-master
+
+[33mcommit c136c455970e4c9948159e1cc8eeb0a0c82b7651[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 18 02:22:36 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_f56236b3
+        tagger Andrew David Wong <adw@qubes-os.org> 1463530895 -0700
+    
+        Tag for commit f56236b30b6ee153ff8dc832e2097e632b025999
+        gpg: Signature made Wed 18 May 2016 02:21:35 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f56236b Merge branch 'kalkin-master'
+        d38ffa3 Add my photo
+
+[33mcommit c9e0a3f27ed8cba7b14877f23407668cf75ba4cb[m
+Author: Bahtiar `kalkin-` Gadimov <bahtiar@gadimov.de>
+Date:   Tue May 17 19:56:08 2016 +0200
+
+    Add myself to Team page
+
+[33mcommit bf3c415872a878373e275262ceeeffead19fa39a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon May 16 13:03:18 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_417664d6
+        tagger Andrew David Wong <adw@qubes-os.org> 1463396577 -0700
+    
+        Tag for commit 417664d6600a548eebfb05f613088d8789d5ff72
+        gpg: Signature made Mon 16 May 2016 01:02:57 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        417664d Follow our file naming conventions
+
+[33mcommit bf1217cbfbed7f1ff254aaa91226e1f0481d3e6c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon May 16 10:34:31 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_de9024c5
+        tagger Andrew David Wong <adw@qubes-os.org> 1463387651 -0700
+    
+        Tag for commit de9024c59cf9da6b98f76b0386bddc0615b05a3f
+        gpg: Signature made Mon 16 May 2016 10:34:11 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        de9024c Fix qvm-serivce commands
+
+[33mcommit e879b0ba394aca5d5f3b680bc100e35ed24479a3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon May 16 09:13:38 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_ca189a8a
+        tagger Andrew David Wong <adw@qubes-os.org> 1463382801 -0700
+    
+        Tag for commit ca189a8a287fe935ffd5261c23a17fb519fac996
+        gpg: Signature made Mon 16 May 2016 09:13:21 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ca189a8 Merge pull request #136 from louy2/patch-1
+        2f4afec Fix list format and typo
+
+[33mcommit 91f0528db2a62d4f25cd0369817b51f7a76e7022[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon May 16 05:03:36 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_bc433f4e
+        tagger Andrew David Wong <adw@qubes-os.org> 1463367797 -0700
+    
+        Tag for commit bc433f4eb798c2cf6490d2a328708c4d89d718fa
+        gpg: Signature made Mon 16 May 2016 05:03:17 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        bc433f4 Merge branch 'Vfreeze31-patch-1'
+        69d7d06 Changed heading levels
+        753cd5d added spaces to improve formatting
+        042d15d rough content for Debian based clone
+        880967c Created intro
+
+[33mcommit 04144c54012f199043c75f9c50b4e11838dcfffc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 15 22:33:53 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_3dbb70cb
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1463344420 +0200
+    
+        Tag for commit 3dbb70cb0afb6bdf4eed3127cbec8e85ae7ac008
+        gpg: Signature made Sun 15 May 2016 10:33:40 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        3dbb70c qrexec: add policy argument info
+        c1aef22 qrexec: update qrexec-client-vm usage and using script as a service
+
+[33mcommit ea8f1fd99c186ce6d91634f7fa903842fad86183[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sun May 15 04:07:12 2016 -0700
+
+    Remove superfluous heading link portion
+
+[33mcommit 7f47784c2b0831cfa3dc2c7ec0820684c98446db[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu May 12 08:23:51 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_dee26a04
+        tagger Andrew David Wong <adw@qubes-os.org> 1463034212 -0700
+    
+        Tag for commit dee26a04a7257c03346886efdf00238a1bcdd717
+        gpg: Signature made Thu 12 May 2016 08:23:33 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        dee26a0 Start Kali page
+
+[33mcommit 04220309a1323ae358551275dd395ec894823372[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Wed May 11 13:20:48 2016 -0700
+
+    Add link to Qubes-certified Laptops page
+
+[33mcommit 139607739a4d724f46bc7ef94f58da945c32fa75[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 11 22:15:56 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_b5bd1659
+        tagger Andrew David Wong <adw@qubes-os.org> 1462997572 -0700
+    
+        Tag for commit b5bd1659ef65dd326450c7141de8c2e67d615d05
+        gpg: Signature made Wed 11 May 2016 10:12:52 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b5bd165 Link to Hardware Certification page
+
+[33mcommit f3ba215ab7d71354ce3268b12df1deecf7abcd9b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue May 10 23:06:13 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_eff33ad5
+        tagger Andrew David Wong <adw@qubes-os.org> 1462914354 -0700
+    
+        Tag for commit eff33ad5b5635a22c37669ba1fa796f20bf82018
+        gpg: Signature made Tue 10 May 2016 11:05:52 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        eff33ad Merge pull request #7 from adrelanos/patch-1
+        4119567 fix upgrading confusion
+
+[33mcommit 2092bdc67e2bafa46cd4a48d956bd79576c46864[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat May 7 13:50:22 2016 -0700
+
+    Add Live USB maintainer and GNOME implementer positions
+    
+    QubesOS/qubes-issues#1700
+
+[33mcommit 79f170f6f7fe3c61171bc9e61b1ea45c24bf157d[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Sat May 7 11:42:10 2016 -0700
+
+    Update R2's status to unsupported
+
+[33mcommit 87afd69e3fd94ed57319b6a03a1bc421a73887a8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat May 7 20:40:41 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_5c6b18dd
+        tagger Andrew David Wong <adw@qubes-os.org> 1462646423 -0700
+    
+        Tag for commit 5c6b18ddc85d6de12f89141ffff6f207b94609bf
+        gpg: Signature made Sat 07 May 2016 08:40:24 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5c6b18d Update R2's status to unsupported
+
+[33mcommit 7b014e9d4d502b90686eda724096ba92519e953f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat May 7 19:44:29 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_a97660eb
+        tagger Andrew David Wong <adw@qubes-os.org> 1462643043 -0700
+    
+        Tag for commit a97660eb62de81962bd6b05502e1f3b608d6b6a8
+        gpg: Signature made Sat 07 May 2016 07:44:04 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a97660e Merge branch 'HeDamsja-patch-1'
+        916c157 Added 'ip a'
+        22c9284 Update install-nvidia-driver.md
+
+[33mcommit 1c897f3859a788cfbd86730d29d8f33f5af17e99[m
+Merge: 87e73a4 cb29019
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri May 6 04:08:50 2016 -0700
+
+    Merge branch 'jobs'
+
+[33mcommit cb2901902d2b9c864fe02b68ae83ca035aff1e87[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri May 6 03:56:08 2016 -0700
+
+    Minor punctuation and capitalization
+
+[33mcommit 87e73a4f3d07ccd411d00a390f90ec58db7cc54a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri May 6 12:53:26 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_fc68100e
+        tagger Andrew David Wong <adw@qubes-os.org> 1462531976 -0700
+    
+        Tag for commit fc68100e9d25efbcddfc8ca1db81edb1b604bda7
+        gpg: Signature made Fri 06 May 2016 12:52:57 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        fc68100 Merge pull request #132 from mfc/patch-17
+        d8c7fbe fixed typo
+
+[33mcommit d804ba31767a1f30d22c9da1896a19826047c1d1[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu May 5 09:30:20 2016 -0700
+
+    Replace gendered pronouns
+
+[33mcommit 05e714e8230ce8b01d44718d2617b7e192086c38[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu May 5 13:56:37 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag adw_03723bfd
+        tagger Andrew David Wong <adw@qubes-os.org> 1462449381 -0700
+    
+        Tag for commit 03723bfd243f5e5c65bc86b2b38b752c722f7518
+        gpg: Signature made Thu 05 May 2016 01:56:18 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        03723bf Add entry for article in _fossBytes_
+        bc9a7d5 Add entry for article in _The Hacker News_
+
+[33mcommit cff1ca4809890db7e350b07cd76c4a111276e7ef[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Thu May 5 04:29:13 2016 -0700
+
+    Add links to Facebook page
+
+[33mcommit ffb244306c4206dd5ba0c91bc0b793ac32573f01[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu May 5 00:16:49 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_72b62910
+        tagger Andrew David Wong <adw@qubes-os.org> 1462400194 -0700
+    
+        Tag for commit 72b62910e4c21f951e85c0f03d6f05349c34599a
+        gpg: Signature made Thu 05 May 2016 12:16:34 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        72b6291 Create section and entries for LinuxCon 2014 slides
+
+[33mcommit 28ef5bb13e1649df02c0c28710bdd5399ac80a1a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu May 5 00:14:28 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_17934834
+        tagger Andrew David Wong <adw@qubes-os.org> 1462399963 -0700
+    
+        Tag for commit 1793483437b371f91b187b730b3d9bd8186d22e8
+        gpg: Signature made Thu 05 May 2016 12:12:44 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1793483 Add LinuxCon 2014 slides
+
+[33mcommit 85c6f0eb4ccf7dbb0d08dfd3f0c2237ec6640fc0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 4 15:17:29 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_93ce65bc
+        tagger Andrew David Wong <adw@qubes-os.org> 1462367834 -0700
+    
+        Tag for commit 93ce65bcc0aa13a60a473e455a34a5447037f883
+        gpg: Signature made Wed 04 May 2016 03:17:11 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        93ce65b Rename `hvm-create` to `hvm` to reflect contents
+
+[33mcommit 26af12d810f99c354ecacb23ce9d22987909286f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 4 09:23:35 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_53674363
+        tagger Andrew David Wong <adw@qubes-os.org> 1462346598 -0700
+    
+        Tag for commit 53674363b45b169258d8955d2905c5a2bb26f454
+        gpg: Signature made Wed 04 May 2016 09:23:19 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5367436 Merge branch 'gutsle-patch-1'
+        d2538c7 Clarify language, correct typos, and fix formatting
+        24423f3 entire device should be used with dd
+
+[33mcommit d3efd46df945550e2763ac9cdca2b0b42354c139[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue May 3 07:52:03 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_e0d3c57c
+        tagger Andrew David Wong <adw@qubes-os.org> 1462254696 -0700
+    
+        Tag for commit e0d3c57cef96c55ba8a6dddc747c9390fd6a1d1a
+        gpg: Signature made Tue 03 May 2016 07:51:36 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e0d3c57 Merge pull request #130 from lambono/patch-2
+        7fe71f3 Update fedora-minimal-template-customization.md
+
+[33mcommit 69d7cd6ba9ec2594663b22d15862fa257e9d2c4c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 1 03:48:09 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_2bd264f6
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1462067276 +0200
+    
+        Tag for commit 2bd264f62760014118bb7acb13fb8ee557f0d760
+        gpg: Signature made Sun 01 May 2016 03:47:56 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        2bd264f salt: Document how to configure system inside of VM
+
+[33mcommit c63b11e473162059918a936c1c3053f916328349[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 1 02:07:04 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_40833922
+        tagger Andrew David Wong <adw@qubes-os.org> 1462061191 -0700
+    
+        Tag for commit 4083392243898180c8ad9a46b471218d687d499c
+        gpg: Signature made Sun 01 May 2016 02:06:31 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4083392 Add redirect from "randomizing..."
+
+[33mcommit 5bc615bad8a68dcaa45d43aed3408716b6428a9e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 1 02:05:08 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_e4f036a4
+        tagger Andrew David Wong <adw@qubes-os.org> 1462061095 -0700
+    
+        Tag for commit e4f036a4e3130a45e44cd7815d12c0a6942262b1
+        gpg: Signature made Sun 01 May 2016 02:04:55 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e4f036a Match main heading to title
+
+[33mcommit 9c5e6dbb15e36ea763eab09df84b17bd28736df4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 1 02:03:11 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag adw_cae73ebd
+        tagger Andrew David Wong <adw@qubes-os.org> 1462060943 -0700
+    
+        Tag for commit cae73ebd3386091db2adbef95a0bdf660a9c6d75
+        gpg: Signature made Sun 01 May 2016 02:02:23 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        cae73eb Match title and link to document
+
+[33mcommit 8ea9a8d5cac6dbe5fe9b9effdac96723562b4db9[m
+Author: Andrew David Wong <adw@qubes-os.org>
+Date:   Fri Apr 29 03:04:12 2016 -0700
+
+    Autodepseudonymization
+
+[33mcommit 91c97e35d90c9098ef66087756f7c49894c54062[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Apr 29 12:03:21 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag adw_67d4d55a
+        tagger Andrew David Wong <adw@qubes-os.org> 1461924149 -0700
+    
+        Tag for commit 67d4d55a39181fca8a9259517fd8e8956dbe8db0
+        gpg: Signature made Fri 29 Apr 2016 12:02:29 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        67d4d55 Add my photo
+
+[33mcommit 0b31f39be19a38150460dfec44a6e88bc93562c1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Apr 29 12:01:17 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag qubes-doc-adw
+        tagger Andrew David Wong <adw@qubes-os.org> 1461922854 -0700
+    
+        Signed by Qubes Documentation Signing Key.
+        gpg: Signature made Fri 29 Apr 2016 11:41:14 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a66f11a Autodepseudonymization
+
+[33mcommit f7b14e8ea837b0a682af7cbf6ddc3a2222611d5e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Apr 25 08:55:23 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_074b10c9
+        tagger Axon <axon@openmailbox.org> 1461567304 +0000
+    
+        Tag for commit 074b10c99283efdce689e9a09f76c6828371afeb
+        gpg: Signature made Mon 25 Apr 2016 08:55:03 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        074b10c Merge pull request #129 from mfc/patch-16
+        732670f more accurate name for debian-8-template
+
+[33mcommit 4e72ecf263a54f782cc8a01c25feacbebe5ea743[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Apr 25 08:49:28 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_b9290d06
+        tagger Axon <axon@openmailbox.org> 1461566945 +0000
+    
+        Tag for commit b9290d06d9e62381cf0f1746aabdcd6efe7a0b63
+        gpg: Signature made Mon 25 Apr 2016 08:49:07 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b9290d0 cleaned up
+        f6b74c6 some small typos & grammar changes
+        8c1beaf added Randomizing your MAC Address
+
+[33mcommit 062a0ca74e3c5fa7cae83f0dc2660faa99f091ca[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Apr 24 19:45:49 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_6d4918d3
+        tagger Axon <axon@openmailbox.org> 1461519932 +0000
+    
+        Tag for commit 6d4918d388c9f892eb1488ec1d27ed0a5cd28f22
+        gpg: Signature made Sun 24 Apr 2016 07:45:32 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6d4918d Add Martus page to ToC (QubesOS/qubes-issues#1836)
+
+[33mcommit 73d6bf5637a1b7b6b0d43693570d6ce5be6c6990[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Apr 24 12:07:19 2016 +0000
+
+    Change "jobs" to "join" (and remove "hiring")
+
+[33mcommit 5fdb8a3e55de4538b96e681ffb7603cbed0b9676[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Apr 24 08:22:20 2016 +0000
+
+    Create Jobs page (QubesOS/qubes-issues#1700)
+
+[33mcommit 775e9f32832e1c49976dbf426d45e8a0e63e915c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Apr 24 10:00:24 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_4d44d9d8
+        tagger Axon <axon@openmailbox.org> 1461484809 +0000
+    
+        Tag for commit 4d44d9d896c3057d98ad1649a8341736a8e89988
+        gpg: Signature made Sun 24 Apr 2016 10:00:09 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4d44d9d Create Martus page (QubesOS/qubes-issues#1836)
+
+[33mcommit 4e10216c8beca5fc816e97bbc6e8c5bc78ead7cb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Apr 24 05:12:16 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_c66d902b
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1461467521 +0200
+    
+        Tag for commit c66d902bad0763718320ad080fb84347ff1bf184
+        gpg: Signature made Sun 24 Apr 2016 05:12:01 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        c66d902 Formatting
+
+[33mcommit 6ff1c67b00c32f17af090ee8e3d1d00b9337111e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Apr 22 12:50:08 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+    
+        68bfd1c Merge branch 'master' of github.com:QubesOS/qubes-attachment
+        9333b68 added screenshot of sys-net with macspoof service
+
+[33mcommit 4d4ef81680d2b0029e86b24a8e5d15fb1fec5a18[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Apr 20 18:43:09 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag axon_610ce0d6
+        tagger Axon <axon@openmailbox.org> 1461170574 +0000
+    
+        Tag for commit 610ce0d6f0f35d49abf57fdb50ed60abaa60a7a9
+        gpg: Signature made Wed 20 Apr 2016 06:42:55 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        610ce0d Merge pull request #6 from tezeb/master
+        f1fc84e Arch linux template building
+
+[33mcommit 36ab2b7510bb02236d392169a4057c4e9032001d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Apr 20 14:37:35 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_1940cb3f
+        tagger Axon <axon@openmailbox.org> 1461155841 +0000
+    
+        Tag for commit 1940cb3f143d92e6fb0a3f51ecad864d5e4d817b
+        gpg: Signature made Wed 20 Apr 2016 02:37:23 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1940cb3 Merge pull request #126 from tezeb/master
+        5257e8f Arch linux template building
+
+[33mcommit efaa6942bb8fab4cd4faeb388dbefb78501aeb65[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Apr 20 12:05:44 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_07539d1e
+        tagger Axon <axon@openmailbox.org> 1461146725 +0000
+    
+        Tag for commit 07539d1e61f7738fbc710532b6a891b169ef0379
+        gpg: Signature made Wed 20 Apr 2016 12:05:26 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        07539d1 Merge pull request #127 from gutsle/patch-2
+        00095d2 Update full-screen-mode.md
+        4d939d0 Update full-screen-mode.md
+
+[33mcommit 1e1b3810e79ddc6b5b1b929578074b24668a9d34[m
+Merge: c282a14 9d477c9
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Apr 19 09:59:29 2016 +0000
+
+    Merge pull request #39 from gutsle/patch-1
+    
+    Update getting-started.md
+
+[33mcommit c282a14d0b820527be8ce740a8a3ed7e895341c8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Apr 19 11:52:04 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_f08f1fbf
+        tagger Axon <axon@openmailbox.org> 1461059504 +0000
+    
+        Tag for commit f08f1fbfbcff816da3f22d4e53915404ea61df95
+        gpg: Signature made Tue 19 Apr 2016 11:51:44 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f08f1fb Merge pull request #123 from gutsle/patch-1
+        9b92909 Update version-scheme.md
+        3415184 Update version-scheme.md
+
+[33mcommit 9d477c943512082dc9a4b39c003395b33a25302f[m
+Author: ChocolateCravings <gutsle@sogetthis.com>
+Date:   Tue Apr 19 10:30:11 2016 +0200
+
+    Update getting-started.md
+    
+    added link to full screen mode docs in the same getting started section
+    - if the redundancy is not intentional I would suggest removing the detailed instruction from the getting started page
+    not everybody immediately needs full screen mode and if they want it they should probably be given all the information
+
+[33mcommit c7fea44f9b239a39d5b530b21a72795142dace9d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Apr 19 05:40:25 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_a28a6967
+        tagger Axon <axon@openmailbox.org> 1461037211 +0000
+    
+        Tag for commit a28a6967f3fed05ed856688272e0486e9ac18fe2
+        gpg: Signature made Tue 19 Apr 2016 05:40:08 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a28a696 Merge pull request #124 from gutsle/patch-2
+        6fb9c3e Update hcl.md
+
+[33mcommit 2633bff16562b94a0173ccf12c37b9ce84277843[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Apr 19 05:09:03 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_dc4e1466
+        tagger Axon <axon@openmailbox.org> 1461035323 +0000
+    
+        Tag for commit dc4e1466ce3967c30d6dbc766d170b6a80642354
+        gpg: Signature made Tue 19 Apr 2016 05:08:38 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        dc4e146 Fix headings (fixes QubesOS/qubes-issues#1914)
+
+[33mcommit 75034d2a6e6269420c9ecd0be961028cde3914cb[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Apr 19 02:54:29 2016 +0000
+
+    Add note on non-fullscreen window-spoofing attacks
+
+[33mcommit bc5398dec894f76e1c8fe232fb6b26f3a2de4076[m
+Author: Brennan Novak <bnvk@invisiblethingslab.com>
+Date:   Mon Apr 18 11:24:05 2016 +0200
+
+    added Funding to architecture.yml
+    
+    QubesOS/qubes-issues#1701
+
+[33mcommit 36326e48666d36afebf8319b631fa2b4f175402f[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sat Apr 9 22:03:33 2016 +0000
+
+    Create Funding page (QubesOS/qubes-issues#1701)
+
+[33mcommit d48ad53c470adc5dad8e61871ed44e8d0aa2393c[m
+Merge: 57c3b3d f144d7d
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Apr 18 10:54:48 2016 +0200
+
+    Merge pull request #38 from QubesOS/news
+    
+    Remove old _data/news.yml
+
+[33mcommit 57c3b3d65962f6421d4c7d9ac116594e7838efc9[m
+Author: Brennan Novak <bnvk@invisiblethingslab.com>
+Date:   Mon Apr 18 10:44:47 2016 +0200
+
+    added some responsive grid to Team page
+    
+    QubesOS/qubes-issues#1869
+
+[33mcommit 5e0015dac0e20e0270e41ef127bffcd87867a3fa[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Apr 13 01:32:24 2016 +0000
+
+    Update Team page
+    
+    Changes as discussed in internal emails:
+    * Update Axon's role and information
+    * Move Hakisho to Community Contributors
+    * Remove Maintainers section
+
+[33mcommit 2bc0f1283b27935e70cff1a28777ed0d69e651c4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Apr 17 14:50:17 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag axon_7b6dc627
+        tagger Axon <axon@openmailbox.org> 1460897401 +0000
+    
+        Tag for commit 7b6dc627ab3e1a8c120479f2083905922f6ccbe8
+        gpg: Signature made Sun 17 Apr 2016 02:50:01 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        7b6dc62 Add Joanna's recent talks
+
+[33mcommit f144d7db58de9c649221d17792eb41f4fdc02e2f[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Apr 17 11:16:25 2016 +0000
+
+    Remove old _data/news.yml
+
+[33mcommit dfbb94704421054cc68a3ff395ccfdf4b49f7365[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Apr 17 13:14:54 2016 +0200
+
+    autoupdate: _posts
+    
+    _posts:
+        tag axon_1397ca8e
+        tagger Axon <axon@openmailbox.org> 1460891665 +0000
+    
+        Tag for commit 1397ca8e42ab5a0445f22357ae06c1511c972e98
+        gpg: Signature made Sun 17 Apr 2016 01:14:25 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1397ca8 Add recent videos and articles about Qubes
+
+[33mcommit 6ff511513e957ec820990df3a7954891fb9baa0f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Apr 17 01:25:31 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_94bf5d98
+        tagger Axon <axon@openmailbox.org> 1460849114 +0000
+    
+        Tag for commit 94bf5d98c32eae7697f878928307a68c94a4d071
+        gpg: Signature made Sun 17 Apr 2016 01:25:14 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        94bf5d9 Merge pull request #122 from mfc/patch-14
+        68f3e6c remove librem 15 section
+
+[33mcommit 4bea2d82e632b8152cc7b6e35aea65600b0242c5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Apr 16 05:36:11 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_fa81ded2
+        tagger Axon <axon@openmailbox.org> 1460777750 +0000
+    
+        Tag for commit fa81ded2080bcc01ee08194656ebd2da6c0cfff5
+        gpg: Signature made Sat 16 Apr 2016 05:35:50 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        fa81ded Add note about VT-x error message
+
+[33mcommit 18636f60cdbd7bc1c286539fb0ace552414da1ef[m
+Author: Brennan Novak <bnvk@invisiblethingslab.com>
+Date:   Fri Apr 15 18:09:25 2016 +0200
+
+    added Isis quote to homepage
+    
+    QubesOS/qubes-issues#1746
+
+[33mcommit 3855f6ab3c6b0a93cf5f1b5911bac054a6531bcd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Apr 15 17:39:39 2016 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag bnvk_597ddbf5
+        tagger Brennan Novak <bnvk@invisiblethingslab.com> 1460734724 +0200
+    
+        Tag for commit 597ddbf5ac92260361e234cf97f3fb6e9c44eec9
+        gpg: Signature made Fri 15 Apr 2016 05:38:45 PM CEST using RSA key ID 2FBC07A9
+        gpg: Good signature from "Brennan Novak (Qubes Website & Documentation Signing) <bnvk@invisiblethingslab.com>"
+    
+        597ddbf added picture of Isis
+
+[33mcommit 727cbe84e5f7bf28f0a1500f86f1417709ffd1be[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Apr 15 02:01:47 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_2c47f67d
+        tagger Axon <axon@openmailbox.org> 1460678454 +0000
+    
+        Tag for commit 2c47f67d7e4d802c7d22214f43a3f3f80315325e
+        gpg: Signature made Fri 15 Apr 2016 02:00:55 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2c47f67 Clarify meaning of "certified"; add Librem 15 section
+
+[33mcommit b04ce065f7769f1561dd128ae1e4184dff8105b9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Apr 15 00:47:40 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_a9cadfc3
+        tagger Axon <axon@openmailbox.org> 1460674038 +0000
+    
+        Tag for commit a9cadfc3b9b2d4b10ca558f51d2de1b221c48385
+        gpg: Signature made Fri 15 Apr 2016 12:47:18 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a9cadfc Update for R3.1; clean up syntax and formatting
+        3c4cd58 Copy-to-dom0 --> Copy-from-dom0
+
+[33mcommit 0b4c43f864bf018ae28a02a710eefb8ce83f78f8[m
+Merge: dfcb509 7e0c113
+Author: Brennan Novak <bnvk@invisiblethingslab.com>
+Date:   Thu Apr 14 15:53:17 2016 +0200
+
+    Merge branch 'research'
+
+[33mcommit 7e0c113813af547d44a42caf79adb32407a2ff7b[m
+Author: Brennan Novak <bnvk@invisiblethingslab.com>
+Date:   Thu Apr 14 15:42:23 2016 +0200
+
+    added data categories to Research page
+    
+    QubesOS/qubes-issues#1905
+
+[33mcommit c597804e32d01d9b7141a9c8e7568781d5662cbf[m
+Author: Axon <axon@openmailbox.org>
+Date:   Thu Apr 14 03:51:12 2016 +0000
+
+    Finish making Research page and section data-driven
+    
+    QubesOS/qubes-issues#1905
+
+[33mcommit dfcb509bae9adef94d790ce1a34c85913e27c9cf[m
+Merge: fe372dc b060d41
+Author: Brennan Novak <bnvk@invisiblethingslab.com>
+Date:   Wed Apr 13 19:17:24 2016 +0200
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit fe372dcd32e6022796a6ba923255caa3c436f72e[m
+Author: Brennan Novak <bnvk@invisiblethingslab.com>
+Date:   Wed Apr 13 19:03:29 2016 +0200
+
+    added Hardware Certification page & rejiggered homepage
+    
+    QubesOS/qubes-issues#1904
+
+[33mcommit b060d4154cee5446d95c8b26e4f189a451d60a82[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Apr 13 19:02:20 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_a133649a
+        tagger Axon <axon@openmailbox.org> 1460566921 +0000
+    
+        Tag for commit a133649a11c0a36c8b77aad769dcbb6698ac70a5
+        gpg: Signature made Wed 13 Apr 2016 07:02:00 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a133649 Fix code block syntax
+
+[33mcommit bb29719d64fa3b74c7628149ba2dc028b4945cf9[m
+Author: Brennan Novak <bnvk@invisiblethingslab.com>
+Date:   Wed Apr 13 18:38:57 2016 +0200
+
+    added 'State considered harmful' to data/research
+
+[33mcommit f584662df094d0c53db5d870b80a79bf95f69591[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Apr 12 13:39:10 2016 +0200
+
+    Fix Joanna's website URL
+
+[33mcommit da00e4c9b66126b0f3ff83879b1fbaaa9a85b9a8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Apr 11 15:49:18 2016 +0200
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag zrubi_634ecb2
+        tagger Zrubi <mail@zrubi.hu> 1460382482 +0200
+    
+        New HCL entries added (20160323-20160411)
+        gpg: Signature made Mon 11 Apr 2016 03:48:08 PM CEST using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        634ecb2 New HCL entries added (20160323-20160411)
+
+[33mcommit c2273ffa06f78bbf1c649ae268f14859939a0f61[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Apr 9 04:53:13 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_73aba43d
+        tagger Axon <axon@openmailbox.org> 1460170377 +0000
+    
+        Tag for commit 73aba43da480f0e5ab7df15155231235e2b0a7be
+        gpg: Signature made Sat 09 Apr 2016 04:52:56 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        73aba43 Add section on attaching and using USB keyboards
+
+[33mcommit ab38a53cd8fabcf3f6a3e8dbd30450c151c64573[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Apr 9 04:18:36 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_a59e8ebe
+        tagger Axon <axon@openmailbox.org> 1460168301 +0000
+    
+        Tag for commit a59e8ebe58a64756112efb6a9e00bc6e78ce66e7
+        gpg: Signature made Sat 09 Apr 2016 04:18:23 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a59e8eb Merge pull request #121 from mfc/patch-13
+        ef77e09 clean up language, added inter-doc link
+
+[33mcommit 596d02900976cfc16c995b775a27d0d3a67e00dc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Apr 9 04:15:48 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_8acbf3f5
+        tagger Axon <axon@openmailbox.org> 1460168117 +0000
+    
+        Tag for commit 8acbf3f563429303add77220e9660dcb4d95a357
+        gpg: Signature made Sat 09 Apr 2016 04:15:19 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8acbf3f Use GitHub's recommended clone URLs (HTTPS)
+
+[33mcommit 32f997a92f0f3932c876ec0b71ef51f3bb0b4e9c[m
+Merge: aafa93c 95ebb67
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Apr 6 15:38:32 2016 +0200
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit aafa93ca6177701187896b2e850f3efe3c16fece[m
+Merge: eb2af2e aee3718
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Apr 6 15:34:40 2016 +0200
+
+    Merge branch 'pajadam-master'
+
+[33mcommit aee3718093aae373ddeea55f6945a01dab5b3ce2[m
+Merge: eb2af2e 25c40c2
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Apr 6 15:33:25 2016 +0200
+
+    Merge branch 'master' of https://github.com/pajadam/qubesos.github.io into pajadam-master
+
+[33mcommit eb2af2e5bbb1582cc65206898a269650c5ca00aa[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Apr 6 15:29:47 2016 +0200
+
+    added responsive classes & margins
+    
+    QubesOS/qubes-issue#1869
+
+[33mcommit 95ebb67c86d78eb7d4e2329dad642c0f6259d5a5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Apr 6 10:34:17 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_9f28991c
+        tagger Axon <axon@openmailbox.org> 1459931607 +0000
+    
+        Tag for commit 9f28991c6e49f6aaa83b8e34cdfa9ae8da2559b9
+        gpg: Signature made Wed 06 Apr 2016 10:33:25 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9f28991 Create CONTRIBUTING file
+
+[33mcommit bca2d8e645f5a59d140a930b8ee6a463dd46bc6f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Apr 5 00:06:10 2016 +0200
+
+    Add support for signed commits
+    
+    Apparently support for it is much better in git than for signed tags.
+    For example there is really easy way for detect good but untrusted
+    signature.
+    
+    Note that rename _utils/verify-git-tag -> _utils/verify-git-ref was
+    accidently commited in previous "auto" commit.
+
+[33mcommit af7e2176df761bbbe775ffe8d920c622d7d25907[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Apr 5 00:05:14 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_ca63844f
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1459555530 +0200
+    
+        Tag for commit ca63844f942830125d00283e1b59bef5d8c25cc0
+        gpg: Signature made Sat 02 Apr 2016 02:05:30 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        ca63844 manpages update
+        6286d5f Clarify DVM custom template regneration steps
+        e00ca4a Merge pull request #120 from privacyguy/patch-2
+        1bd1d68 Update dispvm-customization.md
+
+[33mcommit 9ee711e4cbdd204fc7bcf38c2d0fd751e38a0052[m
+Merge: 1fc5afe 5967c4e
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Sun Apr 3 19:08:20 2016 +0200
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+    
+    Conflicts:
+    	_includes/footer.html
+    	pages/tour.md
+
+[33mcommit 1fc5afecf8da524cc613feced5265d60f55a6c62[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Sun Apr 3 18:23:39 2016 +0200
+
+    tweaked Tour video times & added UI feedback
+    
+    QubesOS/qubes-issues#1878
+
+[33mcommit a40d4acd11505f8f512ac37ef2da87390e2c916b[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Fri Apr 1 20:22:26 2016 +0200
+
+    first pass at adding video to Tour page
+    
+    QubesOS/qubes-issues#1878
+
+[33mcommit 41af56965cd41b370e2fe1f3a025092e3c8d5aef[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Fri Apr 1 00:54:48 2016 +0200
+
+    adjusted Heading spacing
+    
+    QubesOS/qubes-issues#1837
+
+[33mcommit 9822503df250141bc8ebc7d27118d08be7265dfd[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Mar 31 23:55:49 2016 +0200
+
+    addressed word wrapping issue & responsive menu
+    
+    QubesOS/qubes-issues#1841
+
+[33mcommit 9d6347d0026ab4d0834b7c36cee6d5219c263df0[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Mar 31 23:54:02 2016 +0200
+
+    upgraded jQuery & added Bootstrap JS
+    
+    QubesOS/qubes-issues#1841
+
+[33mcommit 25c40c2b875af118017858884803d42a181592b7[m
+Author: Adam Pajkert <pajadam@linux.pl>
+Date:   Sun Apr 3 15:11:01 2016 +0200
+
+    Fixed navbar button - border radius
+
+[33mcommit 5967c4e6a39c8979f1b3ee88263001061e7f19e8[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Apr 3 01:15:14 2016 +0000
+
+    Improve wording (fixes QubesOS/qubes-issues#1886)
+
+[33mcommit 8fc96ae86a08095a013829b49e62e5547b3fa846[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Fri Apr 1 20:22:26 2016 +0200
+
+    first pass at adding video to Tour page
+    
+    QubesOS/qubes-issues#1878
+
+[33mcommit a337476e3b020e9f1f33c87ef40aee9f30be59ee[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Fri Apr 1 00:54:48 2016 +0200
+
+    adjusted Heading spacing
+    
+    QubesOS/qubes-issues#1837
+
+[33mcommit 8a4daea3b1365f28b100b4610eacb6d29e9b1b79[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Mar 31 23:55:49 2016 +0200
+
+    addressed word wrapping issue & responsive menu
+    
+    QubesOS/qubes-issues#1841
+
+[33mcommit 8acf16bbbf2c1fbcf0ef2acd5557386c70e8aa1d[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Mar 31 23:54:02 2016 +0200
+
+    upgraded jQuery & added Bootstrap JS
+    
+    QubesOS/qubes-issues#1841
+
+[33mcommit a336e3967b31bfa363c138b66679957d9a69fdef[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Mar 31 14:24:10 2016 +0200
+
+    removed uneeded 'Mirrors' area
+
+[33mcommit 85e8bd8ee23aa30ea8824b3584bb495956be5f1e[m
+Merge: fa65055 ee215e3
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Mar 30 13:54:30 2016 +0200
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit fa6505527267676629b70fe275dac84c016da996[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Mar 30 13:51:35 2016 +0200
+
+    shortened page title 'Getting Started' to 'Get Started'
+    
+    QubesOS/qubes-issues#1841
+
+[33mcommit ee215e3d711c2f8ae8b28f4e32b6e947eac4d75e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 30 01:26:42 2016 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_7658852d
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1459293960 +0200
+    
+        Tag for commit 7658852df4ba159202a975742bace7e4fbde19eb
+        gpg: Signature made Wed 30 Mar 2016 01:26:00 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        7658852 update manpages
+
+[33mcommit 4a66139f8ffbdb43a4a55cbd27cea95971335de3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 30 01:23:15 2016 +0200
+
+    Add a tool to convert manpages
+
+[33mcommit 2635afc4283a493fa329dec6d020ca41f4948bb0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Mar 29 17:30:30 2016 +0200
+
+    autoupdate: _doc _hcl
+    
+    _doc:
+        tag axon_e536e6c1
+        tagger Axon <axon@openmailbox.org> 1458687180 +0000
+    
+        Tag for commit e536e6c1de42d61cc4b06b5a7490c2eac6a8f604
+        gpg: Signature made Tue 22 Mar 2016 11:53:01 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e536e6c Fix typo
+        7392e97 Add FAQ entry for the glossary
+        6f1df7b Add missing refrence link to glossary
+        dd3d64c Update README
+        160a5f2 Improve clarity, grammar, links, and formatting
+        1a28ef4 Add link and make existing links more explicit
+    
+    _hcl:
+        tag zrubi_82e3b9c
+        tagger Zrubi <mail@zrubi.hu> 1458738714 +0100
+    
+        New HCL entries added (20160302-20160323)
+        gpg: Signature made Wed 23 Mar 2016 02:12:03 PM CET using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        82e3b9c New HCL entries added (20160302-20160323)
+
+[33mcommit 02600334976539a5283ae757fa99cb3edf5ca296[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Mon Mar 28 02:33:36 2016 -0400
+
+    fixed typo
+
+[33mcommit 69fc49fe8c7aeb0db5d633f5c9d1788f6798b5c3[m
+Merge: eb90efa b57445d
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Mar 22 21:01:37 2016 +0000
+
+    Merge pull request #32 from mfc/patch-12
+    
+    updated download description to 3.1
+
+[33mcommit b57445dd30b64fb2740acd32058cc9549cd7abef[m
+Author: Michael Carbone <github@riseup.net>
+Date:   Mon Mar 21 13:49:24 2016 -0400
+
+    updated download description to 3.1
+
+[33mcommit eb90efaab4b994fc42630313578f29a48dda365a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 21 01:31:30 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_ec5325d5
+        tagger Axon <axon@openmailbox.org> 1458520272 +0000
+    
+        Tag for commit ec5325d5717aeb5b18a857524436143588bdbdcf
+        gpg: Signature made Mon 21 Mar 2016 01:31:13 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ec5325d Merge pull request #118 from Galland/patch-2
+        caec6c6 Merge pull request #117 from gnarea/patch-1
+        c612a8c Merge pull request #116 from jaspertron/patch-1
+        a810dfd Removing dangling Dom0 menu with its TemplateVM
+        19bb46a Fixed typo
+        577ac24 Emphasize where .qubes-dispvm-customized should go
+
+[33mcommit a8c6c6375ceecab7f483e3fe742cd9a5fdfeff27[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Mar 18 18:20:29 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_64294f6d
+        tagger Axon <axon@openmailbox.org> 1458321606 +0000
+    
+        Tag for commit 64294f6da281b7be6f555c98501f34d76cf5d689
+        gpg: Signature made Fri 18 Mar 2016 06:20:08 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        64294f6 Add HTTP Filtering Proxy guide
+
+[33mcommit 19a1cec6cc371de361929105c6c20311b5974b95[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Mar 18 18:02:27 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_d44e19a9
+        tagger Axon <axon@openmailbox.org> 1458320531 +0000
+    
+        Tag for commit d44e19a9d5f1c5edd7cdf7abb29e2f10f0eb4260
+        gpg: Signature made Fri 18 Mar 2016 06:02:12 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d44e19a Add NetBSD guide (QubesOS/qubes-issues#1202)
+
+[33mcommit c639aed1f86780e19258cb3c8efe64ca81ab6758[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Mar 18 17:48:26 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_8561b1b0
+        tagger Axon <axon@openmailbox.org> 1458319686 +0000
+    
+        Tag for commit 8561b1b01d8ec7c60cd17a4ea4d7225aa36105b2
+        gpg: Signature made Fri 18 Mar 2016 05:48:08 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8561b1b Organize Whonix pages
+
+[33mcommit 77a5bbd0ea2a0407064efa05709b0de920e14716[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 17 23:47:30 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_b16fd8f6
+        tagger Axon <axon@openmailbox.org> 1458254831 +0000
+    
+        Tag for commit b16fd8f62f04aee31e47bb3cca6074f6b7cda818
+        gpg: Signature made Thu 17 Mar 2016 11:47:11 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b16fd8f Copy pinyin input guide from ML
+
+[33mcommit 980b39c90c120ac3a4c303d70b61d244bc39a02f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 17 02:40:54 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b3d9bcea
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1458178843 +0100
+    
+        Tag for commit b3d9bceaa6206a9791a19f14cdcecb2e32fce627
+        gpg: Signature made Thu 17 Mar 2016 02:40:43 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b3d9bce Marek: Rpmfusion repo definitions are already installed. The repository is simply disabled.
+        d41b4c3 added upgrade command to get repo metadata
+        dc336f5 update wrong RPMFusion repo enabling commands
+
+[33mcommit a0a46c13a055943abee7150896c8305e39845104[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 16 12:12:22 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_6fd7f348
+        tagger Axon <axon@openmailbox.org> 1458126721 +0000
+    
+        Tag for commit 6fd7f348b051d52d0677667397d30f6131406901
+        gpg: Signature made Wed 16 Mar 2016 12:12:02 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6fd7f34 Create empty Lenovo W540 installation guide
+
+[33mcommit cc7f8d271a8b755894a2be9947649aefecf5a66c[m
+Merge: d216ebc fe08677
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Tue Mar 15 19:39:35 2016 +0100
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit d216ebc4a15dc7531632e74da0cd5097ac06d3a5[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Tue Mar 15 19:38:33 2016 +0100
+
+    re-added <hr> to Downloads page
+    fixed unclosed <strong> tag on homepage
+    
+    QubesOS/qubes-issues#1837
+
+[33mcommit fe08677285775941c093c6e9b14e57e755052484[m
+Merge: b876f69 8b0fdcc
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Mar 15 18:11:45 2016 +0000
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit b876f695d2f03aa30f245c857d30ef8349398a69[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Mar 15 18:09:59 2016 +0000
+
+    Revert "Fix heading spacing"
+    
+    This reverts commit 3bb63362c0bf16d7c5fd28957027d2bde19cfe33.
+    
+    Made non-front pages look better but broke the front page.
+
+[33mcommit 8b0fdcc09f7e81a902705268b1be68c610f6b303[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Mar 15 13:05:38 2016 +0100
+
+    Temporary disable one of HTTPS downloads
+
+[33mcommit 9c026f20a101f3b5b2b094e59f05363ceb71dfe9[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Mar 15 11:16:49 2016 +0000
+
+    Update heading to "Installing & Upgrading Qubes"
+
+[33mcommit 69ef9e16c8528de2a924a773c08ecf6ee4ebf7c4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Mar 15 12:16:21 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_6c855f88
+        tagger Axon <axon@openmailbox.org> 1458040567 +0000
+    
+        Tag for commit 6c855f881027e0132e6d26d4ab2b611701613baa
+        gpg: Signature made Tue 15 Mar 2016 12:16:06 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6c855f8 Clean up and organize doc files
+
+[33mcommit 3bb63362c0bf16d7c5fd28957027d2bde19cfe33[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Mar 15 10:36:48 2016 +0000
+
+    Fix heading spacing
+    
+    Makes it so that each paragraph heading is closer to its own paragraph
+    than to the previous paragraph.
+
+[33mcommit 7a240f9a20fcc695176fad6c7c12db5521fc6413[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Mar 15 08:17:05 2016 +0000
+
+    Update mailing-lists.md metadata
+
+[33mcommit 3e25f65ae9f4e0c7a463213be5c7cc7e2d19ace4[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Mar 15 07:46:27 2016 +0000
+
+    Move mailing-lists.md from submodule; update content
+
+[33mcommit 153fcdeed64f3d92b5e6639659c56687fe8103e3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Mar 15 08:46:10 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_3506ceb7
+        tagger Axon <axon@openmailbox.org> 1458027953 +0000
+    
+        Tag for commit 3506ceb78ec79fc95de72cd3a0039c2eb43b40ac
+        gpg: Signature made Tue 15 Mar 2016 08:45:53 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3506ceb Move mailing-lists.md to main repo
+
+[33mcommit 5c005a3ba353e1d4cd761af9a17de99237b3a4c9[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Mar 15 07:08:17 2016 +0000
+
+    Add Joanna's research paper; generalize section title
+
+[33mcommit 29096c3c4bf3ee39bd922a9b8156896fddbc72e6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Mar 15 08:07:07 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_dad29f4a
+        tagger Axon <axon@openmailbox.org> 1458025604 +0000
+    
+        Tag for commit dad29f4a0105405f8305b3034e92ab03c9387344
+        gpg: Signature made Tue 15 Mar 2016 08:06:44 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        dad29f4 Move links to external resources to more appropriate places
+
+[33mcommit 552e4af12498da9b3c40d5422a5f905e5382a24f[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Mar 14 18:31:09 2016 +0000
+
+    Add release category and assign existing releases
+    
+    R2 and R3.0 are old but still supported. This commit correctly reports
+    that information by creating a new release category: "aging". "Aging"
+    means that a release is old, but still supported, while "deprecated"
+    means that a release is old and no longer supported.
+
+[33mcommit a3a20fb9956c82ff29999236ed7becf5609cf486[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Mar 14 17:54:00 2016 +0000
+
+    Improve user-facing headings
+    
+    * Use action-oriented language
+    
+      "Download", then "Verify".
+    
+      Generally, users will not want to download the same ISO twice from
+      different mirrors. Therefore, rather than putting the focus on these
+      as a menu of options ("Downloads"), we should put the focus on the
+      action the user is trying to perform ("Download").
+    
+      Changing "Verifiers" to "Verify".
+    
+      Likewise, we want users to understand that *they* are the ones who
+      have to verify that the ISO they downloaded is authentic. Less
+      technical users might misinterpret "Verifiers" to mean that these
+      are files which automagically verify that all is well without any
+      user attention required. They may not realize, for example, that an
+      attacker could substitute a malicious version of such a file which is
+      designed to report falsely that all is well.
+    
+    * Add a question mark icon next to the heading linking to the Verifying
+      Signatures page with appropriate title text.
+    
+      Users are likely to be familiar with the classic question-circle icon
+      from around the Web. We want to give them as many opportunities as
+      possible to learn about the importance of verifying the authenticity
+      and integrity of their download and how to do it.
+
+[33mcommit 1064a349debc298750c2dfe16a45567ba884b505[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Mar 14 17:37:09 2016 +0000
+
+    Remove leftover <hr>
+    
+    This <hr> was separating the downloads from the mirrors section. Now
+    that the mirrors section is gone, it's no longer needed.
+
+[33mcommit 8e289597cb5e59cea5637c5b4aab5275ed13df41[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Mar 14 17:33:41 2016 +0000
+
+    Remove redundant link to mirrors.kernel.org
+    
+    We already have at least twelve links to mirrors.kernel.org on this
+    page, and all of them are more useful to users since they lead
+    directly to files which users may actually want. The generic link is
+    more likely to confuse users than to be helpful to them.
+
+[33mcommit 2da91184b22d6f0df6337ea0beff056f8f8d994b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 14 18:28:10 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_f4d3aace
+        tagger Axon <axon@openmailbox.org> 1457976470 +0000
+    
+        Tag for commit f4d3aace48aaf028d95f3bf840f4fc52651ef54a
+        gpg: Signature made Mon 14 Mar 2016 06:27:52 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f4d3aac Merge pull request #113 from bnvk/master
+        7097a1b Merge branch 'master' of https://github.com/QubesOS/qubes-doc
+        f0a56a7 some improvements and additional items to Usability doc
+        3cd3b4e first pass of Style Guide first pass at Usability & UX guide
+
+[33mcommit 88699a36a4fd23a32f0f9dda9a526778f1eb7b46[m
+Merge: 29e0a19 04760cc
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 14 17:11:36 2016 +0100
+
+    Merge remote-tracking branch 'origin/pr/30' into new-downloads
+    
+    * origin/pr/30:
+      added "boxless" layout refactored & pretified "Downloads" page
+      Added SCSS file for Docs specific styling Improved <code> styling Added SCSS varirables for more Qubes colors Created YML data file for Style Guide
+      Reformat and realign everything in the page to make better use of the space we have there
+      Exclude the featured release from the list of older things
+      Burnbit link eliminated since we discovered ISOs on Burnbit are tampered with
+      better verbing of the "other choices" option
+      be more explicit about what the steps mean
+      no need for redundant warning icon
+      Booleans bit me again.
+      Make the Qubes OS downloads page fully data driven and beautiful
+      added better responsive grid support to a few pages
+
+[33mcommit 29e0a19a72cae2ebc3dce392203344064726ee78[m
+Merge: 5327173 2604fcb
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 14 16:47:31 2016 +0100
+
+    Merge remote-tracking branch 'origin/pr/29' into new-downloads
+    
+    * origin/pr/29:
+      Make the Qubes OS downloads page fully data driven and beautiful
+
+[33mcommit 04760cc0dd289f6c95c6e018729cb8f51834913e[m
+Merge: d15a56a 5327173
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Mar 14 16:32:22 2016 +0100
+
+    fixing merge conflict
+
+[33mcommit d15a56a686bd71729becf80a5d005b4f17a8e543[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Mar 14 16:11:13 2016 +0100
+
+    added "boxless" layout
+    refactored & pretified "Downloads" page
+
+[33mcommit 5327173da29f66def48e9f64e6db9214d1214a83[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 14 14:51:59 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_4330379b
+        tagger Axon <axon@openmailbox.org> 1457963492 +0000
+    
+        Tag for commit 4330379b70c1b1b81a8ef818bcd62a762c666627
+        gpg: Signature made Mon 14 Mar 2016 02:51:34 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4330379 Update users' FAQ
+        3b9540f Update Documentation Guidelines
+        8c9ca6e Create "Style Guidelines" section; link to glossary
+
+[33mcommit 7dc4cf8e97904ab4dc608bc9717c217a064c6a0c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 14 14:17:08 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_9c65c440
+        tagger Axon <axon@openmailbox.org> 1457961412 +0000
+    
+        Tag for commit 9c65c440c81063abb850cbdc67c513a19b31099c
+        gpg: Signature made Mon 14 Mar 2016 02:16:53 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9c65c44 Convert entries to headings
+
+[33mcommit 6689c5e23e5835c1a70a9aeb40406ac7d5751973[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 14 14:11:31 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_75c03e05
+        tagger Axon <axon@openmailbox.org> 1457961076 +0000
+    
+        Tag for commit 75c03e058e67da8cb0be9b1c105bdca83696b1a3
+        gpg: Signature made Mon 14 Mar 2016 02:11:17 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        75c03e0 Update Glossary
+
+[33mcommit 87240eb97c1682781a70f635702a4bf46550e4ba[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Mar 14 09:42:48 2016 +0000
+
+    Add information section to HCL page
+
+[33mcommit 4121eb2ac13facbe91eb05b0373fdc412e664de1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 14 10:25:26 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_224d4adb
+        tagger Axon <axon@openmailbox.org> 1457947513 +0000
+    
+        Tag for commit 224d4adb25fdf3d2b8955bdb2de39adaad6b58f3
+        gpg: Signature made Mon 14 Mar 2016 10:25:14 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        224d4ad Clean up and update Certified Laptops page
+        c134747 Clean up and update System Requirements page
+
+[33mcommit e64faae0a8e1e96847c737d317b26e23c37c3c79[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 14 09:57:28 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_ba14ef3f
+        tagger Axon <axon@openmailbox.org> 1457945834 +0000
+    
+        Tag for commit ba14ef3f10dbb5c0c946086f69fdcded965ed3bc
+        gpg: Signature made Mon 14 Mar 2016 09:57:15 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ba14ef3 Update Supported Versions for R3.1
+        44bcd71 Update backup-restore
+        c489f1d Rewrap some lines
+        c5673a5 Remove extra space
+
+[33mcommit 112d9ddafe70a04ab4bc791bfc5d344c3551c2f6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Mar 14 09:09:54 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_9d02126d
+        tagger Axon <axon@openmailbox.org> 1457942972 +0000
+    
+        Tag for commit 9d02126d03e5b86dae44355da8f4b5f5080b5ddb
+        gpg: Signature made Mon 14 Mar 2016 09:09:34 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9d02126 Clean up and update Split-GPG page
+        5d1bdae Remove deprecated open-pgp page; redirect to split-gpg
+
+[33mcommit 2604fcbba840d00301dfc4f6e7cc327a9f049444[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 18:14:58 2016 +0000
+
+    Make the Qubes OS downloads page fully data driven and beautiful
+
+[33mcommit f747a55835bc08515e0b1f03882efd56633b1964[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Mar 11 21:19:29 2016 +0100
+
+    Enable kernel.org mirror for R3.1
+
+[33mcommit 278d81d16d70ce6d67c460cee15f61eea8a41f9f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 10 21:59:30 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_93633b51
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1457643555 +0100
+    
+        Tag for commit 93633b5174c15767ebeec38070526f3e18b44648
+        gpg: Signature made Thu 10 Mar 2016 09:59:16 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        93633b5 typo fix
+
+[33mcommit 7ba2f0f31eb5c427be8dc0006419803b0a7495ca[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 10 08:09:06 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_cdf9fe24
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1457593733 +0100
+    
+        Tag for commit cdf9fe241a96078b5aed3eea4491a7aaa40359f9
+        gpg: Signature made Thu 10 Mar 2016 08:08:53 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        cdf9fe2 Redirect from original /news/2016/03/09/qubes-31/ link
+
+[33mcommit 49ac4cb013291419fc9a46e0093b1e6ca37ddf94[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 10 02:37:33 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag axon_6183f7bf
+        tagger Axon <axon@openmailbox.org> 1457573841 +0000
+    
+        Tag for commit 6183f7bf6b7a4e1d210529c013c71ffbd6c66034
+        gpg: Signature made Thu 10 Mar 2016 02:37:21 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6183f7b Make announcement file naming consistent
+        b7aa1cf Minor copy editing
+
+[33mcommit 19c78d03a2197406087acd7b81bbde2d8291be15[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 10 02:09:51 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_386fc203
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1457572180 +0100
+    
+        Tag for commit 386fc203b9ad1f0771e0523fd608bd7e578c20d9
+        gpg: Signature made Thu 10 Mar 2016 02:09:40 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        386fc20 Remove testing-repository requirement from 3.0->3.1 upgrade guide
+
+[33mcommit 2d5ce293ef952cf40300459d8d2a56dc36365eba[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 10 01:30:08 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_305ffd0d
+        tagger Axon <axon@openmailbox.org> 1457569791 +0000
+    
+        Tag for commit 305ffd0d3c33ba29d71a284cc60e6b06dd098aae
+        gpg: Signature made Thu 10 Mar 2016 01:29:51 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        305ffd0 Update Installation Security Considerations
+
+[33mcommit 93ebd8f20791127dec541fe3c943bb5b01bb86c8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 10 01:25:31 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_f08f5904
+        tagger Axon <axon@openmailbox.org> 1457569501 +0000
+    
+        Tag for commit f08f590459f490dc5e5af057381610992af1b7b1
+        gpg: Signature made Thu 10 Mar 2016 01:25:01 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f08f590 Clean up and update installation guide
+
+[33mcommit 7edc5fb2dfe515af570c442e1245079382f562ff[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Mar 9 23:43:28 2016 +0000
+
+    Create custom 404 page
+    
+    Having a custom 404 page (rather than using the GitHub pages default)
+    is more user friendly for many reasons, but mainly because it preserves
+    our top navigation bar, so users have a better chance of finding what
+    they're looking for. It also allows us to encourage users to report
+    things like broken links, so that they are more likely to get fixed.
+
+[33mcommit 0a18cb6eff1d1285f8b0524fe956f9eeef79cfed[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Mar 9 23:24:07 2016 +0000
+
+    Update link to source code
+    
+    There's no point in having a page on our website about the source code
+    if we don't link to it, so we should either consistently link to it
+    (whenever linking to "Qubes OS source code") or simply remove the page.
+    I would argue that we should keep the page (and consistently link to it)
+    rather than linking directly to GitHub since Qubes OS source code is
+    independent of GitHub. (For example, we could one day decide to switch
+    from GitHub to a different Git hosting service.)
+
+[33mcommit fceb4a12401060a3720d957262679a6c819c3cb0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 9 21:46:22 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_49d29315
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1457556371 +0100
+    
+        Tag for commit 49d29315f50e6e03e94ae8c04e9ded4b3c9cd403
+        gpg: Signature made Wed 09 Mar 2016 09:46:12 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        49d2931 Qubes 3.1 post: minor typos/grammar corrections
+
+[33mcommit 8bcad564c5649a2024a28bbc9c1eb8a9116047cc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 9 21:33:11 2016 +0100
+
+    Move Live USB download down on the page
+
+[33mcommit 34c9669f34435c285a939c5d612bce1456cff971[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 9 21:32:43 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_6dc6c621
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1457555548 +0100
+    
+        Tag for commit 6dc6c621b56f11bd09d05f2e563725cf7ece0c35
+        gpg: Signature made Wed 09 Mar 2016 09:32:31 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        6dc6c62 add tags to Qubes 3.1 release annoucement
+
+[33mcommit 9e9570164f2ef2bc0ca147101f119f265c69003a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 9 21:30:36 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_eaab6f0c
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1457555419 +0100
+    
+        Tag for commit eaab6f0c9b531152d9005d751497352a3c0df72b
+        gpg: Signature made Wed 09 Mar 2016 09:30:20 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        eaab6f0 Qubes 3.1 release announcement
+
+[33mcommit 584760351c3f4221dfe4d91ee275e438d63ca66a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 9 21:28:08 2016 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        tag mm_1e2c30ab
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1457555274 +0100
+    
+        Tag for commit 1e2c30abbce8a4022d00f1beb28bcfb1e917811b
+        gpg: Signature made Wed 09 Mar 2016 09:27:55 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        1e2c30a add Qubes 3.1 firstboot screenshot
+
+[33mcommit 4dc70f5d0ea828916e88f9f1642dd9d14bfff762[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 9 21:19:07 2016 +0100
+
+    Add final Qubes 3.1 download links
+
+[33mcommit b766d2d99a5fd812d1e3f8f01c97c7fd58057997[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Mar 9 19:46:10 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_509ab602
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1457549131 +0100
+    
+        Tag for commit 509ab60255cd88baeaaf8cfc2e5e299560d7413c
+        gpg: Signature made Wed 09 Mar 2016 07:45:31 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        509ab60 Remove experimental notice from 3.0->3.1 upgrade instruction
+
+[33mcommit 73989bc66696d0db4b556299b71f3f554c4ac4bd[m
+Merge: cca337b 3068ec9
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Mar 9 14:10:20 2016 +0100
+
+    Merge branch 'improvelooks2' of https://github.com/Rudd-O/qubesos.github.io
+
+[33mcommit 6b95622cca2779fc30ab5d424ac9cfb40d040358[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Mar 8 23:27:30 2016 +0000
+
+    Fix code block horizontal scrolling
+    
+    Previously, every code block had a space below it for a horizontal
+    scroll bar, yet no horizontal scroll bars were ever created. Code
+    blocks would never scroll horizontally and would instead wrap lines.
+    This commit fixes that. Now, a space for a horizontal scroll bar will
+    exist only when there is actually a horizontal scroll bar present to
+    fill it, and every code block which is long enough (horizontally) to
+    require scrolling will in fact scroll horizontally.
+
+[33mcommit cca337b5ebb807417b5765cc9688c8346b263926[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Tue Mar 8 23:48:21 2016 +0100
+
+    Added SCSS file for Docs specific styling
+    Improved <code> styling
+    Added SCSS varirables for more Qubes colors
+    Created YML data file for Style Guide
+    
+    QubesOS/qubes-issues#1755
+
+[33mcommit fba9930d395321f0625d2d358b5759c86b5fc671[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Mar 8 22:59:21 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_06b3f7af
+        tagger Axon <axon@openmailbox.org> 1457474328 +0000
+    
+        Tag for commit 06b3f7af831d48d07f8b3c64068b57813a819eaf
+        gpg: Signature made Tue 08 Mar 2016 10:58:49 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        06b3f7a Add code-signing.md to ToC and sort entries
+        8d7e3cd Create code-signing.md
+        60ad631 Update content and clean up formatting
+
+[33mcommit 3068ec90790e29b795752d99249a80af0c50dc6e[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Sun Mar 6 21:56:31 2016 +0000
+
+    Reformat and realign everything in the page to make better use of the space we have there
+
+[33mcommit 3233372e62206c5d15db91f7040741882b89bfb6[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Sun Mar 6 21:56:11 2016 +0000
+
+    Exclude the featured release from the list of older things
+
+[33mcommit 4f42b04a7b8bd748cb11b336ecf5ce274c5b3d34[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Mar 6 00:14:02 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_3099d714
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1457219629 +0100
+    
+        Tag for commit 3099d7149f7b4b6266e6b7d25cbc31d79407f6f4
+        gpg: Signature made Sun 06 Mar 2016 12:13:49 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        3099d71 Add disclaimer to certified laptops page
+        f4436af Add UEFI troubleshooting guide
+        6233a33 Fix "archlinux: add spaces around '###' markers"
+
+[33mcommit df6d3664acb870da022a6e4ca63e64e18cf7deb5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Mar 4 10:40:20 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_e3dc58fd
+        tagger Axon <axon@openmailbox.org> 1457084383 +0000
+    
+        Tag for commit e3dc58fd33383e0c1f861ab98c032e8f6beed2db
+        gpg: Signature made Fri 04 Mar 2016 10:39:45 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e3dc58f Merge pull request #112 from hdevalence/master
+        af89a57 Clarify that resizing root.img requires shutting down AppVMs
+
+[33mcommit c3064b795147cad19b6a68b20372f158503243af[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Mar 3 10:28:13 2016 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag zrubi_671231a
+        tagger Zrubi <mail@zrubi.hu> 1456997241 +0100
+    
+        New HCL entries added (20160219-20160302)
+        gpg: Signature made Thu 03 Mar 2016 10:27:26 AM CET using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        671231a New HCL entries added (20160219-20160302)
+
+[33mcommit 20b008ffc6121e707bb23837b65e2c47cbf60678[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Sat Feb 27 19:53:10 2016 +0000
+
+    Burnbit link eliminated since we discovered ISOs on Burnbit are tampered with
+
+[33mcommit a937f45e49cb11ddaee5503dcaaaae4cdfd817dd[m
+Merge: 3c3733f 0138ff3
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Fri Feb 26 15:13:27 2016 +0100
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+    
+    Conflicts:
+    	pages/hcl.html
+    	pages/help.md
+
+[33mcommit 0138ff36047dee17a79265980640beddb41c97bc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 26 14:41:37 2016 +0100
+
+    Enable mirrors.kernel.org for R3.1-rc3
+
+[33mcommit d25c7124d9f2f04deda28b654e98f081e5ec2a01[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 26 06:35:28 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_d13ca72f
+        tagger Axon <axon@openmailbox.org> 1456464877 +0000
+    
+        Tag for commit d13ca72fb92808d48fc73917b90e9ec994e88ae5
+        gpg: Signature made Fri 26 Feb 2016 06:34:38 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d13ca72 Fix typos
+
+[33mcommit 16e2a0cf605cd39791b54e2126fe222f6f864a70[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 26 06:30:38 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_419137c3
+        tagger Axon <axon@openmailbox.org> 1456464094 +0000
+    
+        Tag for commit 419137c3a5b53016e1a8ede8c1b6f8c328ad9ed7
+        gpg: Signature made Fri 26 Feb 2016 06:21:35 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        419137c Updating dom0 does not update templates
+
+[33mcommit 2e4eeb620850a3455fa04c838764d14a096d0d9b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 26 04:11:10 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_eb410547
+        tagger Axon <axon@openmailbox.org> 1456456244 +0000
+    
+        Tag for commit eb4105476f83566fde97a8faf02e4cad880e351e
+        gpg: Signature made Fri 26 Feb 2016 04:10:46 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        eb41054 Merge pull request #111 from youknow0/patch-2
+        37cac07 Fix link to disposable VM doc
+
+[33mcommit b25e138d56fd646ab52a5702c7b967d87bc6a71d[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Thu Feb 25 01:25:04 2016 +0000
+
+    better verbing of the "other choices" option
+
+[33mcommit b6d330851578e5641575c01463cd4e028c219aaa[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 20:49:15 2016 +0000
+
+    be more explicit about what the steps mean
+
+[33mcommit 815fc940dfdb21511a0492fc17e22fadbfe69d4a[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 20:47:43 2016 +0000
+
+    no need for redundant warning icon
+
+[33mcommit 55d07bb32ec48afb68cdb69cb164298fe221bcc1[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 20:47:08 2016 +0000
+
+    Booleans bit me again.
+
+[33mcommit 1bd98023b2ebf78b3a960305fb12967dd25c58d1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 24 21:08:18 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_f47bfc67
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1456344478 +0100
+    
+        Tag for commit f47bfc67353074ff3ff17ed85a7473e85b24622c
+        gpg: Signature made Wed 24 Feb 2016 09:07:59 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        f47bfc6 fix link in R3.1rc3 announcement
+
+[33mcommit 71867c689d331b286298b7e160af02ff7e6f6132[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 18:14:58 2016 +0000
+
+    Make the Qubes OS downloads page fully data driven and beautiful
+
+[33mcommit bd870ab02147170fd0ce9e5ee85f00187f4622e8[m
+Merge: 1aaa21e 9ae80b5
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 24 17:42:29 2016 +0100
+
+    Merge remote-tracking branch 'origin/pr/25'
+    
+    * origin/pr/25:
+      verifiers are made to look nice instead of using brackets as simulations of buttons
+      distinguish between methods to obtain a file
+      Verifiers carry a warning sign
+      hand meaning featured
+      Reincorporate the verifiers
+      ingest qubes release 3.0 into the same data format
+      fix the featured problem
+      Add release name as rendered tag
+      Revert "Include plain CSS non-SASS styling file"
+      Move download data into a data file.
+      Include plain CSS non-SASS styling file
+
+[33mcommit 1aaa21e8e8e1f49a6f931e8810165109bae67b38[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 24 02:31:59 2016 +0100
+
+    Update download links to R3.1 rc3
+    
+    As usual, wait with mirrors.kernel.org to pull new image.
+
+[33mcommit 55cd56e20fda833bf721f85d7e97c6d723cb24e0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 24 02:31:01 2016 +0100
+
+    Add warning about outdated Live images.
+
+[33mcommit 2d9522dd39a3b8ba4d229fffa20f6d3130a4ffef[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 24 17:29:03 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_6db9e336
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1456331311 +0100
+    
+        Tag for commit 6db9e336ac771e6004e2a8dc4a7127c2a447d982
+        gpg: Signature made Wed 24 Feb 2016 05:28:37 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        6db9e33 R3.1-rc3 release
+
+[33mcommit 9ae80b5bdd63c687748e7cbfdd9d6a8fb9d9ddbf[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 14:00:58 2016 +0000
+
+    verifiers are made to look nice instead of using brackets as simulations of buttons
+
+[33mcommit e88742da304fe366fb38bd40abd3e12875c218ed[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 13:53:35 2016 +0000
+
+    distinguish between methods to obtain a file
+
+[33mcommit 59f19154c2bfa8c46c3e7b29e92bef8b2d2c9c73[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 13:53:23 2016 +0000
+
+    Verifiers carry a warning sign
+
+[33mcommit 0038bbdf4691bd347b9d7664cf0fa71b927ff43f[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 13:48:32 2016 +0000
+
+    hand meaning featured
+
+[33mcommit c25f89761cecb63cadb44fba49737cbd8d2163f1[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 13:43:31 2016 +0000
+
+    Reincorporate the verifiers
+
+[33mcommit eb1bed0404c758cb2c124af486becda73e9e40df[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 13:41:41 2016 +0000
+
+    ingest qubes release 3.0 into the same data format
+
+[33mcommit d0c831e1c5034340437349ce62ae5c7cb0ea9698[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 13:38:47 2016 +0000
+
+    fix the featured problem
+
+[33mcommit 31885a643e632578f746c441eb4476c7353c7136[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 13:21:18 2016 +0000
+
+    Add release name as rendered tag
+
+[33mcommit f61b67a6414e89d9d50a153890924cb087b798a7[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 13:19:36 2016 +0000
+
+    Revert "Include plain CSS non-SASS styling file"
+    
+    This reverts commit 0247a8da5dfd0cfeb692a41e97e56d521be95843.
+
+[33mcommit b491e5e81a434eee0e8de69eb7a483f58a28ea31[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Feb 24 13:19:27 2016 +0000
+
+    Move download data into a data file.
+
+[33mcommit 8ae728740b4fb6605ed249f74727bb3ec022d72a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Feb 22 23:44:59 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_391df3f0
+        tagger Axon <axon@openmailbox.org> 1456181077 +0000
+    
+        Tag for commit 391df3f01aa3f99497b5a58ba835bb06d8d335b5
+        gpg: Signature made Mon 22 Feb 2016 11:44:38 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        391df3f Use yum directly to remove a package in dom0
+        3431bbb Merge pull request #105 from antitree/patch-1
+        1bb7fed Suggestion to show how to uninstall a package
+
+[33mcommit 99c83bb21a5c37464de610c71bcaddd5c57ec9c0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Feb 22 23:32:00 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_73f38cb6
+        tagger Axon <axon@openmailbox.org> 1456180297 +0000
+    
+        Tag for commit 73f38cb6513707a9cdc23dc85a4081eae0a302aa
+        gpg: Signature made Mon 22 Feb 2016 11:31:38 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        73f38cb Merge pull request #109 from wllm-rbnt/typos
+        7347b38 fix typos
+
+[33mcommit 77ca3a224e25f6a3bd6ea29f1e6b9a0e51e0a43d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 21 22:55:50 2016 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag mm_87ee383a
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1456091737 +0100
+    
+        Tag for commit 87ee383a3a4b5af45b813fd8a32d58bdc12794b4
+        gpg: Signature made Sun 21 Feb 2016 10:55:37 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        87ee383 Fix formatting of ASRock-B85M_Pro4-20160201-220556.yml
+
+[33mcommit 87d3311c13de5dc85e22ea4c4996694b92dfb6d6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 19 17:32:50 2016 +0100
+
+    HCL: support device type 'notebook'
+    
+    (cherry picked from commit 715c66317d96c997a2dd92e72039ce525a98afbb)
+
+[33mcommit 380292135320ecb790f1f1f58613fd35df280e02[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sat Feb 20 22:18:51 2016 +0000
+
+    Use shorter terms to avoid wrapping in narrow columns
+
+[33mcommit 9a8501cae0ee76965553d0187a3755a9d1c4de0f[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sat Feb 20 22:16:07 2016 +0000
+
+    Update general doc link to Troubleshooting guides
+
+[33mcommit 041f5faa6c4720abc147984cd753f6ee14c0b1ad[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sat Feb 20 22:09:59 2016 +0000
+
+    Make the docs more visible and accessible
+    
+    (QubesOS/qubes-issues#1714)
+
+[33mcommit 9071dde926091f571a6038935a37c3fbf183886f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Feb 20 23:09:33 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_61ced3aa
+        tagger Axon <axon@openmailbox.org> 1456006152 +0000
+    
+        Tag for commit 61ced3aa60baf95b404343f26147f638ff4111f0
+        gpg: Signature made Sat 20 Feb 2016 11:09:13 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        61ced3a Make using and contributing to the docs more accessible
+
+[33mcommit f0ef93781b4307adf023e8da67897ef89b6ed68f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Feb 20 22:38:06 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_6a71ab6b
+        tagger Axon <axon@openmailbox.org> 1456004265 +0000
+    
+        Tag for commit 6a71ab6b485b4e8a7eb3860b4030b7a87a1fb053
+        gpg: Signature made Sat 20 Feb 2016 10:37:46 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6a71ab6 Update link
+
+[33mcommit e612d9262428526e36c60e34b49ac1133349b1ce[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sat Feb 20 21:31:58 2016 +0000
+
+    Revert to HCL nomenclature
+
+[33mcommit f99d6efcde47c37e1b80facb23289b87baeba2b6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Feb 20 22:22:56 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_73a54685
+        tagger Axon <axon@openmailbox.org> 1456003354 +0000
+    
+        Tag for commit 73a546854ad357a650da99060b5c0847f46d239d
+        gpg: Signature made Sat 20 Feb 2016 10:22:35 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        73a5468 Clean up and organize privacy pages
+
+[33mcommit b38c566945eb8816ed8e304f637280c864e3e641[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Feb 20 20:45:49 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_d27949b5
+        tagger Axon <axon@openmailbox.org> 1455997525 +0000
+    
+        Tag for commit d27949b5b48da3cf55c1d677d2355f4132236cd4
+        gpg: Signature made Sat 20 Feb 2016 08:45:27 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d27949b Add redirect from `/doc/vpn/` (fixes QubesOS/qubes-issues#1765)
+
+[33mcommit 9b3151c6516ce8b84fbab41888c2dfa6328e65fe[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 19 20:44:17 2016 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag zrubi_dbd7923
+        tagger Zrubi <mail@zrubi.hu> 1455911006 +0100
+    
+        New HCL entry added
+        gpg: Signature made Fri 19 Feb 2016 08:43:48 PM CET using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        dbd7923 New HCL entry: Lenovo T450 - added
+
+[33mcommit cf3fe538fb2571a110d6c0f14545cc760827259d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 19 18:21:26 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_e909fe2c
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1455902472 +0100
+    
+        Tag for commit e909fe2c0f1f46b55a4c0d0a1eef00f797343256
+        gpg: Signature made Fri 19 Feb 2016 06:21:12 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        e909fe2 archlinux: add spaces around '###' markers
+        bd674bc Merge remote-tracking branch 'origin/pr/102'
+        a8cabf6 Fix issues
+        8be506c Fix issues
+        4442261 fix formating and image linking
+        f14b5dd Add full instructions for Archlnux Template build
+
+[33mcommit 87fa6f94e54128f4bc4ce180411a3ee7434409a1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 19 18:03:47 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag zrubi_de5ae51
+        tagger Zrubi <mail@zrubi.hu> 1455901371 +0100
+    
+        HCL output (.txt -> .yml) correction
+        gpg: Signature made Fri 19 Feb 2016 06:03:15 PM CET using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        de5ae51 HCL output (.txt -> .yml) correction
+
+[33mcommit 6345fa143347c6e947e4bba4b98a9a29492dd6f0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 19 17:42:21 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_45cbd006
+        tagger Axon <axon@openmailbox.org> 1455900117 +0000
+    
+        Tag for commit 45cbd006fcac4dd7178bf8e34b0f3d697b6709a4
+        gpg: Signature made Fri 19 Feb 2016 05:41:58 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        45cbd00 Merge branch 'TimFW-patch-1'
+        bebad1a Minor formatting fixes
+        099d991 Fix issues
+        badc99c Fix issues
+        de65095 fix formating and image linking
+        412b5f9 Add full instructions for Archlnux Template build
+
+[33mcommit 715c66317d96c997a2dd92e72039ce525a98afbb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 19 17:32:50 2016 +0100
+
+    HCL: support device type 'notebook'
+
+[33mcommit 8648184e3683e3ad134a80f1d3fbd42cce0d9193[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 19 17:11:31 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_f565895b
+        tagger Axon <axon@openmailbox.org> 1455898242 +0000
+    
+        Tag for commit f565895b026b956127938098d5988aa340fcb23f
+        gpg: Signature made Fri 19 Feb 2016 05:10:43 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f565895 Fix typo and line wrapping
+        12234ca Merge pull request #108 from mfc/patch-12
+        4bf6712 fixed link to Whonix, called torvm depreciated
+
+[33mcommit fe2792ac161e9209272ee89c78942614d506e1dd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 19 16:07:51 2016 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag zrubi_3b50d03
+        tagger Zrubi <mail@zrubi.hu> 1455894406 +0100
+    
+        OLD HCL reports added (20150826-20160101)
+        gpg: Signature made Fri 19 Feb 2016 04:07:21 PM CET using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        3b50d03 New HCL entries added (20150826-20160101)
+
+[33mcommit 9d6a7ca7ec38801af3041e850d64a564c21770f3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 19 14:41:21 2016 +0100
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag zrubi_50c71ec
+        tagger Zrubi <mail@zrubi.hu> 1455889176 +0100
+    
+        New HCL entries added (20160101-20160219)
+        gpg: Signature made Fri 19 Feb 2016 02:40:11 PM CET using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        50c71ec New HCL entries added (20160101-20160219)
+
+[33mcommit 5ea94189ba9228e59a1157ad13a4532fa450bd1c[m
+Author: Wojtek Porczyk <woju@invisiblethingslab.com>
+Date:   Thu Feb 18 17:03:02 2016 +0100
+
+    Change counter URI to https
+
+[33mcommit fba195ce5b412c99ffdb879d6b9eaea057b64d04[m
+Author: Axon <axon@openmailbox.org>
+Date:   Thu Feb 18 16:08:32 2016 +0000
+
+    Correct 'otfc' -> 'oftc'; use port 6697 for SSL
+
+[33mcommit 76411e7ae8483f8502b2e8946c85cc78cea57fc5[m
+Merge: dee6410 d3b721b
+Author: Axon <axon@openmailbox.org>
+Date:   Thu Feb 18 16:01:45 2016 +0000
+
+    Merge pull request #28 from mfc/patch-12
+    
+    changed unofficial IRC channel to OTFC
+
+[33mcommit dee64105de0e2fdbe2ce4e6818e2be3c1da9f72d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Feb 18 16:35:16 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_cce0722e
+        tagger Axon <axon@openmailbox.org> 1455809690 +0000
+    
+        Tag for commit cce0722e8e49031611c4d24c88f14520639d7671
+        gpg: Signature made Thu 18 Feb 2016 04:34:52 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        cce0722 Merge pull request #106 from mfc/patch-11
+        2964bae Merge pull request #107 from youknow0/patch-1
+        40c1864 Fix link to disposable VM customization
+        d2a97d2 dnf -> yum
+
+[33mcommit d3b721bf0f7c9831da3531d760383b521fe9f573[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Thu Feb 18 05:00:27 2016 -0500
+
+    changed unofficial IRC channel to OTFC
+    
+    because freenode blocks tor connections, which are default on Qubes.
+    
+    see: https://github.com/QubesOS/qubes-issues/issues/1571
+
+[33mcommit 3c3733f6f2acbb6739a6f8de43c9194d24bd0081[m
+Merge: 35a055b 23ff730
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Feb 18 00:16:57 2016 +0100
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit 35a055b7389abac8ce486eefe21eb8c8dc129a6d[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Feb 18 00:12:12 2016 +0100
+
+    added better responsive grid support to a few pages
+    
+    QubesOS/qubes-issues#1460
+
+[33mcommit 23ff730e31312e6643f2fe69d108b4cbc658706b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 17 21:30:42 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b49c2ee6
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1455741019 +0100
+    
+        Tag for commit b49c2ee65e7a777dd8cdee565a81afe1a1e393ba
+        gpg: Signature made Wed 17 Feb 2016 09:30:19 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b49c2ee Update 3.1-rc3 release date
+
+[33mcommit d8a1730e634e47cf041df919ececcda4afef76af[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Feb 17 17:29:54 2016 +0100
+
+    added a few links for Qubes-certified Laptops
+    fixed responsive grid on homepage
+
+[33mcommit fb47cef2c579330af55ea78fb64563418b88c1b8[m
+Merge: d1ab054 f914e8a
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Feb 17 15:51:38 2016 +0100
+
+    fixing merge conflict
+
+[33mcommit f914e8ad4f2df167c0d12e28cbf3f469643266c9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 12 02:08:03 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_635aeab7
+        tagger Axon <axon@openmailbox.org> 1455239265 +0000
+    
+        Tag for commit 635aeab7dc233bf631df66dc129f3fb8d47eb750
+        gpg: Signature made Fri 12 Feb 2016 02:07:45 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        635aeab Merge pull request #104 from brianshumate/master
+        fc8e0be Minor edits to Live USB
+
+[33mcommit 7ad5559d6f9f463c60a5c7bfa953eaaa5f439979[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Feb 11 14:18:27 2016 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        tag mm_90ee0c87
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1455196691 +0100
+    
+        Tag for commit 90ee0c874494464452f2cfb6f8a602ce9b4033d4
+        gpg: Signature made Thu 11 Feb 2016 02:18:11 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        90ee0c8 fixed corrupted image (*.png) for linking to doc archlinux.md
+        3d7a95c Add archlinux images to be linked to managing-os/templates/archlinux.md to replace image link to my personal account.
+
+[33mcommit 6de94599c88e5a50a79c8f73bb5ad2c14de38e32[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Feb 11 05:12:36 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_286b46a5
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1455163940 +0100
+    
+        Tag for commit 286b46a51b54b4222e5c4d91c68df1248cd7fc4d
+        gpg: Signature made Thu 11 Feb 2016 05:12:20 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        286b46a Add a link to multiboot doc from User FAQ
+        b20bc08 Adding notes on dual/multi booting Qubes
+        0747af8 Merge remote-tracking branch 'origin/pr/101'
+        991f197 simplified title
+        df2d26e 80 columns and simplified my last part and good script
+
+[33mcommit 7db13b1b84e35eebcee79cfe6037d1cc8fb878cf[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Feb 7 20:43:25 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_0af53d1e
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1454874176 +0100
+    
+        Tag for commit 0af53d1e780343c1407472af597cf660e90b8d9c
+        gpg: Signature made Sun 07 Feb 2016 08:42:56 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        0af53d1 Fix GUI protocol doc formatting
+
+[33mcommit af85142a1e340d34419853f73d474d713d0139d4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Feb 5 01:42:17 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_88afdd9c
+        tagger Axon <axon@openmailbox.org> 1454632919 +0000
+    
+        Tag for commit 88afdd9c3c18a50f043269f667efc61534741531
+        gpg: Signature made Fri 05 Feb 2016 01:41:58 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        88afdd9 Merge pull request #100 from JasperWeiss/patch-1
+        135b345 Update xfce.md
+
+[33mcommit 1445accbb689381ecd8406d1cb93fcff6ac4c822[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Feb 3 17:18:27 2016 +0000
+
+    Improve code appearance (fixes QubesOS/qubes-issues#1715)
+
+[33mcommit d1ab054e05ffd6e3fcd0cc24d1beff2952f47e5e[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Feb 3 18:06:53 2016 +0100
+
+    changed background-color of <pre> and <code> block, fixes #1715
+
+[33mcommit 8e52b6a4cae0b2a6c9b7657fc7303e4940f93d36[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Feb 3 16:44:03 2016 +0000
+
+    Update link to Templates page
+
+[33mcommit 9aa7c799a3240427d249d10f0f38560215d017e6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 3 15:39:03 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_968441af
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1454510331 +0100
+    
+        Tag for commit 968441af3fec91bcbe7dc0642f612b9b93f3dca4
+        gpg: Signature made Wed 03 Feb 2016 03:38:51 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        968441a hvm: Add info about DNS address in network configuration
+
+[33mcommit 89cbc7a40001b7194fcbd1f350728de7d8e6e9e9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 3 13:18:46 2016 +0100
+
+    Revert "Revert "Change highlighter to rouge to suppress page build warning""
+    
+    This reverts commit 0bd1b0208f772db5bdb3bf2c25c36c167ceaed6c.
+    That was correct commit. The whole issue is caused by github pages
+    update (to jekyll 3.0).
+    
+    QubesOS/qubes-issues#1715
+
+[33mcommit 0bd1b0208f772db5bdb3bf2c25c36c167ceaed6c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 3 12:19:22 2016 +0100
+
+    Revert "Change highlighter to rouge to suppress page build warning"
+    
+    This reverts commit 76ca7a3793c53a3861c16c9f621c3e7c26eaa408.
+    
+    While according to the github documentation, it shouldn't matter,
+    apparently it does and renders code sections white on white.
+    
+    QubesOS/qubes-issues#1715
+
+[33mcommit 1f06200a92275048adc28720766034ca1665a3d2[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Feb 2 23:35:54 2016 +0000
+
+    Update old links
+
+[33mcommit 47df0600e44a8e8793f6634e6d810754be5996aa[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Feb 2 23:33:22 2016 +0000
+
+    Update downloads.md
+
+[33mcommit 77c4ae54a2bee027cfb2cda0951790f119daa387[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Feb 2 23:30:49 2016 +0000
+
+    Update "help and support" links
+
+[33mcommit 9eb8118e3ae299e6a0b400e1a5b90fc2b49f6976[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 3 00:12:45 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_263a8302
+        tagger Axon <axon@openmailbox.org> 1454454713 +0000
+    
+        Tag for commit 263a83028d015c000951944ea9c0c9abbb23b305
+        gpg: Signature made Wed 03 Feb 2016 12:11:53 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        263a830 Update doc-guidelines
+
+[33mcommit 26e8a379fb083779b4fe3a6628f0f50a9baa1419[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Feb 3 00:11:26 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_b912a1aa
+        tagger Axon <axon@openmailbox.org> 1454454633 +0000
+    
+        Tag for commit b912a1aa8bbe71e08283d20c379bdbd81dc33ec3
+        gpg: Signature made Wed 03 Feb 2016 12:10:33 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b912a1a Update doc-guidelines
+
+[33mcommit 6a0f6c62a3b295d385e33d942404ad708b02688d[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Feb 2 22:34:25 2016 +0000
+
+    Add prominent link to documentation contribution instructions
+
+[33mcommit 4d56050c63588cdafe99742df23678cf40bf36f4[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Feb 2 22:24:13 2016 +0000
+
+    Update architecture.yml to reflect integration of Intro with Tour
+
+[33mcommit ffcbc5216dbc0a5e86facabbe9f8c7ffba55fac6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Feb 2 23:09:12 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_3aeccb1d
+        tagger Axon <axon@openmailbox.org> 1454450900 +0000
+    
+        Tag for commit 3aeccb1d5ad35ebe483c953119683dc687f02a8d
+        gpg: Signature made Tue 02 Feb 2016 11:08:19 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3aeccb1 Remove Intro (integrated into Tour)
+
+[33mcommit 486651c87a505ee05665da2a4e4013d288e1e4d6[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Feb 2 22:06:34 2016 +0000
+
+    Update home page to reflect integration of Intro into Tour
+
+[33mcommit eb306f83af3109af3c4341ac1e3cbdaf6b1cbde3[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Feb 2 21:59:41 2016 +0000
+
+    Integrate Intro with Tour
+    
+    Replace "Intro" link with "Architecture" link
+
+[33mcommit c639ce2cc42e814c5badf49c5a773d16d7f09155[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Feb 2 22:46:31 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_20861e71
+        tagger Axon <axon@openmailbox.org> 1454449537 +0000
+    
+        Tag for commit 20861e71525d23f9b4f7c93d8696b368edb21f75
+        gpg: Signature made Tue 02 Feb 2016 10:45:37 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        20861e7 Improve page naming
+
+[33mcommit 0247a8da5dfd0cfeb692a41e97e56d521be95843[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Tue Feb 2 21:34:16 2016 +0000
+
+    Include plain CSS non-SASS styling file
+
+[33mcommit 7e4baa8471b466fd4dc32cf6bb5f8fbec64c77d6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Feb 2 21:59:08 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_8ce3b25b
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1454446738 +0100
+    
+        Tag for commit 8ce3b25b9fd554f6cb9383e9658251e57331fdbf
+        gpg: Signature made Tue 02 Feb 2016 09:58:58 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        8ce3b25 supported versions: remove "Under construction" warning
+
+[33mcommit bac1d3fcafa5571ece2100fd5764fc5cc21588c2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Feb 2 21:56:01 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_c3401b78
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1454446550 +0100
+    
+        Tag for commit c3401b78bf4637f2f65038570435846ef80a242e
+        gpg: Signature made Tue 02 Feb 2016 09:55:50 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        c3401b7 Remove note about non-GPL Windows Tools, as no longer applicable
+
+[33mcommit 12061f460a8eda9f82b1396fcf66a55e0408f235[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Feb 2 20:30:28 2016 +0000
+
+    Fix typos
+
+[33mcommit af21922c9416fa70a2af47cda75c7ca3fe9bc85b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Feb 2 20:29:36 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_3a11eacb
+        tagger Axon <axon@openmailbox.org> 1454441321 +0000
+    
+        Tag for commit 3a11eacb640e8a88bfbe7305e85269831f1212c6
+        gpg: Signature made Tue 02 Feb 2016 08:28:43 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3a11eac Update supported-versions.md
+
+[33mcommit 0aa07fc374d4e7ebb7cc20546a4850d7b0040b97[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Feb 2 20:05:52 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_10e07da1
+        tagger Axon <axon@openmailbox.org> 1454439885 +0000
+    
+        Tag for commit 10e07da11147aa976349a019eccdadaa746c6411
+        gpg: Signature made Tue 02 Feb 2016 08:04:48 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        10e07da Merge pull request #99 from mvermaes/patch-2
+        6d47b03 Merge pull request #98 from mvermaes/patch-1
+        b12c09f Merge pull request #97 from marmarek-test/patch-1
+        09b7f43 Change qrexec-timeout references to qrexec_timeout
+        bcdc269 Minor VPN doc syntax cleanup
+        779ceec Update fedora template version in TorVM doc
+
+[33mcommit 76ca7a3793c53a3861c16c9f621c3e7c26eaa408[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Feb 2 12:57:48 2016 +0100
+
+    Change highlighter to rouge to suppress page build warning
+    
+    Github pages doesn't support any other highlighter anyway, so it isn't
+    any functional change. Additionally it is compatible with `pygments`.
+    
+    Details:
+    https://help.github.com/articles/using-syntax-highlighting-on-github-pages/
+
+[33mcommit 1d8481e4f62a85888becd993e326f86ef6cbe2ed[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Feb 2 12:50:53 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b08d8027
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1454413842 +0100
+    
+        Tag for commit b08d8027d45c325e804cd67c679589bb75559c19
+        gpg: Signature made Tue 02 Feb 2016 12:50:42 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b08d802 release checklist: notify @Rudd-O about new ISO, for torrent mirror
+
+[33mcommit 286c549fd11e6617431f1004b8ef1fed64d36bc5[m
+Merge: 6d6b4f2 39675bb
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Feb 2 12:45:09 2016 +0100
+
+    Merge remote-tracking branch 'origin/pr/23'
+    
+    * origin/pr/23:
+      Homogeneize links on the table for qubes 3.1 download.
+      Remove code tags and remove magnet links as well.
+      No need for the paragraph break, it does itself.
+      Explicit paragraph break before 'also at'
+      Clarify what is it that people are downloading, it's not the iso
+      Reformat the way that the link appears so that it actually appears.
+      Format the domain name properly to conform with the rest.
+      Add downloadable BitTorrent non-magnet link.
+      Reformat 3.1RC into table / add BitTorrent download
+
+[33mcommit 39675bb06e82ceecff606ac26477b460d1ef035e[m
+Author: Rudd-O <rudd-o@rudd-o.com>
+Date:   Mon Feb 1 22:26:58 2016 +0000
+
+    Homogeneize links on the table for qubes 3.1 download.
+
+[33mcommit 8806e1698f59afcfa28a5799dbb7a0aba47320cf[m
+Author: Rudd-O <rudd-o@rudd-o.com>
+Date:   Mon Feb 1 05:52:54 2016 +0000
+
+    Remove code tags and remove magnet links as well.
+
+[33mcommit 6d6b4f2179bac96a80582637ee8da75982871c53[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jan 29 13:41:08 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_60b0f78e
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1454071222 +0100
+    
+        Tag for commit 60b0f78e540b58d0b150f0ddf1a30785597760cb
+        gpg: Signature made Fri 29 Jan 2016 01:40:23 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        60b0f78 Add ilustrated documentation contribution guide
+
+[33mcommit faa3c7c2ecd51eb09448514f6e73bbf26c68e49d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jan 29 13:13:17 2016 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        tag mm_fd54f7e6
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1454069520 +0100
+    
+        Tag for commit fd54f7e6a4246395ab425b96c1708befba048770
+        gpg: Signature made Fri 29 Jan 2016 01:12:01 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        fd54f7e Add documentation edit workflow screenshots
+
+[33mcommit 06096dca6318d319a3047edd432bf0503e39193d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jan 28 13:11:30 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_9d59c48a
+        tagger Axon <axon@openmailbox.org> 1453983038 +0000
+    
+        Tag for commit 9d59c48aa76f31fe313bc8b81995cb2f67410fbd
+        gpg: Signature made Thu 28 Jan 2016 01:10:36 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9d59c48 Reorganize USB-related information
+
+[33mcommit ff678b166660c8a5a44baa4b35c0b9e942ede053[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jan 28 11:17:50 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_a22db63b
+        tagger Axon <axon@openmailbox.org> 1453976218 +0000
+    
+        Tag for commit a22db63b3bdc21f72b06de1d86f66c49c11546f9
+        gpg: Signature made Thu 28 Jan 2016 11:16:56 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a22db63 Move and rename Salt page
+
+[33mcommit 5ea866f010ce3317e83755bf913da1dc3083bbf1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 27 16:52:52 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_cfbbd10d
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1453909956 +0100
+    
+        Tag for commit cfbbd10d2f5adc9329b566739de56c096a2508e9
+        gpg: Signature made Wed 27 Jan 2016 04:52:36 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        cfbbd10 Update license information for Qubes Windows Tools
+
+[33mcommit 7325fa228cb5d5def02b82db6a81e276cb5f34ac[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 27 15:32:26 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_487b9851
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1453905135 +0100
+    
+        Tag for commit 487b98511748fe8082a066c40d4e215c48b56d72
+        gpg: Signature made Wed 27 Jan 2016 03:32:15 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        487b985 Announcing opening the source of Qubes Windows Tools
+
+[33mcommit c8900f3628e78f1d5fd10a010b6448967b56afce[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 27 12:01:19 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b8dd639e
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1453892461 +0100
+    
+        Tag for commit b8dd639e75cfe3f79e8f775010c14badb0006cd2
+        gpg: Signature made Wed 27 Jan 2016 12:01:01 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b8dd639 add note about lack of audio support in Windows HVMs
+        a77b129 fix typo
+        e4b6b91 update Qubes Windows Tools license
+        1c3cb9e unify Windows Tools naming
+
+[33mcommit 38442e3e1a3f92f740787b2e18b357d0cc4f3c27[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 27 00:34:28 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_f6797344
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1453851256 +0100
+    
+        Tag for commit f67973448c0206d7008b5542be98b9bb43256978
+        gpg: Signature made Wed 27 Jan 2016 12:34:16 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        f679734 extend 3.1 release schedule
+
+[33mcommit c65c7b9d0b60e007e7e4e5ff8ea7aaa629462565[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jan 26 11:06:02 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag zrubi_cb582a1
+        tagger Zrubi <mail@zrubi.hu> 1453802634 +0100
+    
+         cb582a1
+        gpg: Signature made Tue 26 Jan 2016 11:04:28 AM CET using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        cb582a1 custom VPN connection status icons for NetworkManager running in a ProxyVM
+
+[33mcommit df3802a4ed0400a98f12e11695db3ebd6432fccc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jan 25 23:05:07 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_aa0aca73
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1453758245 +0100
+    
+        Tag for commit aa0aca7395191158e63ee6d89ea8a69cfb36e4da
+        gpg: Signature made Mon 25 Jan 2016 10:44:05 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        aa0aca7 Add link to r3.1 release schedule
+
+[33mcommit 84a9be38832916cf92a846fc13e5f1285cc96f2f[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Jan 25 21:39:12 2016 +0000
+
+    Create "Supported Versions" page
+
+[33mcommit ce44980834eeec4cdff008b83ad795acfe829167[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jan 24 11:05:12 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_cabe3de0
+        tagger Axon <axon@openmailbox.org> 1453629857 +0000
+    
+        Tag for commit cabe3de0cfb4b25ae59c6fe3b3e925e8b268a6f4
+        gpg: Signature made Sun 24 Jan 2016 11:04:18 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        cabe3de Merge pull request #92 from dan-mi-sun/patch-1
+        a4a9a5a Update verifying-signatures.md
+
+[33mcommit 31c2741272db8e78e3b08aec2bab810896236f91[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jan 23 11:34:24 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_6a9124bf
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1453545252 +0100
+    
+        Tag for commit 6a9124bf6aa533bb4155ae81bf386da4c1a8b4e2
+        gpg: Signature made Sat 23 Jan 2016 11:34:12 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        6a9124b Correction in faq about reassigning PCI device to dom0
+
+[33mcommit 7a204c75b3099ae6176f2e885752d4dfd6bb47af[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jan 22 11:35:00 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag zrubi_fa96552-1-g4467858-1-gf22f7d5
+        tagger Zrubi <mail@zrubi.hu> 1453458835 +0100
+    
+        more yum/dnf changes
+        gpg: Signature made Fri 22 Jan 2016 11:34:08 AM CET using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        f22f7d5 Update fedora-minimal.md
+
+[33mcommit 0f6abf7bc5d2ca6d0a052c6313a152f9cdc80ef6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jan 22 11:27:55 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag zrubi_fa96552-1-g4467858
+        tagger Zrubi <mail@zrubi.hu> 1453458392 +0100
+    
+         1052 fixed :)
+        gpg: Signature made Fri 22 Jan 2016 11:26:56 AM CET using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        4467858 Update vpn.md
+
+[33mcommit f0c7e27959b21c21a3fa7168521e40c50d180743[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jan 22 11:10:24 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag zrubi_fa96552
+        tagger Zrubi <mail@zrubi.hu> 1453457339 +0100
+    
+         Updated fedora-minimal.md
+        gpg: Signature made Fri 22 Jan 2016 11:09:06 AM CET using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        f802c03 Update fedora-minimal.md
+        fa96552 Update fedora-minimal.md
+
+[33mcommit 42e172b3c17986bd02a7a683724e0a033de0e7da[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jan 21 21:17:23 2016 +0100
+
+    Fix my name on team page
+
+[33mcommit 3391dba318ff905bef8249ca5a09a7c8ee1b401b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jan 21 13:10:55 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag axon_4ef0efd8
+        tagger Axon <axon@openmailbox.org> 1453378161 +0000
+    
+        Tag for commit 4ef0efd81a2e40035346894b246db946b7524dfc
+        gpg: Signature made Thu 21 Jan 2016 01:09:22 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4ef0efd Fix quotation marks (closes QubesOS/qubes-issues#1667)
+
+[33mcommit ab76e09d2a7eed3b945f050b14fa7eca8c3ea30a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 20 21:22:27 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_6d94e485
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1453321335 +0100
+    
+        Tag for commit 6d94e4852afdb341ba7d803bf8cc6df2b513edc6
+        gpg: Signature made Wed 20 Jan 2016 09:22:15 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        6d94e48 Merge remote-tracking branch 'origin/pr/93'
+        4d7693d document that there is no progress indicator
+
+[33mcommit 420c489166eee060e08eb8251ed63312557112b2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 20 21:21:47 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_785a3943
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1453321292 +0100
+    
+        Tag for commit 785a39432959ff825fe5616383e57c4b628de5d4
+        gpg: Signature made Wed 20 Jan 2016 09:21:32 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        785a394 upgrade: Whonix templates should also be upgraded
+        3930e72 Add missing step to R3.0->R3.1 debian template upgrade instruction
+
+[33mcommit bb5ab458f1dc7a05aacb86601cc7440ee5a29868[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Jan 20 03:52:55 2016 +0000
+
+    No need for the paragraph break, it does itself.
+
+[33mcommit 4a8963cda265aa163e49c35b67472286c149d21b[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Jan 20 03:52:22 2016 +0000
+
+    Explicit paragraph break before 'also at'
+
+[33mcommit ede2afa3ccded1f0f72c2c4e6b2b86c89219e5ee[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Jan 20 03:51:37 2016 +0000
+
+    Clarify what is it that people are downloading, it's not the iso
+
+[33mcommit 443a36cd84b1f608a01ddedd67b734bd4ef28c73[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Jan 20 03:50:04 2016 +0000
+
+    Reformat the way that the link appears so that it actually appears.
+
+[33mcommit c5df54700a7fcba74b41b72446d117d8b5c147ef[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Jan 20 03:40:49 2016 +0000
+
+    Format the domain name properly to conform with the rest.
+
+[33mcommit 0b7ddc38bc8f926268a333dd5e97a5056698df9d[m
+Author: Manuel Amador (Rudd-O) <rudd-o@rudd-o.com>
+Date:   Wed Jan 20 03:39:16 2016 +0000
+
+    Add downloadable BitTorrent non-magnet link.
+
+[33mcommit 86a5c63e30835ec98b3a99039d5a6a3701e344dd[m
+Author: Rudd-O <rudd-o@rudd-o.com>
+Date:   Wed Jan 20 02:32:02 2016 +0000
+
+    Reformat 3.1RC into table / add BitTorrent download
+    
+    This adds the BitTorrent magnet infohash as a download option.  Of course, verification remains exactly the same as is necessary.  Importantly, Github Markdown doesn't seem to render links to magnet: URIs, but I have chosen to preserve the URI up until the moment they decide to get their shit together and make it happen.
+    
+    I will be hosting the torrent download indefinitely.  Please double-check: download it using a torrent client and check that the download is valid.
+
+[33mcommit fe156e2613575c08b85a4e3e8b248f4cbd2367a9[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Fri Jan 15 09:25:48 2016 -0500
+
+    added Access Now as a partner
+
+[33mcommit 92d2d2cb2ed68128cf1cffe0f4ee700bcda85ff8[m
+Merge: 978f248 7db8e81
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jan 15 02:56:49 2016 +0100
+
+    Merge remote-tracking branch 'origin/pr/21'
+    
+    * origin/pr/21:
+      minor tweaks to HCL page QubesOS/qubes-issues#1203
+      Refactored HCL page to look nicer QubesOS/qubes-issues#1203
+
+[33mcommit 978f24839b01a1b61a0e96b7dcc766830b9585ca[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jan 14 15:24:28 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag w_e82180b2
+        tagger Wojtek Porczyk <woju@invisiblethingslab.com> 1452781161 +0100
+    
+        Tag for commit e82180b263ab051933e0baea8b5ca317f0feb4eb
+        gpg: Signature made Thu 14 Jan 2016 03:19:21 PM CET using RSA key ID D272F2A8
+        gpg: Good signature from "Wojtek Porczyk (Qubes OS documentation signing key) <woju@invisiblethingslab.com>"
+    
+        e82180b Statistics: editing, spelling, grammar
+
+[33mcommit 7db8e81f1575e0307b2299357ad19f4a3345c29a[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Jan 14 15:01:43 2016 +0100
+
+    minor tweaks to HCL page QubesOS/qubes-issues#1203
+
+[33mcommit 1de60aaca65ee80c8dd77e5de25ce59ef86ebfd9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jan 14 14:28:51 2016 +0100
+
+    Enable kernel.org mirror for R3.1-rc2
+    
+    The iso is synced there now.
+
+[33mcommit 5ab26d79ea3c36f79c2db0a5591c1094c9550884[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jan 14 14:19:18 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag w_9d5c8887
+        tagger Wojtek Porczyk <woju@invisiblethingslab.com> 1452773022 +0100
+    
+        Tag for commit 9d5c8887e2a4562a628c270bd6734aa494a8621f
+        gpg: Signature made Thu 14 Jan 2016 01:03:42 PM CET using RSA key ID D272F2A8
+        gpg: Good signature from "Wojtek Porczyk (Qubes OS documentation signing key) <woju@invisiblethingslab.com>"
+    
+        9d5c888 Estimated Qubes OS user base
+
+[33mcommit d60a745dcb9e0e2a0c5c3d90d3453b70497b46ac[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Jan 14 13:44:56 2016 +0100
+
+    Refactored HCL page to look nicer QubesOS/qubes-issues#1203
+
+[33mcommit 0f4544f55b738f0138bf6ffe128338f8da45f7c9[m
+Author: Wojtek Porczyk <woju@invisiblethingslab.com>
+Date:   Thu Jan 14 12:43:40 2016 +0100
+
+    pages: add Statistics
+
+[33mcommit 3a594052b104ea35f583aade176f45651222d92c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 13 22:03:34 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_f059f84b
+        tagger Axon <axon@openmailbox.org> 1452718966 +0000
+    
+        Tag for commit f059f84b87426338ccf871229439750cd3ea55aa
+        gpg: Signature made Wed 13 Jan 2016 10:02:46 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f059f84 Merge pull request #91 from Brand3n/master
+        92267b8 Fix a few (of my own) typos
+
+[33mcommit f212f49399bf6e98fc969d76cc355290c032125f[m
+Merge: af1968f 740ad21
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 13 15:28:32 2016 +0100
+
+    Merge remote-tracking branch 'origin/pr/19'
+
+[33mcommit af1968fa98b38d3d1e50897af43b5f16eff81930[m
+Merge: 24393f5 c286919
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Jan 13 01:47:33 2016 +0000
+
+    Merge pull request #20 from mfc/patch-9
+    
+    Stack Overflow --> Stack Exchange
+
+[33mcommit 24393f58e6cfbda714f5ae67537271402ef7237d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jan 13 02:06:28 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_ec6c4d0e
+        tagger Axon <axon@openmailbox.org> 1452647129 +0000
+    
+        Tag for commit ec6c4d0eba1300830b1ba1761f0bb4eab946c2b0
+        gpg: Signature made Wed 13 Jan 2016 02:05:29 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ec6c4d0 Rewrite R3.1 in-place upgrade page for accuracy and clarity
+
+[33mcommit 16b37e5d968c5d334d54f82a1b9134963cd8b0f5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jan 12 23:39:26 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_147e056a
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1452638326 +0100
+    
+        Tag for commit 147e056ae8d701e03ea376061d21072471061dc4
+        gpg: Signature made Tue 12 Jan 2016 11:38:46 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        147e056 fix authorship
+
+[33mcommit 52ff95042c816f99289ad1f0bda1a1bd2bd060b5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jan 12 23:30:16 2016 +0100
+
+    Update download links for R3.1-rc2
+
+[33mcommit 6843975dc0706c84383eb866983969082b6d1231[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jan 12 23:29:00 2016 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_6e350531
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1452637701 +0100
+    
+        Tag for commit 6e3505312fba51354d473d3aff61aa7c48698f21
+        gpg: Signature made Tue 12 Jan 2016 11:28:21 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        6e35053 Add R3.1-rc2 release announcement
+
+[33mcommit 6c3fa0e7cf5639f443301362bbc709f6a1150775[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jan 12 23:28:10 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_53f00906
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1452637623 +0100
+    
+        Tag for commit 53f009065428d8dd554d9ecea00ed05e5447fb7f
+        gpg: Signature made Tue 12 Jan 2016 11:27:04 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        53f0090 Remove issues already fixed in 3.1-rc2
+
+[33mcommit c286919f314669180ca7f749b6dc5b776c30ff7b[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Tue Jan 12 10:31:14 2016 -0500
+
+    Stack Overflow --> Stack Exchange
+    
+    user reports that StackOverflow is not appropriate for users (targeted at devs), also has no content re: Qubes:
+    https://groups.google.com/d/msgid/qubes-users/d92b4850-b951-44bc-b4d2-0d01a120db8a%40googlegroups.com
+    
+    StackOverflow: https://stackoverflow.com/questions/tagged/qubes
+    
+    vs:
+    
+    StackExchange: https://stackexchange.com/search?q=qubes
+    
+    in the longer term we should consider trying to create a qubes.stackexchange.com
+
+[33mcommit 1334d6fd97747a1f9787e36b56bba28fd37c6c35[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Jan 12 09:31:53 2016 +0000
+
+    Comment out broken "contact" link for now
+
+[33mcommit 740ad2191a92369e2b2524a035d703e2b0b43003[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Jan 11 17:34:34 2016 +0100
+
+    Refactored and styled Team page QubesOS/qubes-issues#1579
+
+[33mcommit aaffd7704267240701fd991d104c0300ab945635[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jan 11 09:11:52 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_e09fe532
+        tagger Axon <axon@openmailbox.org> 1452499857 +0000
+    
+        Tag for commit e09fe5320c174f1561850bf3363587b692964cfa
+        gpg: Signature made Mon 11 Jan 2016 09:10:57 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e09fe53 Merge pull request #90 from Brand3n/master
+        0baa097 Fix a few typos
+
+[33mcommit c7e29da257de4bee8eb0750459fbf48299c0cc9c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jan 10 00:21:35 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_5ae0d5df
+        tagger Axon <axon@openmailbox.org> 1452381650 +0000
+    
+        Tag for commit 5ae0d5dfb0cd2dfb59a73ab17a9451350599213f
+        gpg: Signature made Sun 10 Jan 2016 12:20:53 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5ae0d5d Merge pull request #89 from Chris00/master
+        346c2ac Fix typo
+
+[33mcommit 2b42a2a160727f601bfa743b9074b832a571a10b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jan 9 01:42:58 2016 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        tag mm_3fb4d308
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1452300161 +0100
+    
+        Tag for commit 3fb4d308513172430f5228a0efb197805e6dda61
+        gpg: Signature made Sat 09 Jan 2016 01:42:41 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        3fb4d30 Merge remote-tracking branch 'origin/pr/4'
+        5dddeb0 added pics of various team members
+
+[33mcommit 72a71d4cb9778e8a3d3db0adca208cde1cf90bda[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jan 7 12:41:36 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_e876fc2a
+        tagger Axon <axon@openmailbox.org> 1452166847 +0000
+    
+        Tag for commit e876fc2a1137b960aa000848b40f1c629951cca9
+        gpg: Signature made Thu 07 Jan 2016 12:40:46 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e876fc2 Fix typo
+
+[33mcommit 456a1aa1329e7b61f61ba27fd72d248c60889d7e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jan 5 05:21:02 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_673a2787
+        tagger Axon <axon@openmailbox.org> 1451967582 +0000
+    
+        Tag for commit 673a278752a37bb1b055026b9437609148f3480b
+        gpg: Signature made Tue 05 Jan 2016 05:19:43 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        673a278 Add QSB #23 (fixes QubesOS/qubes-issues#1583)
+
+[33mcommit c93a761bc80620672c3f8aad7821e62ef0248eac[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Jan 4 23:32:43 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_6f2bd69e
+        tagger Axon <axon@openmailbox.org> 1451946702 +0000
+    
+        Tag for commit 6f2bd69e980c588edeff6d5a7f5983f1efa51608
+        gpg: Signature made Mon 04 Jan 2016 11:31:45 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6f2bd69 Fix code blocks
+
+[33mcommit 69cc35b96bfd7adf2b62b16b77206b7dd32d81dd[m
+Merge: 35ccee9 1c6893b
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Jan 4 04:56:48 2016 +0000
+
+    Merge pull request #18 from jbreaksit/whonixurlfix
+    
+    Fix link to Whonix documentation from the homepage.
+
+[33mcommit 1c6893bb8c6d24590117e9b5dc2542df2b2bbb99[m
+Author: jbreaksit <james@jbreaks.it>
+Date:   Sun Jan 3 15:02:34 2016 -0800
+
+    Fix link to Whonix documentation from the homepage.
+
+[33mcommit 35ccee968d93bd041964e2c2376fe57740615d55[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jan 3 23:38:35 2016 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_93e8ed20
+        tagger Axon <axon@openmailbox.org> 1451860677 +0000
+    
+        Tag for commit 93e8ed206e75b80360dfce55f018c082aad4863e
+        gpg: Signature made Sun 03 Jan 2016 11:37:58 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        93e8ed2 Merge pull request #86 from adrelanos/patch-25
+        ba566f8 Merge pull request #88 from adrelanos/patch-27
+        bdb036f fix, not tied to AppVMs but VMs generally
+        6b8b0ec torified upgrades
+
+[33mcommit d3aadb4baf9d5115d928bac8ba90bf2ea4d0eed1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 29 06:33:26 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_2eaf76cf
+        tagger Axon <axon@openmailbox.org> 1451367171 +0000
+    
+        Tag for commit 2eaf76cf43cf9a9696710d3983528c75f16489ae
+        gpg: Signature made Tue 29 Dec 2015 06:32:51 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2eaf76c Remove duplicate TorVM entry
+        d0bab94 Merge pull request #85 from adrelanos/patch-24
+        6df70a3 Update doc.md
+
+[33mcommit 7e84910d2849dc46b8713cbe1370f191f33edf33[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 29 06:28:03 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_3205c4f3
+        tagger Axon <axon@openmailbox.org> 1451366847 +0000
+    
+        Tag for commit 3205c4f34309f9fc2535dbc65c51e47a068db4c0
+        gpg: Signature made Tue 29 Dec 2015 06:27:27 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3205c4f Change qvm-service name from "cron" to "crond"
+
+[33mcommit c7f7f1305d5455645dbde4f351b349571a96fea2[m
+Merge: 6b3facf 32a3706
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Dec 23 07:50:41 2015 +0000
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit 32a370648d52273c3fa5038019453df14f9d7527[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Dec 23 08:50:46 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_964a1cbc
+        tagger Axon <axon@openmailbox.org> 1450856991 +0000
+    
+        Tag for commit 964a1cbc022a17dcd5e6a0bf81edd88a5a47e665
+        gpg: Signature made Wed 23 Dec 2015 08:49:52 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        964a1cb Delete releases index (merging into downloads page)
+
+[33mcommit 6b3facf34d0423290ec90589f913f9641c358165[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Dec 23 07:46:52 2015 +0000
+
+    Merge releases index into downloads page
+
+[33mcommit db1f1fbd3f8263c42dd2b65ddc9fc2bd3361f223[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 21 23:42:58 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_12591b38
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1450737355 +0100
+    
+        Tag for commit 12591b38a711fe7dd647427796928d99dbc0d352
+        gpg: Signature made Mon 21 Dec 2015 11:35:55 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        12591b3 r3.1 schedule: Add link to version-scheme
+        b8a1e19 Add R3.1 to releases index
+        1707238 r3.1 schedule - adjust table borders
+        edc4cac Add R3.1 release schedule
+        c5d45f1 Merge pull request #84 from mfc/patch-10
+        dfbdac3 adding FSDG entry
+        8831a07 Merge pull request #83 from mfc/patch-9
+        c047073 fixed typo
+        aebe419 Merge remote-tracking branch 'origin/pr/82'
+        bb94fed Merge remote-tracking branch 'origin/pr/59'
+        a8f8064 building-archlinux-template: Add workaround for fetching mgmt-salt
+        39f26b1 building-archlinux-template: Simplify component build command
+        5faa2df Update QTW component list
+        993ddbc Remove unused cfg option
+        3090b45 Update QTW log levels
+        192c279 Add note on disk PV drivers
+        fd4bffe Update installable QTW components
+        d02d521 Remove note about templates being not supported
+        4669b27 Add note on GPU support
+        37342d1 Fix typo
+        acd05ec Add link to trubleshooting page
+        7bbb22c Add missing text on qrexec policy
+        cd732b1 Add note on qrexec-timeout
+        2b2a81f Remove note on unsigned drivers warning (not showing anymore)
+        d7049a5 Add instructions for installing QTW from testing repos
+        5da8c0c Add note on autologon in Windows VMs
+        06db75b Add note on supported OS versions
+        5f6d311 building-archlinux-template: Update instructions for R3
+
+[33mcommit 04fa6732075892a4a908a1db72d2946847d8b0bb[m
+Merge: ec92252 9859f5a
+Author: Axon <axon@openmailbox.org>
+Date:   Fri Dec 18 21:13:42 2015 +0000
+
+    Merge pull request #17 from mfc/patch-8
+    
+    grammar fix
+
+[33mcommit ec92252f2f89baf60b5c7bf3e13e28f03fcb3796[m
+Merge: b19f6d3 5a02dd1
+Author: Axon <axon@openmailbox.org>
+Date:   Fri Dec 18 21:13:19 2015 +0000
+
+    Merge pull request #16 from mfc/patch-7
+    
+    fixed two typos, added mailing list
+
+[33mcommit 9859f5a4afed635a9dd6a4cff3cbc549805dc5eb[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Fri Dec 18 12:04:33 2015 -0500
+
+    grammar fix
+
+[33mcommit 5a02dd1b8563be685aa3c41114069abc7a6e038b[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Fri Dec 18 12:03:20 2015 -0500
+
+    fixed two typos, added mailing list
+    
+    fixed two typos, added mailing list to Contact section
+
+[33mcommit b19f6d3e4a17c70744f74bab653d30756704eb23[m
+Merge: b4610b0 dc46cf6
+Author: Axon <axon@openmailbox.org>
+Date:   Fri Dec 18 00:52:01 2015 +0000
+
+    Merge pull request #15 from mfc/patch-5
+    
+    added brennan
+
+[33mcommit dc46cf6e5e3d0b6a0227098ba117ba428e0895e6[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Thu Dec 17 18:18:09 2015 -0500
+
+    added brennan
+
+[33mcommit b4610b042ba75112852f0f51fe21bf79c1921dc1[m
+Merge: c2ec710 94cc356
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Dec 16 10:20:51 2015 +0000
+
+    Merge pull request #14 from mfc/patch-4
+    
+    added asia, clean language
+
+[33mcommit 94cc35608076749dc87c5dca1fbde97c501e450b[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Tue Dec 15 09:57:51 2015 -0500
+
+    Update team.md
+
+[33mcommit ebdf0e50227518e3bed53b6127b60b8605e01ecd[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Tue Dec 15 08:45:22 2015 -0500
+
+    added asia, clean language
+
+[33mcommit c2ec71028aa19cc12308fc42b98c299fc6d9811b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 14 14:36:40 2015 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_988e3e24
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1450100178 +0100
+    
+        Tag for commit 988e3e243d180e1b8858084bfee1b881fb20e65b
+        gpg: Signature made Mon 14 Dec 2015 02:36:19 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        988e3e2 Merge remote-tracking branch 'origin/pr/4'
+        99c9542 added new article
+
+[33mcommit 825502fc286bfb620dc58beb952ca28eb622e8ae[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 14 13:33:05 2015 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_cc600751
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1450096363 +0100
+    
+        Tag for commit cc600751b094b44370c2909d4316b9b5cda87814
+        gpg: Signature made Mon 14 Dec 2015 01:32:44 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        cc60075 mgmt-stack: escape config example
+
+[33mcommit 6fb7bc79eaa2d612cc1d9772d08f66d2d5efd073[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 14 13:13:52 2015 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_0c231abd
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1450095209 +0100
+    
+        Tag for commit 0c231abd29220ac1418b99ae8a6f98ca949ce79c
+        gpg: Signature made Mon 14 Dec 2015 01:13:30 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        0c231ab Add date field
+
+[33mcommit 63a69f64cf5f58d66b38c0101d278d546c7f00c0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 14 13:12:20 2015 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_f86e2b1f
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1450095115 +0100
+    
+        Tag for commit f86e2b1fe2f7d6acaf2a135dc66f2b3bb6415e82
+        gpg: Signature made Mon 14 Dec 2015 01:11:56 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        f86e2b1 Post about management stack
+
+[33mcommit f024f0ebecb702ad2f6717bf20e2b68ad056c7a5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 13 19:34:37 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_f861b7b1
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1450031665 +0100
+    
+        Tag for commit f861b7b15b0c4b2ae42afe6643ad335496cba074
+        gpg: Signature made Sun 13 Dec 2015 07:34:25 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        f861b7b r3.1: known issues
+
+[33mcommit 21eb62cf8174b3471c47e62fea3be9d31b947501[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Dec 13 01:52:38 2015 +0000
+
+    Update link to Live USB page
+
+[33mcommit 72f28a5a129574e8ed0b2a61c34e60088cf5975b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 13 02:51:55 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_4f76c47c
+        tagger Axon <axon@openmailbox.org> 1449971489 +0000
+    
+        Tag for commit 4f76c47c7f5322abd2b5d3c372bd930b756c124b
+        gpg: Signature made Sun 13 Dec 2015 02:51:30 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4f76c47 Clean up Live USB page
+
+[33mcommit 8f6a7b2d56d3834c900baf68bced1cc5ebe56e31[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Dec 13 02:43:34 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_13877517
+        tagger Axon <axon@openmailbox.org> 1449970983 +0000
+    
+        Tag for commit 1387751739f593b5aceae6cb6160779fd6ad3613
+        gpg: Signature made Sun 13 Dec 2015 02:43:04 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1387751 Create Live USB page and add link
+        4ccd1f3 Merge pull request #78 from Thomas-Fleming/patch-3
+        362d7b7 simplify shutdown step
+        49f14dc Formalize shutdown step
+
+[33mcommit 3120b7ac7522316b8f8fa75925902e14cc9c9a9a[m
+Merge: b2888a2 573d103
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Dec 13 00:31:26 2015 +0000
+
+    Merge pull request #11 from mfc/patch-3
+    
+    change "proprietary code" to "windows tools" devs
+
+[33mcommit b2888a2f6fea557d20c4acc15e3e0db69dfd1a2a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Dec 12 23:08:03 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_0d427d13
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449958034 +0100
+    
+        Tag for commit 0d427d137aeff9a24308da83b31ad2f4f1a505c9
+        gpg: Signature made Sat 12 Dec 2015 11:07:28 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        0d427d1 Add link to "Adding SSD storage cache" message
+
+[33mcommit 0c0a61ce98a8a78eeacfde427a507189df0ebfa1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Dec 11 16:46:43 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_879d3c5b
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449848789 +0100
+    
+        Tag for commit 879d3c5b475e03fb01749a8f2073c62be8257896
+        gpg: Signature made Fri 11 Dec 2015 04:46:29 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        879d3c5 Mark R3.0->R3.1 upgrade as experimental.
+
+[33mcommit 4bed6675d19e91f4911c13bee5f09ed17ea2c83b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Dec 11 14:43:33 2015 +0100
+
+    r3.1: Uncomment kernel org mirror and digests file on qubes-os.org
+
+[33mcommit b18e9f3e1b83b0624bb830250b6320ffa6cc6311[m
+Merge: 09793f0 29e8023
+Author: Axon <axon@openmailbox.org>
+Date:   Thu Dec 10 17:02:17 2015 +0000
+
+    Merge pull request #13 from bnvk/master
+    
+    fixed typo on homepage
+
+[33mcommit 29e80232edd663244816487617d8e9e39c1ba8a6[m
+Merge: c28aefe 09793f0
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Dec 10 17:29:39 2015 +0100
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit c28aefe48ef07cbee6c94644491061e23ca65e47[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Dec 10 17:26:29 2015 +0100
+
+    fixed typo QubesOS/qubes-issues#1460
+
+[33mcommit 09793f018d639013861b6df06a44470c56cc438c[m
+Author: Axon <axon@openmailbox.org>
+Date:   Thu Dec 10 16:22:17 2015 +0000
+
+    Sync submodules
+
+[33mcommit 97b5567df54174b048c9fe71b5470aa60b560916[m
+Merge: 991ec89 b6e83ec
+Author: Axon <axon@openmailbox.org>
+Date:   Thu Dec 10 16:14:06 2015 +0000
+
+    Merge pull request #12 from bnvk/master
+    
+    Made default categories & author on blog work QubesOS/qubes-issues#1460
+
+[33mcommit b6e83ec5482272b0b7620a2261602a90ddf8da21[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Thu Dec 10 11:56:16 2015 +0100
+
+    Made default categories & author on blog work QubesOS/qubes-issues#1460
+
+[33mcommit 991ec896af2083f5fd57cc100cacd0987af667e6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 10 04:01:35 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_67e188a7
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449716468 +0100
+    
+        Tag for commit 67e188a7fb69cd38bf87f8a7530c32287e8f96f0
+        gpg: Signature made Thu 10 Dec 2015 04:01:11 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        67e188a Merge remote-tracking branch 'origin/pr/79'
+        a446266 use Qubes + Purism image
+        f3660bc Merge remote-tracking branch 'origin/pr/77'
+        6f17716 Merge remote-tracking branch 'origin/pr/76'
+        b047cae Merge remote-tracking branch 'origin/pr/75'
+        451a364 Merge remote-tracking branch 'origin/pr/74'
+        729f949 Merge remote-tracking branch 'origin/pr/73'
+        6566ed6 documented Split GPG incompatibility with TorBirdy
+        74ed4a4 fixed link
+        978f257 Update updating-whonix.md
+        44d5422 Update updating-whonix.md
+        9d4fe06 Update whonix.md
+        ea01a59 Update customizing-whonix.md
+        0e39d61 Update install-whonix.md
+
+[33mcommit edf6e4f41cfe558a587cfc5a21b744122efc253b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 10 02:41:47 2015 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        tag mm_cf1e524f
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449711683 +0100
+    
+        Tag for commit cf1e524f92f89fec77a2193bdbeb7d27759a9ef2
+        gpg: Signature made Thu 10 Dec 2015 02:41:23 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        cf1e524 Merge remote-tracking branch 'origin/pr/3'
+        1f89440 Update Purism 13 picture
+        67d452b updated wiki/Whonix/Create_Qubes-Whonix-Workstation_AppVM.png
+
+[33mcommit 01ce82e1884151199ca291d31c715c10996202f0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 10 02:28:51 2015 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_ea85c5c0
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449710909 +0100
+    
+        Tag for commit ea85c5c0c6a1c50d5cbb297e66359cc92f80592f
+        gpg: Signature made Thu 10 Dec 2015 02:28:32 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        ea85c5c Purism partnership announcement
+
+[33mcommit f76d0a5a779ba116305b05bb1c69d18af69f982e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Dec 9 20:38:01 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_bd937d12
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449689842 +0100
+    
+        Tag for commit bd937d12117824fae8b8017b8095b65cf797ee21
+        gpg: Signature made Wed 09 Dec 2015 08:37:37 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        bd937d1 Merge remote-tracking branch 'origin/pr/71'
+        34bbcb3 Merge remote-tracking branch 'origin/pr/70'
+        1656818 Merge remote-tracking branch 'origin/pr/69'
+        b72dc0d Merge remote-tracking branch 'origin/pr/68'
+        a20aeea Merge remote-tracking branch 'origin/pr/67'
+        96edaf5 Merge remote-tracking branch 'origin/pr/66'
+        7fd05d4 Merge remote-tracking branch 'origin/pr/65'
+        74314ce Merge remote-tracking branch 'origin/pr/63'
+        2cb1883 Merge remote-tracking branch 'origin/pr/64'
+        6f89663 r3.1: minor fix
+        296851a fixed broken /en/ links
+        3637b00 fixed spelling, reintroduced '-' for Whonix VM names
+        c628a0c Update updating-whonix.md
+        559f11b fix link
+        6f84cd8 remove mock-up language
+        5066f0c Update fedora-template-upgrade-21.md
+        5cee14b fix link
+        81641a6 updated instructions
+        6b90147 highlighting Whonix gateway template more
+
+[33mcommit f6fda57523c0137a2ff7db3785d0d483ef994328[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 8 16:29:33 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b079a3b7
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449588545 +0100
+    
+        Tag for commit b079a3b70547039980289dc780e49cde4fc405a8
+        gpg: Signature made Tue 08 Dec 2015 04:29:07 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b079a3b Merge remote-tracking branch 'origin/pr/62'
+        1ae209a moved Getting Started & Research to site repo QubesOS/qubes-issues#1460
+        40c1312 fixed Privacy Guides heading QubesOS/qubes-issues#1202
+        84c1a0c fixed merge conflict QubesOS/qubes-issues#1202
+        c956a2c saved changes to Doc index as QubesOS/qubes-issues#1202
+        c7aa41b started porting over Whonix documentation QubesOS/qubes-issues#1201 QubesOS/qubes-issues#1202
+        554e5fd harmonized names for 'Resizing' things and improved Root Disk Size (QubesOS/qubes-issues#1441)
+        015758b fixed link to Template Whonix and Doc ToC
+        763abfb added Privacy section, moved TorVM & VPN there
+        25a2fc0 Merge branch 'upstream'
+        fb107c1 fixed markdown on resize-root-disk-image
+
+[33mcommit d2d6e2c926d6fa1f6c3a1a82001ab94914195013[m
+Merge: a52aeeb 12349eb
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 8 16:22:22 2015 +0100
+
+    Merge remote-tracking branch 'origin/master'
+
+[33mcommit 12349eb59b051a7fbc5b2a923a01060e4c35f997[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 8 16:19:41 2015 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_720e8de6
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449587955 +0100
+    
+        Tag for commit 720e8de687149edae8b9cdb943088f8cc4207473
+        gpg: Signature made Tue 08 Dec 2015 04:19:18 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        720e8de Change author to Qubes OS
+
+[33mcommit a52aeebec9b8a87af702abcbbc845e32f7aca69c[m
+Merge: aab027f ae759ac
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 8 16:01:22 2015 +0100
+
+    Merge remote-tracking branch 'origin/pr/10'
+
+[33mcommit aab027f16d1edf436415a56a6b514bb4d5c33cd1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 8 15:52:04 2015 +0100
+
+    Add R3.1 rc1 download links
+
+[33mcommit 61ef4fe7f2a759eb2281c688c0b16d139bc924cb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 8 15:54:20 2015 +0100
+
+    autoupdate: _posts
+    
+    _posts:
+        tag mm_dc7e289f
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449586397 +0100
+    
+        Tag for commit dc7e289f8ee7f99499f286b053a39a5d3e6935d5
+        gpg: Signature made Tue 08 Dec 2015 03:53:20 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        dc7e289 R3.1 rc1 release annoucement
+        7d7efae Updated post categories with commas QubesOS/qubes-issues#1460
+        8bc55fe created posts for all articles QubesOS/qubes-issues#1460
+        c336b5e first pass at converting blog posts to actual Jekyll posts QubesOS/qubes-issues#1460
+
+[33mcommit b660de70d5c76093d664a00479b2f7eb426e78a9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 8 12:51:02 2015 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        tag mm_e2bb9da5
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449575429 +0100
+    
+        Tag for commit e2bb9da55dece671e8a8819c7e17dbc97787bdd3
+        gpg: Signature made Tue 08 Dec 2015 12:50:30 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        e2bb9da added BTC QR code and changed color of outline logo QubesOS/qubes-issues#1460
+        4b9d49c Merge branch 'master' of https://github.com/QubesOS/qubes-attachment
+        74d7256 added qubes-purism-image
+        18bcc0f added various icons and logos for new site design
+        f22bf3c added Site graphics
+
+[33mcommit ae759ace90ebc5e85f8d06b08e61e22699d9b337[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Tue Dec 8 11:06:36 2015 +0100
+
+    Some minor tweaks to home banner styling QubesOS/qubes-issues#1460
+
+[33mcommit 77a160b8fb4d85985caf4ba8ef6b34d316f9b75d[m
+Merge: b250731 6109cbe
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 17:06:38 2015 +0100
+
+    Merge pull request #2 from bnvk/mfc-patch-2
+    
+    improved language
+
+[33mcommit b250731d2f67730c140030b9ba54f3aff3d7cb27[m
+Merge: 58d3919 78044a2
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 17:05:58 2015 +0100
+
+    Merge branch 'mfc-patch-1' into bnvk/new-design
+
+[33mcommit 78044a24375975c0dc1e22e56f77194d9ab85dd8[m
+Merge: 36cab01 58d3919
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 17:04:18 2015 +0100
+
+    fixing merge conflict
+
+[33mcommit 58d391980961f730baeaa4eba5bb61ea6a8e0c50[m
+Merge: 5c5e791 46b7f40
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 17:00:35 2015 +0100
+
+    Merge branch 'bnvk/new-design' of github.com:bnvk/qubesos.github.io into bnvk/new-design
+
+[33mcommit 5c5e791b042dd3d371f40e8983809edd20d29119[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 16:59:15 2015 +0100
+
+    Updated README with docs, commented out Donate items, changed draft template, and improved Donate page  QubesOS/qubes-issues#1460
+
+[33mcommit 46b7f4038fb960beceaf59187f904b45e80cce86[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Mon Dec 7 10:35:04 2015 -0500
+
+    change "proprietary code" to "windows tools" devs
+    
+    moving this [merge request](https://github.com/QubesOS/qubesos.github.io/pull/11/files) into Brennan's branch
+    
+    ---
+    
+    conversation there:
+    
+    the current language is unclear whether "proprietary" refers to working on Windows (which is proprietary) or the code itself is proprietary (which has previously been the case).
+    
+    Soon the Windows Tools will be open sourced, but for now (and always) it may be more clear just to refer to these developers as "Windows Tools" developers.
+
+[33mcommit 6109cbe348edf194de45eddb81f7fbb65ab9a494[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Mon Dec 7 08:56:01 2015 -0500
+
+    improved language
+
+[33mcommit 36cab01e0abc3cece1016871a72f039a11331811[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Mon Dec 7 08:54:06 2015 -0500
+
+    cleaned up some language
+
+[33mcommit 39b920b5eb4caadf89187427a47320738cfe1a1e[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 14:26:36 2015 +0100
+
+    added icons to buttons and better margins on overview pages QubesOS/qubes-issues#1460
+
+[33mcommit 6d11924743b8daa09fb1f4e724d32c741dba54e2[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 14:25:29 2015 +0100
+
+    upgraded FontAwesome lib QubesOS/qubes-issues#1460
+
+[33mcommit 2c37f8f8e7cd83e08fd46f05031030a10efb4fd7[m
+Merge: ea4d8d1 5bb543f
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 13:25:33 2015 +0100
+
+    Merge branch 'bnvk/new-design' of github.com:bnvk/qubesos.github.io into bnvk/new-design
+
+[33mcommit ea4d8d183924e67572955db96396f0e604101fb4[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 13:24:56 2015 +0100
+
+    added defaults and categories to config QubesOS/qubes-os#1460
+
+[33mcommit 90cb96736b2425218323e135f8839dffd977ccdf[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 13:19:15 2015 +0100
+
+    Some changes to a few things in pages/ QubesOS/qubes-issues#1460
+
+[33mcommit c0d7385d78e7cb84c65b4ffa55517458a6e984fa[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 13:18:22 2015 +0100
+
+    Lotsa changes things to SCSS files QubesOS/qubes-issues#1460
+
+[33mcommit 272db4b6e01bb918b5ff3f0b8d2a0744a33628a4[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 13:13:10 2015 +0100
+
+    Modified & added news.yml data files QubesOS/qubes-issues#1460
+
+[33mcommit 6eeb6386c56a1faec0e4732394e51d27414f3867[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 13:10:59 2015 +0100
+
+    moved News file to own folder
+
+[33mcommit f6dc470c2ef9420743d31fe7e1f6d7f307d6339d[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 13:10:19 2015 +0100
+
+    Updated multiple layouts & include files QubesOS/qubes-issues#1460
+
+[33mcommit 64cebd30276c8945d15647d9e15e0e4753994282[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Dec 7 05:26:45 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_8b15fe1b
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449462392 +0100
+    
+        Tag for commit 8b15fe1b3ffc9762c73baaa507224cfb9d132a42
+        gpg: Signature made Mon 07 Dec 2015 05:26:32 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        8b15fe1 Update R3.1 upgrade instruction and known issues
+
+[33mcommit ec5f2f0c6e8377ddba88fc631c5a2183fabc952c[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Dec 7 00:30:18 2015 +0100
+
+    added feature to the jquery ToC plugin QubesOS/qubes-issues#1460
+
+[33mcommit 878763330bf4abe9e99bd8f4d41eff3e315e64c6[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Sun Dec 6 17:27:45 2015 +0100
+
+    added _drafts folder and template QubesOS/qubes-issues#1460
+
+[33mcommit 2108dfaa90e8823e305ecf7e88b8ca427498f98e[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Sun Dec 6 15:34:21 2015 +0100
+
+    improved styling of Search & Footer links QubesOS/qubes-issues#1460
+
+[33mcommit 6ef43d592d21d39dcad741944a51412b152fe70d[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Sat Dec 5 15:52:10 2015 +0100
+
+    fixed <title> doubling of site title QubesOS/qubes-issues#1460
+
+[33mcommit 20968ac48851af3eb11f91f9a8ebe699d760e973[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Dec 5 12:35:41 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_62389a30
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1449315326 +0100
+    
+        Tag for commit 62389a3098f87fc3f10f373a9dcf6788e7535ccc
+        gpg: Signature made Sat 05 Dec 2015 12:35:26 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        62389a3 Merge remote-tracking branch 'origin/pr/60'
+        00a0461 Add Terminal shortcut to Fedora 23 known issues.
+
+[33mcommit 5bb543fffbc7092b5667f4fc501a47f331cc1a47[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Fri Dec 4 13:17:19 2015 -0500
+
+    cleaned up language
+
+[33mcommit 573d1031c3c2b3c5f2603467028422f2ec8df479[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Fri Dec 4 12:32:14 2015 -0500
+
+    change "proprietary code" to "windows tools" devs
+    
+    the current language is unclear whether "proprietary" refers to working on Windows (which is proprietary) or the code itself is proprietary (which has previously been the case).
+    
+    Soon the Windows Tools will be open sourced, but for now (and always) it may be more clear just to refer to these developers as "Windows Tools" developers.
+
+[33mcommit 9bb3c37bf6e0b80890ae35190d04ac39aaa632fb[m
+Merge: 5bca222 0e0c13b
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Fri Dec 4 17:46:25 2015 +0100
+
+    Merge branch 'bnvk/new-design' of github.com:bnvk/qubesos.github.io into bnvk/new-design
+
+[33mcommit 5bca222b083e62b35447ad3eb37afdfe45c16571[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Fri Dec 4 17:44:00 2015 +0100
+
+    started refactoring Help page QubesOS/qubes-issues#1460
+
+[33mcommit 0e0c13b89f4107e518a995947d94aebbdc30e62d[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Fri Dec 4 11:00:18 2015 -0500
+
+    fixed markdown of link
+    
+    fixed markdown of link
+
+[33mcommit 91092884daeffd44d9741f695621218398bd82be[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Fri Dec 4 16:56:29 2015 +0100
+
+    created Tour, Getting Started pages & ported over from Docs QubesOS/qubes-issues#1460
+
+[33mcommit d50380ca72257b827143ca9a9421f3617be0fc29[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Fri Dec 4 11:32:52 2015 +0100
+
+    fixed RSS feed and meta tags QubesOS/qubes-issues#1460
+
+[33mcommit ce286e2119ade717bb9cb3f48e4a93d1ed455dc8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Dec 3 11:55:09 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag joanna_4adf2483
+        tagger Joanna Rutkowska <joanna@invisiblethingslab.com> 1449055356 +0100
+    
+        Tag for commit 4adf24835ecbce383e0696408f7255e7a83f7080
+        gpg: Signature made Wed 02 Dec 2015 12:22:38 PM CET using RSA key ID CA74A5C3
+        gpg: checking the trustdb
+        gpg: 3 marginal(s) needed, 1 complete(s) needed, PGP trust model
+        gpg: depth: 0  valid:   1  signed:   0  trust: 0-, 0q, 0n, 0m, 0f, 1u
+        gpg: Good signature from "Joanna Rutkowska (Qubes Documentation Signing Key) <joanna@invisiblethingslab.com>" [ultimate]
+    
+        4adf248 certified laptops page is currently just a mockup
+
+[33mcommit 6775d884c4af2db7034026274608adbc53df6c90[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Dec 2 14:55:32 2015 +0100
+
+    tidied up main.scss a bit #1460
+
+[33mcommit de34951441880c3745f6667ce3ef8f4d858a6e9a[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Dec 2 14:54:30 2015 +0100
+
+    tweaks to spacing and fonts on Home and News #1460
+
+[33mcommit a9ee2e630da9d18192b9d18a0ce1d8a7500337ff[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Dec 2 14:53:50 2015 +0100
+
+    tidied up layout files #1460
+
+[33mcommit 9462587a88b798033cbdfabfcb30eb56851656ac[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Dec 2 14:52:55 2015 +0100
+
+    quick hack changes to data.architecure #1460
+
+[33mcommit e3eb3c609c44c0b850ef7a8bd73721cb2f98fa2f[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Dec 2 14:51:56 2015 +0100
+
+    renamed HCL to Compatible Hardware & created layout file #1460
+
+[33mcommit 947a8712742580c6be17bcee98761720cf0d96a7[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Dec 2 14:44:16 2015 +0100
+
+    a bunch of sytle updates to SASS files #1460
+
+[33mcommit 9cde8b13b09a58b4635cd212482a67e7824daae7[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Dec 2 13:51:10 2015 +0100
+
+    made header dynamic using data.architecture
+
+[33mcommit 33277dbcfba134b9807f429d4ed42f4ceef81f5f[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Wed Dec 2 13:40:18 2015 +0100
+
+    made <title> also show site title on sub pages
+
+[33mcommit 992ed31f7e70b14fe7c01fd3cd584429dd9e9ca1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Dec 2 02:40:08 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_ad1fb0cc
+        tagger Axon <axon@openmailbox.org> 1449020388 +0000
+    
+        Tag for commit ad1fb0cc057fe3da3de2dff00f938fcc30716dfb
+        gpg: Signature made Wed 02 Dec 2015 02:39:48 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ad1fb0c Clean up formatting
+
+[33mcommit 3bdc93ad4a371e07b1828a5df3dec8530eb7ac09[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Dec 1 16:45:14 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_0dfe8b35
+        tagger Axon <axon@openmailbox.org> 1448984693 +0000
+    
+        Tag for commit 0dfe8b35d7947d47bcbf740d0e976e5a3d925689
+        gpg: Signature made Tue 01 Dec 2015 04:44:54 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        0dfe8b3 Update entry for Qubes-Certified Laptops
+        27d8d2a Merge pull request #61 from mfc/master
+        6054395 add certified-laptops page
+
+[33mcommit be77595fb0d856cc642949eadcb3293273944835[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Tue Dec 1 16:16:46 2015 +0100
+
+    first pass at massive refactor of homepage
+
+[33mcommit d040fe62462c53f39d07666376b99bf7ae604384[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Tue Dec 1 16:15:13 2015 +0100
+
+    replaced and added SASS files for Font-Awesome, Bootstrap, and custom
+
+[33mcommit e84fa6cb613b6fa43449acfc8883ff72296ed6a2[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Tue Dec 1 16:02:18 2015 +0100
+
+    added Research data object
+
+[33mcommit 0253283fd293421af2e7ca9b7298f40f1ecc36df[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Nov 30 20:56:53 2015 +0100
+
+    added Architecture & News data files
+
+[33mcommit 524d3b8966b1d8fe9ecb1d052107aa6a9b3ac765[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Nov 30 20:39:50 2015 +0100
+
+    added alternate formats of Ostrich font
+
+[33mcommit d02dcf7ab664e40ad760b7984db889700973cc36[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Mon Nov 30 12:46:46 2015 +0100
+
+    removed uneeded scss/ font-awesome files
+
+[33mcommit be2314647faa3b77bb9c2e01d69fab370dfda9be[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 30 07:30:59 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_c8c0fa3c
+        tagger Axon <axon@openmailbox.org> 1448865028 +0000
+    
+        Tag for commit c8c0fa3c2fe214ab28f5198aac5461133b90030c
+        gpg: Signature made Mon 30 Nov 2015 07:30:28 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c8c0fa3 Clean up Markdown formatting
+
+[33mcommit 4b3521a952bddbe956150e70212744487c244b7b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 29 23:46:03 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_4537350e
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1448837152 +0100
+    
+        Tag for commit 4537350e0b7b4571663c268a159b92e235b689a2
+        gpg: Signature made Sun 29 Nov 2015 11:45:52 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        4537350 Prefer Fedora 21 -> Fedora 23 upgrade
+
+[33mcommit 7ef8ce45672a9576f62652c68bef659d6f3cdb78[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 29 23:01:13 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_bcbaebbc
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1448834459 +0100
+    
+        Tag for commit bcbaebbcb27e3dfa1577dd39294f1055fece2874
+        gpg: Signature made Sun 29 Nov 2015 11:00:59 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        bcbaebb Remove totally outdated building instruction
+
+[33mcommit 74d01bb2ecebeedc3ea9d64c047f5f7283bfd68b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 29 22:55:55 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_79fb0fe2
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1448834141 +0100
+    
+        Tag for commit 79fb0fe2ea344d97f07d1eaf1dda3fcde2e5e38a
+        gpg: Signature made Sun 29 Nov 2015 10:55:41 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        79fb0fe R3.1 release notes and upgrade instruction
+
+[33mcommit e5497584094953e92d8b979c73859eb076e12220[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Sun Nov 29 17:03:25 2015 +0100
+
+    removed LESS files
+
+[33mcommit f1cbfe89e67ba09740bf7bea79693b494a69cbd5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 29 15:14:58 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_ed0942c7
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1448806481 +0100
+    
+        Tag for commit ed0942c7a5474d3859709dc1af4e8c21c9cd445d
+        gpg: Signature made Sun 29 Nov 2015 03:14:41 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        ed0942c mgmt-salt: add links to documentation, typo fix
+        1f15a91 Add salt mgmt stack to documentation index
+        227d88d Documentation for mgmt-salt
+
+[33mcommit 24bbc7265f725e73f1679d77947823b78d907dfd[m
+Author: Brennan Novak <hi@bnvk.me>
+Date:   Sun Nov 29 13:41:43 2015 +0100
+
+    added Open Sans & Ostrich fonts
+
+[33mcommit 8012b15cda24e67b98add266f60e8a435e54e1e8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Nov 25 15:34:15 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_850dbde9
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1448462042 +0100
+    
+        Tag for commit 850dbde9677385b13a01d2bd5db4babbd3760925
+        gpg: Signature made Wed 25 Nov 2015 03:34:02 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        850dbde TorVM: update config path
+        d1a69d4 Merge pull request #58 from northox/master
+        07c38cd Minor tidying.
+
+[33mcommit a677ed16e61da00d42c53f214a3c67bb481f255a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 24 03:13:38 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b2df100f
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1448331207 +0100
+    
+        Tag for commit b2df100fe5f60cfe7ec36d7e8fbd68e7b10afaa4
+        gpg: Signature made Tue 24 Nov 2015 03:13:27 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b2df100 development-workflow: add script for inter-VM git and packages copy
+        dc3801a development-workflow: minor update - component names, formating
+        a1b0c44 development-workflow: wrap long lines
+
+[33mcommit 8d24335d3293a1106cc5022dabcb2276c253f8cd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 24 01:19:57 2015 +0100
+
+    autoupdate: attachment
+    
+    attachment:
+        tag mm_4bbdb25d
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1448324350 +0100
+    
+        Tag for commit 4bbdb25d50c4fcce307c6d49ae76e52068158997
+        gpg: Signature made Tue 24 Nov 2015 01:19:10 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        4bbdb25 Merge pull request #1 from bnvk/master
+        27ff2e2 added DiskSize folder for documentation
+        55c0639 added Whonix config screenshots
+
+[33mcommit b5ef9315c0bbc9e32e134b9dac3328d5cd0015fb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Nov 24 01:18:09 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_5e44445b
+        tagger Axon <axon@openmailbox.org> 1448162545 +0000
+    
+        Tag for commit 5e44445bf462e2c34428e03a1c64ee62551ee9c8
+        gpg: Signature made Sun 22 Nov 2015 04:22:26 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5e44445 Merge pull request #57 from adrelanos/patch-11
+        e4ad2ed resize2fs not required for qvm-grow-private
+        965036d Fix typo
+        a678c3a Merge pull request #56 from adrelanos/patch-10
+        66d6239 Update copy-paste.md
+
+[33mcommit 8e2d242e8eef98da43e64db76a9b78e75d5afaf4[m
+Merge: 57e15a0 ed0bc79
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Nov 18 22:15:08 2015 +0000
+
+    Merge pull request #9 from mfc/patch-2
+    
+    Rewrite donations page to be less scary
+
+[33mcommit ed0bc794900beab7b4bc7689615953a0e6a2d712[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Tue Nov 17 18:33:51 2015 -0500
+
+    rewrite donations page to be less scary
+    
+    following: https://github.com/QubesOS/qubes-issues/issues/1246
+
+[33mcommit 57e15a012a66dd1c2ff350a8194e6304eb00f0a4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 14 16:23:18 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b77640fd
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1447514588 +0100
+    
+        Tag for commit b77640fd6e67a9fd3584b3a599859c9be8834ac0
+        gpg: Signature made Sat 14 Nov 2015 04:23:08 PM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b77640f Fedora 21->22: minor improvements
+
+[33mcommit a136e2799f2177066e0d676774dc22d2736acfa8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Nov 14 02:51:35 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_65390ee3
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1447465880 +0100
+    
+        Tag for commit 65390ee35a03463325b5582f6330df3106adfadc
+        gpg: Signature made Sat 14 Nov 2015 02:51:20 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        65390ee Fedora 21 -> Fedora 22 template upgrade
+
+[33mcommit 9987e96a774bd614e627246dfb448791357167eb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Nov 12 02:42:53 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_279b1c89
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1447292560 +0100
+    
+        Tag for commit 279b1c89a8c970644532a54e10f74a9e00825703
+        gpg: Signature made Thu 12 Nov 2015 02:42:40 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        279b1c8 Managing VM kernel documentation, including PV GRUB
+
+[33mcommit 38678f5e63e36927d86570613b2e86912edf35b9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 9 01:58:59 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_b92bedd3
+        tagger Axon <axon@openmailbox.org> 1447030704 +0000
+    
+        Tag for commit b92bedd3129125cfc985e48f16269445cfe0e56f
+        gpg: Signature made Mon 09 Nov 2015 01:58:24 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b92bedd Make separation of internals section more pronounced
+
+[33mcommit 64b6b327fc39d9834dc2161aff3e112dc4e56242[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 9 01:21:01 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_bffa21f6
+        tagger Axon <axon@openmailbox.org> 1447028433 +0000
+    
+        Tag for commit bffa21f6134301e27d8f746f9a8667ff44148088
+        gpg: Signature made Mon 09 Nov 2015 01:20:33 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        bffa21f Make direct links to internals sections (QubesOS/qubes-issues#1392)
+
+[33mcommit f67129339136d39f37281691b9ea8702d565f323[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Nov 9 01:16:30 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_3fe2f6e6
+        tagger Axon <axon@openmailbox.org> 1447028159 +0000
+    
+        Tag for commit 3fe2f6e6aa384a0c929067c18e92c09fee9bf93f
+        gpg: Signature made Mon 09 Nov 2015 01:15:59 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3fe2f6e Rewrite qrexec docs (fixes QubesOS/qubes-issues#1392)
+
+[33mcommit de60a79e59106487aab3969f5b713f12bf604bb6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 8 02:47:11 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_6b9223ec
+        tagger Axon <axon@openmailbox.org> 1446947193 +0000
+    
+        Tag for commit 6b9223ec9af327eafdf313a058052eae3ec7cf1d
+        gpg: Signature made Sun 08 Nov 2015 02:46:34 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6b9223e Update intro and wrap lines
+
+[33mcommit 77a0d9bd4e4c9d91d80a687534e936474fd48c0d[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Nov 8 01:06:32 2015 +0000
+
+    Update README
+
+[33mcommit d02610e40a6fc71937410470e9b2134bfe0f28a8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 8 02:06:24 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_49c5e763
+        tagger Axon <axon@openmailbox.org> 1446944754 +0000
+    
+        Tag for commit 49c5e763b9a35b777c43f3875a79821171b3c2db
+        gpg: Signature made Sun 08 Nov 2015 02:05:56 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        49c5e76 Update README
+
+[33mcommit d9d368185c7812863c5146f1db2132bded6fe374[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Nov 8 00:58:00 2015 +0000
+
+    Update README
+
+[33mcommit f0072f5439c96650d2dc75fd92d05b90a03201aa[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 8 01:18:10 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_be65e57a
+        tagger Axon <axon@openmailbox.org> 1446941850 +0000
+    
+        Tag for commit be65e57a4f0af15b67aaa663fcfa0ac157777a20
+        gpg: Signature made Sun 08 Nov 2015 01:17:31 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        be65e57 Do not explicitly use curl to verify torified connectivity
+
+[33mcommit 576b1c1555a792f2931b571a3618a82edad19f37[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Nov 8 01:12:55 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_81171790
+        tagger Axon <axon@openmailbox.org> 1446941547 +0000
+    
+        Tag for commit 811717903c13e276f30ad9694e4f335d75ad21f3
+        gpg: Signature made Sun 08 Nov 2015 01:12:28 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8117179 Merge pull request #55 from Rafiot/patch-1
+        77ac6ca Fix typo
+
+[33mcommit d69983e72e8385cc047f0a40d111b14d5046980b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Nov 5 17:15:37 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_f15cb936
+        tagger Axon <axon@openmailbox.org> 1446740111 +0000
+    
+        Tag for commit f15cb93628c1bef97243ebc86083ca6ba5531cc7
+        gpg: Signature made Thu 05 Nov 2015 05:15:12 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f15cb93 Merge pull request #54 from erihe251/patch-1
+        45096bc Fixed broken link
+
+[33mcommit be774ca2a0b0823dd5ee16185e54e5a957560c7b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Nov 4 21:16:14 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_be451b60
+        tagger Axon <axon@openmailbox.org> 1446668152 +0000
+    
+        Tag for commit be451b60aa01c767684b476529f089516ea5c72c
+        gpg: Signature made Wed 04 Nov 2015 09:15:53 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        be451b6 Merge branch 'master' of github.com:QubesOS/qubes-doc
+        da05b91 Fix Markdown syntax and clean up text
+        701a95d Merge pull request #52 from adrelanos/patch-8
+        9fe0521 Update vpn.md
+
+[33mcommit 517e488b8889acba91b9cab27118478c98d72f11[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Oct 30 07:03:29 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_04eea587
+        tagger Axon <axon@openmailbox.org> 1446184977 +0000
+    
+        Tag for commit 04eea5872c271f2d5155c2c0183ba9cc8f92c8f5
+        gpg: Signature made Fri 30 Oct 2015 07:02:56 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        04eea58 Fix typo
+        b5fb31c Merge pull request #51 from b4dger/patch-3
+        f762fe6 Merge pull request #50 from b4dger/patch-2
+        5379ff6 Update full-screen-mode.md
+        6860ccd Update install-nvidia-driver.md
+
+[33mcommit 0f9f34f7bdf6d9835fbfe365e99deeb978ae8fdd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Oct 30 06:59:15 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_bf3fc175
+        tagger Axon <axon@openmailbox.org> 1446184737 +0000
+    
+        Tag for commit bf3fc175b37ab2f667b679ec0455de2e612c7aab
+        gpg: Signature made Fri 30 Oct 2015 06:58:57 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        bf3fc17 Merge branch 'master' of github.com:QubesOS/qubes-doc
+        b88132a Merge pull request #49 from b4dger/patch-1
+        4b7498d Update security bulletins
+        447cd2a Update out-of-memory.md
+        362c028 Merge pull request #48 from JCCR/patch-1
+        9f88935 Fix typo on intro page
+
+[33mcommit 04c4c917b91b4c06317de07c73ce68c5c661c911[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Oct 28 22:18:14 2015 +0000
+
+    Remove en/ from URLs (QubesOS/qubes-issues#1333)
+
+[33mcommit 14773578b32e9bc34787381ccfec6bec7307ba48[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Oct 28 23:17:45 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_fc385586
+        tagger Axon <axon@openmailbox.org> 1446070637 +0000
+    
+        Tag for commit fc385586b6f7fe5207d3ed50fc81b3bd241e6ac7
+        gpg: Signature made Wed 28 Oct 2015 11:17:17 PM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        fc38558 Remove en/ from URLs (QubesOS/qubes-issues#1333)
+        2e68758 Remove en/ directory (QubesOS/qubes-issues#1333)
+
+[33mcommit 5401d2241c3c10dcbe38074458d0121cfdd5aa0c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 26 03:01:40 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b30b7d26
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1445824890 +0100
+    
+        Tag for commit b30b7d266b269c69cd685ae9f62f5f72184e04a4
+        gpg: Signature made Mon 26 Oct 2015 03:01:30 AM CET using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b30b7d2 hvm-create: remove duplicated ToC and Windows tools chapter
+
+[33mcommit 2197976476438c68e62f2349c90519b1c46baf6e[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 26 01:27:56 2015 +0000
+
+    Add margin-top to h1
+
+[33mcommit 3792d54a756d854abe7d6a2635c727ca5aa969a8[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 26 01:21:03 2015 +0000
+
+    Fix source links
+
+[33mcommit 64df20c6edb1f2d85b49f46e27f5882f7002e40d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 26 02:17:17 2015 +0100
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_d9a83248
+        tagger Axon <axon@openmailbox.org> 1445753680 +0000
+    
+        Tag for commit d9a832484c6e64e10ea9b069e85bffe714ce75d5
+        gpg: Signature made Sun 25 Oct 2015 07:14:42 AM CET using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d9a8324 Fix headers
+
+[33mcommit 244f206836ef7ad2d6739e7b2334daabe396b504[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 26 00:46:40 2015 +0000
+
+    Fix layouts and hide broken source links
+
+[33mcommit e015ee437a327c3cf7bd60939b44cdbf39754eaf[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 25 06:09:14 2015 +0000
+
+    Implement tocmd-generator
+
+[33mcommit 880efb322735f3fe2052cf7dc52617e32a4a0b50[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 25 03:50:38 2015 +0000
+
+    Revert relative_path change
+
+[33mcommit 5b67f0549631068e46a170253f7bc7a06073258d[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 25 03:48:12 2015 +0000
+
+    Use relative_path
+
+[33mcommit bbc583b67f9dbd5117cee71c0ed64646d3dfbbec[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 25 03:27:00 2015 +0000
+
+    Improve source link styling
+
+[33mcommit aa81175c2bad31601ebb17c3ece2bb76f2ec090a[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 25 03:07:20 2015 +0000
+
+    Create source and edit links on all "doc" layout pages
+
+[33mcommit e8f798059a6804c8609faf5829f927acafcee6ba[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Oct 24 21:42:46 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_d30012b1
+        tagger Axon <axon@openmailbox.org> 1445715739 +0000
+    
+        Tag for commit d30012b1a7e8bba72362b7691639810b5104f6d6
+        gpg: Signature made Sat 24 Oct 2015 09:42:21 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d30012b Create page and entry on recording optical discs
+        9e2e040 Update information about recording optical discs
+
+[33mcommit a372c47707501b4b71435863b9fc90091d0c4ce5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 22 12:37:23 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_bc592c7a
+        tagger Axon <axon@openmailbox.org> 1445510229 +0000
+    
+        Tag for commit bc592c7a99a99c213a795dc12b2862b16ebaf6d8
+        gpg: Signature made Thu 22 Oct 2015 12:37:10 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        bc592c7 Update backup-restore
+
+[33mcommit 40542843933e0e190073768ab707f72f8232ecb1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 22 06:05:34 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_4ffd590f
+        tagger Axon <axon@openmailbox.org> 1445486720 +0000
+    
+        Tag for commit 4ffd590f7850872bc4800878b86e7d874604c71d
+        gpg: Signature made Thu 22 Oct 2015 06:05:21 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4ffd590 Update KDE and XFCE entries
+        c68112a Update heading and add mailing list link
+
+[33mcommit b2039b1645dfefce651b9467ccd658aaffd0c07c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 22 05:53:58 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_231a3b9d
+        tagger Axon <axon@openmailbox.org> 1445486022 +0000
+    
+        Tag for commit 231a3b9dcf204d42f72e7f7cff2f8d2554f62877
+        gpg: Signature made Thu 22 Oct 2015 05:53:43 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        231a3b9 Create KDE page
+
+[33mcommit df0f0fe3f6207dc6b25e0f97726f3f8cb541616b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 22 05:42:09 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_480b348f
+        tagger Axon <axon@openmailbox.org> 1445485315 +0000
+    
+        Tag for commit 480b348f4ac9a98a3a205531900f77d9ec6c62ed
+        gpg: Signature made Thu 22 Oct 2015 05:41:55 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        480b348 Create table of contents
+
+[33mcommit 63f9aa5cd47aebe64e816d93d6d63bc1a069661d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 22 05:18:04 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_c4e5573f
+        tagger Axon <axon@openmailbox.org> 1445483867 +0000
+    
+        Tag for commit c4e5573f7ee10165860eb9824db5f464fa68eb46
+        gpg: Signature made Thu 22 Oct 2015 05:17:48 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c4e5573 Add link to the marmarek git repo (fixes QubesOS/qubes-issues#1330)
+
+[33mcommit ef7390df31ecf4d1a8abecf55b8db317a5dbeb24[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Oct 17 03:57:24 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_5cf41e5e
+        tagger Axon <axon@openmailbox.org> 1445046981 +0000
+    
+        Tag for commit 5cf41e5efa4648cc1d54ece1c421696e060846cc
+        gpg: Signature made Sat 17 Oct 2015 03:56:21 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        5cf41e5 Add Olivier Medoc's template customization guides
+        a203cc4 Merge pull request #47 from ptitdoc/master
+        6cfcb68 markdown fixes
+        24ee9e3 markdown fixes
+        448c495 markdown: minor newline fixe
+        94bad71 markdown: fix newlines
+        fa39cd4 markdown: remove tabs
+        08e1b2b markdown improvement
+        8133ac8 markdown fixes
+        64abdf5 custom templates: initial versions for fedora and windows
+
+[33mcommit adaf483e8e15ccb30ab5bb92a9ee8da04db554b0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Oct 17 03:42:33 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_dd73066e
+        tagger Axon <axon@openmailbox.org> 1445046134 +0000
+    
+        Tag for commit dd73066eb39e6b631caeaa85a1ae38927db76f22
+        gpg: Signature made Sat 17 Oct 2015 03:42:14 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        dd73066 Add entry on TemplateBasedVM directories (QubesOS/qubes-issues#1336)
+        7afe80d Rewrite and add notes on TemplateBasedVM directories (QubesOS/qubes-issues#1336)
+        00fd49c Fix typos
+
+[33mcommit 068ab80156f731bc5c1dc18d33c1d60ad63b2bbc[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Oct 16 02:30:42 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_a1999e6f
+        tagger Axon <axon@openmailbox.org> 1444955406 +0000
+    
+        Tag for commit a1999e6f098b753182940627090a04366c196602
+        gpg: Signature made Fri 16 Oct 2015 02:30:06 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a1999e6 Add note regarding TemplateBasedVM directory inheritance and persistence (fixes QubesOS/qubes-issues#1336)
+
+[33mcommit 5661a507e0bbbe94e7206855608aed23b905a10c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 15 14:02:45 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_59a101e2
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1444910548 +0200
+    
+        Tag for commit 59a101e2ba930e504ec0397022cdc4d4f9d92280
+        gpg: Signature made Thu 15 Oct 2015 02:02:28 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        59a101e Add missing source verification to builder instruction
+
+[33mcommit 7179b34fbd2f7d9da19a1fdda994bff8665f32be[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 15 08:06:20 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_b219adda
+        tagger Axon <axon@openmailbox.org> 1444889138 +0000
+    
+        Tag for commit b219addad5803dcd9483eeabcb729a643c4c05ea
+        gpg: Signature made Thu 15 Oct 2015 08:05:38 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b219add Add links to Olivier's template customization guides
+
+[33mcommit bdeda280e0b42e5961a163a15a9b6bbe396ae85b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 15 07:50:10 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_31f068e1
+        tagger Axon <axon@openmailbox.org> 1444888135 +0000
+    
+        Tag for commit 31f068e17973f6175a80fd9e89707010920c25f9
+        gpg: Signature made Thu 15 Oct 2015 07:48:54 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        31f068e Merge branch 'mfc-patch-4'
+        0d461f8 added additional 64-bit justification
+
+[33mcommit 580bc982209609d73e7fbaf23e20b7fe1b27a6de[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Oct 14 05:33:57 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_6deb63eb
+        tagger Axon <axon@openmailbox.org> 1444793563 +0000
+    
+        Tag for commit 6deb63ebcb56d3f4cda69543b8da8128edf34b53
+        gpg: Signature made Wed 14 Oct 2015 05:32:43 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6deb63e Update page titles from CamelCase to lowercase-hyphen-separated (closes QubesOS/qubes-issues#1205)
+
+[33mcommit 30aca364d717b5e26a528cad4048e9f4bf5719ad[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Oct 14 05:00:55 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_e0a4b9e5
+        tagger Axon <axon@openmailbox.org> 1444791634 +0000
+    
+        Tag for commit e0a4b9e576552d3e5189a8364e780344ce8dc9a2
+        gpg: Signature made Wed 14 Oct 2015 05:00:34 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e0a4b9e Rename all files from CamelCase to lowercase-hyphen-separated
+
+[33mcommit 7f37974434bb619fd541e8d07a53218ecd2e7cbb[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Oct 14 02:08:37 2015 +0000
+
+    Update page title
+
+[33mcommit 7601b841bf397494f62af36191c1a4dd047e315e[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Oct 14 02:06:24 2015 +0000
+
+    Minor wording change
+
+[33mcommit 1869e0964442f2d13c0fc2667751dcea5f1cc808[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Oct 14 02:01:39 2015 +0000
+
+    Update Partners page (fixes QubesOS/qubes-issues#1247)
+    
+     * Update page content in accordance with QubesOS/qubes-issues#1247
+     * Add link to nav bar
+     * Shorten "Introduction" to "Intro" to make room for "Partners"
+       on nav bar
+
+[33mcommit 06203c7455f012c36707a28620c15bbbc3ac9f62[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 12 18:27:21 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_657cbcb1
+        tagger Axon <axon@openmailbox.org> 1444667226 +0000
+    
+        Tag for commit 657cbcb1b85c2c546d554cf2a7d10ed251935d52
+        gpg: Signature made Mon 12 Oct 2015 06:27:05 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        657cbcb Update links
+
+[33mcommit c0a4bab8db14554bba281bee4143d8508725c14b[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 16:12:33 2015 +0000
+
+    Update list link to Security
+
+[33mcommit 1348eb3aeb72e29f94022785bd1974318030ced9[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 16:11:14 2015 +0000
+
+    Update nav-bar link to Security
+
+[33mcommit 6ec3b30fd44ebd0f9712e901d0d0d89775f6683a[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 16:10:05 2015 +0000
+
+    Move from qubes-doc
+    
+    This page is not part of the documentation for Qubes OS.
+    (It does not directly contain any security information relevant to
+    using Qubes OS.) Rather, it is a page containing security
+    information for the Qubes OS *Project* as a whole.
+
+[33mcommit a9cc80731b8e7f10b2974f460ca539c6c1ce911c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 12 18:09:39 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_d1a2e195
+        tagger Axon <axon@openmailbox.org> 1444666164 +0000
+    
+        Tag for commit d1a2e1958f94cea5b40dfe0f8c10324fc7368bb9
+        gpg: Signature made Mon 12 Oct 2015 06:09:24 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d1a2e19 Move to qubesos.github.io repo
+
+[33mcommit ede56ce4ddf0384b4f6a611e7d9d57990ebc27ce[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 15:52:34 2015 +0000
+
+    Organize team/people/community/help pages (QubesOS/qubes-issues#1247)
+    
+    The "Community" page was actually a help page, so it's now more
+    accurately named "Help". However, it's important to acknowledge
+    the community, so I've added a section on the "Team" page doing so.
+    The "Team" page was renamed from "People".
+    
+    Also added a nav-bar link to the Security page.
+
+[33mcommit 716c7383af1f6ecdc59e470a627dd20014e38b13[m
+Merge: bd34198 84b78f2
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 15:49:32 2015 +0000
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit 84b78f2d8f4ec19bae82bdb7a670d50a08c41a37[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 12 17:20:40 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_9158d228
+        tagger Axon <axon@openmailbox.org> 1444663226 +0000
+    
+        Tag for commit 9158d2284fec5e2a7c7050ee3c348c818846a49c
+        gpg: Signature made Mon 12 Oct 2015 05:20:26 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9158d22 Consolidate security pages and add relevant entries to ToC
+
+[33mcommit 00e79fa64955a9f5a166b8a5365adfa3c14c00dd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 12 16:54:15 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_745718be
+        tagger Axon <axon@openmailbox.org> 1444661641 +0000
+    
+        Tag for commit 745718be7eca6ab3a3041d2e9bfd39caa5750b66
+        gpg: Signature made Mon 12 Oct 2015 04:54:00 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        745718b Update links
+
+[33mcommit bd3419873de5be277b7f8971ed89d3056a00b4c1[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 14:42:00 2015 +0000
+
+    Clean up list of links
+
+[33mcommit c1ce99aa6c8b2ea63b5e0e48948a831b7996cc7d[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 14:34:50 2015 +0000
+
+    Remove "Beyond Qubes R2" bullet point
+    
+    I recently added a link to the same blog post in the main
+    description, a few lines above. In addition, Qubes R3.0 has
+    now been released, so the phrase "Beyond Qubes R2" sounds
+    somewhat antiquated.
+
+[33mcommit 5d9f934defa124bb198b220c033ab6eeea31835f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 12 14:55:48 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_4d725e68
+        tagger Axon <axon@openmailbox.org> 1444654532 +0000
+    
+        Tag for commit 4d725e681b26f59d241cff8aee6aa95a5254dc03
+        gpg: Signature made Mon 12 Oct 2015 02:55:32 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4d725e6 Clean up formatting
+
+[33mcommit 692132878f3ac061fa5fd4914792b5611ec2f093[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 12:42:49 2015 +0000
+
+    Update home page links
+
+[33mcommit a7982c5d4433c7f211570792c1b41cd7ee649b44[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 12:25:25 2015 +0000
+
+    Replace download link with announcement link for old releases
+
+[33mcommit d6aa94385500a334ef5e9b52c1cf05f8ac88f73c[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 12:20:40 2015 +0000
+
+    Add lots of old news entries
+
+[33mcommit e4b68b375f0ac728d7a52bccad4594d127a1761a[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 11:49:04 2015 +0000
+
+    Revamp Qubes OS News
+    
+     * Create dedicated Qubes OS News Archives page
+     * Move all news entries to dedicated News page
+     * Restrict news on home page to events from the past year
+     * Use ISO 8601 date format
+     * Eliminate unnecessary bullet points
+
+[33mcommit 5db1495e036578d70868f192d5b5569953700b08[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 11:25:23 2015 +0000
+
+    Remove redundant site title from footer
+
+[33mcommit cadffc616c14f983b407e31b487a40afd757060a[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 10:56:09 2015 +0000
+
+    Remove cancelling floats
+
+[33mcommit c690e11b1f6daacb456c84a4989b107d3eda9114[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 10:42:07 2015 +0000
+
+    Replace description with search box (fixes QubesOS/qubes-issues#1093)
+
+[33mcommit b8ab7c4d6761194d27c4a41e3c70225aa691fbfb[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 09:48:30 2015 +0000
+
+    Update Downloads page (fixes QubesOS/qubes-issues#1114)
+    
+     * Update URLs
+     * Clarify page titles
+     * Add link to release-specific PGP key next to each ISO
+     * Add link to verifying-signatures page along with each set of
+       links to "verification files" (hash digests, signatures,
+       and signing keys)
+     * Shorten names of verification files to make room for everything
+
+[33mcommit d531b854c6d5de41a5353f38df3b42baf248acc4[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 08:37:43 2015 +0000
+
+    Add CSS margins around Qubes icon
+
+[33mcommit c4aa17e2c0a87f7b38767382acf2cf85cf200e76[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 07:35:17 2015 +0000
+
+    Turn Qubes icon into a home page link
+
+[33mcommit b6c1ce79387e5f7577915d03536b71e8f1f5bc1e[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 07:30:14 2015 +0000
+
+    Change Qubes icon float direction (fixes QubesOS/qubes-issues#1327)
+
+[33mcommit 2bb05bd5b6757f6dd3fe0593763213d862aaf2a8[m
+Merge: c3b9526 5f2e4d2
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Oct 12 00:04:02 2015 -0700
+
+    Merge pull request #6 from ypid/use_jekyll_serve_watch
+    
+    Use `jekyll serve --watch` to make testing faster.
+
+[33mcommit c3b952643aead5c70d072f04d095a02621ba6f53[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Oct 12 08:59:59 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_d4b5d409
+        tagger Axon <axon@openmailbox.org> 1444633186 +0000
+    
+        Tag for commit d4b5d40927794aa22b4d0bfc208178eee334db09
+        gpg: Signature made Mon 12 Oct 2015 08:59:45 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d4b5d40 Merge pull request #45 from adrelanos/patch-7
+        7582ca5 minor
+
+[33mcommit dd2b12b515acec7a19b99bb161914470532a81a3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Oct 11 10:10:12 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_01946d67
+        tagger Axon <axon@openmailbox.org> 1444550158 +0000
+    
+        Tag for commit 01946d67dfb458b451d0e3d5d16ea663b414a587
+        gpg: Signature made Sun 11 Oct 2015 09:56:01 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        01946d6 Remove `/en/` from select pages
+
+[33mcommit b0eb715df37c81a14969f9f10f797a3dc08c1a13[m
+Merge: 201e9a6 2619d56
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 11 08:07:23 2015 +0000
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit 201e9a60439a14e6641d92358c27db816e1d9431[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 11 08:01:21 2015 +0000
+
+    Remove `/en/` from select pages
+
+[33mcommit 2619d56c72077326878d133f4289c35efddd4a38[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Oct 11 09:30:24 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_a91496e9
+        tagger Axon <axon@openmailbox.org> 1444548607 +0000
+    
+        Tag for commit a91496e9d6a827e516d6568d1dec3f0c2d9ad0e2
+        gpg: Signature made Sun 11 Oct 2015 09:30:10 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a91496e Move current pages to `/en/` subdirectory
+
+[33mcommit 524a1af7e0f2bd7f4cec874469a2c0a46f8e0cb8[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 11 07:25:10 2015 +0000
+
+    Move current subpages to `/en/` subdirectory
+
+[33mcommit ac1b47c45d29b1b3578189a45b33caf2a3e29e4a[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 11 07:20:32 2015 +0000
+
+    Postpend `/en/` to Home link
+
+[33mcommit 80bdc7e5a5e178376e74e527633a20030ac42950[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 11 07:16:25 2015 +0000
+
+    Prefix all current subpages with `/en/`
+
+[33mcommit bcdf8d46b5e82ef2fe9640e5ff8f92af475758b5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Oct 11 09:07:50 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_f3ee78f2
+        tagger Axon <axon@openmailbox.org> 1444547246 +0000
+    
+        Tag for commit f3ee78f2237b6b2b1275fdaf49afff96c11e9a7d
+        gpg: Signature made Sun 11 Oct 2015 09:07:28 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        f3ee78f Change URIs from CamelCase to lowercase-hyphen-separated
+
+[33mcommit fe7bd4bec33eae3cb9af8fee369df8690d643d2e[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 11 06:14:26 2015 +0000
+
+    Update description
+
+[33mcommit b74c2aff35bbcf0b510ad31fe0ee8e4fc733de22[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 11 06:06:42 2015 +0000
+
+    Uncomment 3.0 mirrors.kernel.org links
+    
+      Also, change general mirror.kernel.org link from HTTP to HTTPS.
+
+[33mcommit eb0ea1b402a70c5c3bef5030c37387bca72b4bbb[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sun Oct 11 05:41:30 2015 +0000
+
+    Add link to Motherboard article
+
+[33mcommit 5265a0fe9d7799e1b5d0bfc961ce540c806c52e3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 8 02:55:22 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_bb5fb465
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1444265020 +0200
+    
+        Tag for commit bb5fb465271f5058c7d9f1b3e995525e71e226f4
+        gpg: Signature made Thu 08 Oct 2015 02:43:40 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        bb5fb46 Some more code blocks fixes
+        b1b09f6 merged QubesBuilder.md
+        a08bd91 merged AutomatedTests.md
+        39ef737 replaced all github flavored code blocks with fenced kramdown code blocks
+        df467ba the tilde syntax is easier to read with html code block than normal markdown
+        75b7c36 UserFaq basic markdown block
+        4dbccc3 Merge remote-tracking branch 'upstream/master'
+        b65aa75 basics and customization fenced blocks replaced with standard markdown
+
+[33mcommit 75a56309e97cf10b72a8a69bc58ec27c0f0b594a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Oct 7 22:33:41 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_4421bdf4
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1444250010 +0200
+    
+        Tag for commit 4421bdf46e5a2a20642d680f7bbdb41c544d812d
+        gpg: Signature made Wed 07 Oct 2015 10:33:30 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        4421bdf Fix formatting in QubesBuilder
+
+[33mcommit 20c59a8866a5aac55ba2cc88a9c6a48c3d5767e3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Oct 7 09:10:58 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_70d3037c
+        tagger Axon <axon@openmailbox.org> 1444201835 +0000
+    
+        Tag for commit 70d3037c8c12718adbbe33331d51c5617a47f90a
+        gpg: Signature made Wed 07 Oct 2015 09:10:36 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        70d3037 Add permission modification step
+
+[33mcommit 380746cba39625cd2fc675deab6170fc56ca6d50[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Oct 7 02:09:33 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_eb83895c
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1444176562 +0200
+    
+        Tag for commit eb83895cdab4e1666be8471072ca8347f743e8df
+        gpg: Signature made Wed 07 Oct 2015 02:09:22 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        eb83895 Fix arch-spec-0.3.pdf link in a couple more places
+
+[33mcommit 90edb2e0f35addc4dd81e02a0884d3613ce6665c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Oct 7 02:07:14 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b5bb6752
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1444176422 +0200
+    
+        Tag for commit b5bb6752d2252f1df8c72c135002bbcbfc3c4f16
+        gpg: Signature made Wed 07 Oct 2015 02:07:02 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b5bb675 Add link to original architecture document
+
+[33mcommit 78f9f57338ac2ed8713d0f205c56f9c8c327d877[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Oct 7 01:59:24 2015 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag mm_36167853
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1444175953 +0200
+    
+        Tag for commit 36167853ec7418b64b3d3fd1789ef422713176eb
+        gpg: Signature made Wed 07 Oct 2015 01:59:13 AM CEST using RSA key ID 42CFA724
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes OS signing key) <marmarek@invisiblethingslab.com>"
+    
+        3616785 Add original architecture document
+
+[33mcommit d4e764af1ae1352660f0e222a4687b5faaa3b9ea[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Oct 7 01:02:05 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_d4e41dda
+        tagger Axon <axon@openmailbox.org> 1444172489 +0000
+    
+        Tag for commit d4e41ddace71e4f61f24ffd41bef5f4ea434a1c0
+        gpg: Signature made Wed 07 Oct 2015 01:01:29 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d4e41dd Add troubleshooting tip
+
+[33mcommit 19daf5607c8c6a96ba728391051659b468466d58[m
+Author: Michael Carbone <mfc@riseup.net>
+Date:   Mon Oct 5 05:20:26 2015 -0400
+
+    adding myself to people/team page
+    
+    feel free to change description.
+
+[33mcommit f31f42ba2c2c552ee0af561bc0e8d8a08c58b2aa[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Oct 3 02:22:47 2015 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag axon_e59e0de7
+        tagger Axon <axon@openmailbox.org> 1443831727 +0000
+    
+        Tag for commit e59e0de7a9e480fca8e198a35d04ca28fed1fe58
+        gpg: Signature made Sat 03 Oct 2015 02:22:07 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        e59e0de Add losslessly compressed version of image
+
+[33mcommit dc73d957bc0ac035cdca1b182ae38f8f7fe2dc01[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sat Oct 3 00:09:23 2015 +0000
+
+    Create Partners page
+
+[33mcommit 17bdb17c1cdf8fe8040a0ec0fd3f9b110b3b2ddf[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Oct 3 01:36:10 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_31b71489
+        tagger Axon <axon@openmailbox.org> 1443828941 +0000
+    
+        Tag for commit 31b71489d7d417e07b599ca2833432d70792d1c8
+        gpg: Signature made Sat 03 Oct 2015 01:35:41 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        31b7148 Fix typo
+
+[33mcommit f56443b3f3cf572d928569397acdff29b1211483[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Oct 2 23:52:09 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_56daa2ad
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1443822718 +0200
+    
+        Tag for commit 56daa2ad5293d9fe04e4d964ebaf61b7cfe31496
+        gpg: Signature made Fri 02 Oct 2015 11:51:58 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        56daa2a Fix URL in 3.0 release notes
+
+[33mcommit a28562cd45b41066396b86d4e3c5e15e18fae5d1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Oct 2 11:49:18 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_78ceab8b
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1443779345 +0200
+    
+        Tag for commit 78ceab8b044554796b6f9c2ef4dd4179cb787ac9
+        gpg: Signature made Fri 02 Oct 2015 11:49:05 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        78ceab8 VersionScheme: fix typo in image URL
+
+[33mcommit 99a199a2bd83a8fd9684ea65f568c78661e63efb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Oct 2 03:41:20 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag w_505426a0
+        tagger Wojtek Porczyk <woju@invisiblethingslab.com> 1443724067 +0200
+    
+        Tag for commit 505426a063f3f72b63095899482099488822bcd7
+        gpg: Signature made Thu 01 Oct 2015 08:27:47 PM CEST using RSA key ID 3C677AEC
+        gpg: Good signature from "Wojtek Porczyk (Qubes Documentation Signing Key) <woju@invisiblethingslab.com>"
+    
+        505426a VersionScheme: illustration and table border
+        8510848 releases/todo: add reminder about updating installation instructions
+
+[33mcommit edf40bcfd21ef7ca929a64b8943dfd3fda7981fe[m
+Author: Axon <axon@openmailbox.org>
+Date:   Fri Oct 2 01:16:28 2015 +0000
+
+    Update and clarify lanage around old releases
+
+[33mcommit 2a317453150f3f292cbc2e09cee38de4421895ba[m
+Author: Axon <axon@openmailbox.org>
+Date:   Fri Oct 2 01:09:25 2015 +0000
+
+    Update intro text
+
+[33mcommit 6986673ba345ce6b6d447f1a75a9a0e0fbbb2f45[m
+Author: Axon <axon@openmailbox.org>
+Date:   Fri Oct 2 00:30:37 2015 +0000
+
+    Add 3.0 announcement & clean up Recent News
+
+[33mcommit 0a6d9c9dc22f95fadde7ccc94963e6887bbb728b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 1 16:32:02 2015 +0200
+
+    Add new contributors
+
+[33mcommit 984f1a99301a67548cce4f5afdb8151d9689c90f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 1 16:31:53 2015 +0200
+
+    Fix dashes
+
+[33mcommit 6e28041cfcb0b4f0332c69c7acbf7186b525806a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 1 15:12:42 2015 +0200
+
+    Final R3.0 release
+
+[33mcommit 239314434d961d4389759d02f7e95eab66cec868[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 1 15:11:08 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_8aeecd5c
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1443705057 +0200
+    
+        Tag for commit 8aeecd5c6e62e7906cd90b635d0d1b2c40051921
+        gpg: Signature made Thu 01 Oct 2015 03:10:57 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        8aeecd5 Merge branch 'r3.0-release'
+        d9a890d Minor fixes to R3.0 release notes
+        b8fed71 More detailed R3.0 features list
+        0804955 Update R3.0 release notes
+
+[33mcommit 0f6662b2dc8f9664f0715300c1fbc7463051a51c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 1 00:49:06 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b6d76e8c
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1443653290 +0200
+    
+        Tag for commit b6d76e8cea00cb88020fd9c4c9c19c0868201691
+        gpg: Signature made Thu 01 Oct 2015 12:48:10 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b6d76e8 AutomatedTests: add missing link and screenshot
+
+[33mcommit 4b5b43f3dd973a4f744e8749d9a5c0078baf4da3[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Oct 1 00:47:59 2015 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag mm_2a4a19f4
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1443653258 +0200
+    
+        Tag for commit 2a4a19f4a5cb369f2351172be1fae44f9df5fd49
+        gpg: Signature made Thu 01 Oct 2015 12:47:38 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        2a4a19f Add automated tests screenshot
+
+[33mcommit 4e0f1d12d658a6bcfbe929b91d7a1761910f7d96[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Sep 26 05:17:07 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_6345b676
+        tagger Axon <axon@openmailbox.org> 1443237410 +0000
+    
+        Tag for commit 6345b676cd48799da2af9bc3939a0f620098d1fe
+        gpg: Signature made Sat 26 Sep 2015 05:16:50 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+
+[33mcommit 641ae9d2ade881a1b07fccdf64fb45acd4798b28[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Sep 26 04:30:51 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_bd877ddc
+        tagger Axon <axon@openmailbox.org> 1443234628 +0000
+    
+        Tag for commit bd877ddc545cce31519b10ff854584c358414708
+        gpg: Signature made Sat 26 Sep 2015 04:30:28 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        bd877dd Assign unsorted pages and delete deprecated/blank/test pages
+
+[33mcommit c9bddee64284782036fd91a897a3becb5a2f70e6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 24 10:52:05 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_c53dbe5c
+        tagger Axon <axon@openmailbox.org> 1443084712 +0000
+    
+        Tag for commit c53dbe5c2e3e2d26a2957669aa71c3be844b3e50
+        gpg: Signature made Thu 24 Sep 2015 10:51:52 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c53dbe5 Remove underscore from beginning of directory name
+
+[33mcommit 5f2e4d21ea841d892d5953ab99cf6bc6dfa7901f[m
+Author: Robin Schneider <ypid@riseup.net>
+Date:   Wed Sep 23 21:51:30 2015 +0200
+
+    Use `jekyll serve --watch` to make testing faster.
+    
+    * `jekyll build` takes its time to complete and `jekyll serve --watch`
+      only recompiles the changed files.
+
+[33mcommit 12dc47618b0bc4e20bf52dc31ff08223a3693486[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Sep 23 15:53:45 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_cbdd6e00
+        tagger Axon <axon@openmailbox.org> 1443016411 +0000
+    
+        Tag for commit cbdd6e00ab6a24ab3c58e6dce6ffe1741671670d
+        gpg: Signature made Wed 23 Sep 2015 03:53:31 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        cbdd6e0 Update URL
+
+[33mcommit 5155b365c5ffb26bfc91eb8022a0f2399582b441[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Sep 23 15:24:17 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_6a0c7579
+        tagger Axon <axon@openmailbox.org> 1443014641 +0000
+    
+        Tag for commit 6a0c757996445f88b7ede71730e47eb169586d06
+        gpg: Signature made Wed 23 Sep 2015 03:24:01 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6a0c757 Implement directory structure
+        892c099 Update URL
+
+[33mcommit 1be230b0f860d2e014f95fba795f2b49e1c6e9ab[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Sep 23 12:39:59 2015 +0000
+
+    Move documentation-related pages back into `qubes-doc`
+
+[33mcommit 768a190ee21db24c5b9fe3b1223abfabe0efe62e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Sep 23 14:39:47 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_b948b32a
+        tagger Axon <axon@openmailbox.org> 1443011970 +0000
+    
+        Tag for commit b948b32ae0a27b9a3665e5a5e5e15fdef8d34367
+        gpg: Signature made Wed 23 Sep 2015 02:39:30 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b948b32 Move documentation-related pages back into `qubes-doc`
+
+[33mcommit 63ec46a828f54ca15a881f14a850e7d52ed46235[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Sep 23 12:25:45 2015 +0000
+
+    Clean up formatting
+
+[33mcommit e6897d248f246863685072946f0753d5eef2b5e4[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Sep 23 12:02:22 2015 +0000
+
+    Unescape backticks
+
+[33mcommit 7a0029d34922824bb8f40c6c96bbe4a486605596[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Sep 23 11:39:46 2015 +0000
+
+    Deprioritize pages on upgrading old Fedora versions
+
+[33mcommit 5297aa6236b35e228cc4dee941514a4e3e0bd295[m
+Author: Axon <axon@openmailbox.org>
+Date:   Wed Sep 23 11:38:28 2015 +0000
+
+    Update Whonix entry
+
+[33mcommit b03e9771fadb8a07522bbeb71b2477d9a22be0e5[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 20:51:28 2015 +0000
+
+    Update URLs
+
+[33mcommit 9d32bf26d3546070ca2066cc25f0118a0afe0a6a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 22 21:24:57 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_41c6988d
+        tagger Axon <axon@openmailbox.org> 1442949881 +0000
+    
+        Tag for commit 41c6988d8b5a9dfa1e56da4d07186d850d2872b4
+        gpg: Signature made Tue 22 Sep 2015 09:24:41 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        41c6988 Fix pluralization
+
+[33mcommit 3a32dd8fcae6473b219c1cbd6356dc1d3668059f[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 19:19:13 2015 +0000
+
+    Rename "media" to "screenshots" (QubesOS/qubes-issues#1200)
+
+[33mcommit 4e1b8125de9c8fe31956a79680c2a1597c6ba433[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 22 21:05:16 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_dce44659
+        tagger Axon <axon@openmailbox.org> 1442948637 +0000
+    
+        Tag for commit dce446596fe79fcb06a2fd895dce5d82ad54f92e
+        gpg: Signature made Tue 22 Sep 2015 09:03:57 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        dce4465 Create section on verifying digests (QubesOS/qubes-issues#1077)
+
+[33mcommit 0b5e2459020a7fc1baa57cda00078ac9592168ee[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 22 20:13:55 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_6f90c5ef
+        tagger Axon <axon@openmailbox.org> 1442945619 +0000
+    
+        Tag for commit 6f90c5ef197622ce0a9ccaa8a6eec90e803f9814
+        gpg: Signature made Tue 22 Sep 2015 08:13:39 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6f90c5e Fix code blocks and escapes
+
+[33mcommit b45cc4e17e68e5db643c15f7aa88e54005924bb1[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 22 20:01:38 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_d52ca153
+        tagger Axon <axon@openmailbox.org> 1442944871 +0000
+    
+        Tag for commit d52ca1538b4ae74348469b6149c4c481648ab538
+        gpg: Signature made Tue 22 Sep 2015 08:01:11 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        d52ca15 Fix formatting
+
+[33mcommit b2abb640ba86dfcc28bad81e2bdf1e1a57646c95[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 22 19:30:46 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_0979ba26
+        tagger Axon <axon@openmailbox.org> 1442943027 +0000
+    
+        Tag for commit 0979ba26275230f2fa7b731fc593affadcf0ebd4
+        gpg: Signature made Tue 22 Sep 2015 07:30:27 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        0979ba2 Fix code blocks and update subkey section
+
+[33mcommit 0dcfb6569fd50ff49ddab82fabc4a893368ae229[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 22 18:28:16 2015 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag axon_ecb4a6a3
+        tagger Axon <axon@openmailbox.org> 1442939280 +0000
+    
+        Tag for commit ecb4a6a325cfa2f68f81ac95f78587833b0b7d51
+        gpg: Signature made Tue 22 Sep 2015 06:28:01 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ecb4a6a Eliminate superfluous subdirectory
+
+[33mcommit 28cb0d9f66d7a7f04e5c537e5a3c54ee10302f9a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 22 18:26:58 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_c031ef1a
+        tagger Axon <axon@openmailbox.org> 1442939202 +0000
+    
+        Tag for commit c031ef1a0817395fa87413f0ebf634a68083eabf
+        gpg: Signature made Tue 22 Sep 2015 06:26:42 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        c031ef1 Rename attachment paths
+
+[33mcommit cdc79e8f84e996fe7e7b4b4feb491e124afd8349[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 16:12:02 2015 +0000
+
+    Add link to @Puri_sm tweet re: Qubes certified laptops
+
+[33mcommit ec302c1cccba98bc9ef8c6addf2becb1d834e84e[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 16:03:09 2015 +0000
+
+    Reconcile duplicate doc pages
+
+[33mcommit ac54d0d33d646ddac237dcffaf3554110f82b57a[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 15:58:37 2015 +0000
+
+    Add missing page; fix URL and naming
+
+[33mcommit 00ac5880babe6cbde74500e0b55d6c3329f1c353[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 15:41:06 2015 +0000
+
+    Add Qubes Live USB entry and clarify other release statuses
+
+[33mcommit 5372efe81f984cc010ab747d212af2605d7c0ef7[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 11:56:11 2015 +0000
+
+    Streamline downloads page
+
+[33mcommit 3adf4033ecd691cc34576cb4bbd8ca0fae8e4791[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 11:27:00 2015 +0000
+
+    Add links to digests
+
+[33mcommit 656e16af0fa865021ba3b7c04bf3fbe5a1a5c4f0[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 11:15:05 2015 +0000
+
+    Update doc-guidelines URL
+
+[33mcommit ad4f7af557b10a13fd7bd2e0db69a1ba00a2ed4e[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 11:11:48 2015 +0000
+
+    Incorporate troubleshooting and dev documentation
+
+[33mcommit 1ac9f60633d5b031fae14d68236d78764cce6a65[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 10:41:57 2015 +0000
+
+    Remove "Recent News" from 2013
+
+[33mcommit 97d135d6aeae98b36d0c74499b6b72861137631e[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 22 12:37:11 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_2d7f823a
+        tagger Axon <axon@openmailbox.org> 1442918215 +0000
+    
+        Tag for commit 2d7f823a53e8b8619ebb3d64ed7e366ab0813b62
+        gpg: Signature made Tue 22 Sep 2015 12:36:56 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        2d7f823 Activate URL
+
+[33mcommit d12e9304ff900db5dfa009c2426c3f004deb43e7[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 22 12:32:50 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_07a650e2
+        tagger Axon <axon@openmailbox.org> 1442917954 +0000
+    
+        Tag for commit 07a650e258f6e10436f9274d9f0112d7666d9d43
+        gpg: Signature made Tue 22 Sep 2015 12:32:34 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        07a650e Update documentation contribution guidelines
+        5f040b3 Create README
+
+[33mcommit 1217bd844af969e00d1d322d51e72c621aad8357[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 22 11:02:45 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_cfa58808
+        tagger Axon <axon@openmailbox.org> 1442912550 +0000
+    
+        Tag for commit cfa58808288fe497f56b2260f5b6c75f3771c162
+        gpg: Signature made Tue 22 Sep 2015 11:02:30 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        cfa5880 Fix redirects
+
+[33mcommit ad471b6e23d7746416586db96b224ab3abb12afb[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 08:55:44 2015 +0000
+
+    Fix redirects
+
+[33mcommit 279aa1dfe03623c9ed812bee389c549bd141104c[m
+Merge: 168de59 90b3ad9
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 08:50:45 2015 +0000
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit 90b3ad911c761ab4bc0107f5836391149edf7273[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 22 10:46:10 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_b51431b1
+        tagger Axon <axon@openmailbox.org> 1442911552 +0000
+    
+        Tag for commit b51431b197d737da3c01568a886efeb94e76207a
+        gpg: Signature made Tue 22 Sep 2015 10:45:52 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        b51431b Delete old ToCs
+        6333eb3 Delete old page (incorporated into ToC)
+        8eee17c Delete old copy of moved page
+        e6332a4 Eliminate superfluous subdirectory
+        56abdc3 Delete old copies of moved pages
+        e4cecaa Eliminate superfluous subdirectory
+        7216c1b Delete old copies of moved pages
+
+[33mcommit 168de59d47b6fd835cbb073b2e04467603ef45a6[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 08:42:43 2015 +0000
+
+    Update URLs
+
+[33mcommit 54456b8c6e39075037371ae45f5652da3a15ef91[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 08:38:16 2015 +0000
+
+    Reorganize doc structure
+
+[33mcommit b4bf7117d436dbf2fb97fb90cc3baaedc1324aa5[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 08:19:18 2015 +0000
+
+    Move page to top level and add to navbar
+
+[33mcommit 63859fec2d5aa77a2382efc578ce98333a5f13c6[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 08:11:18 2015 +0000
+
+    Consolidate main pages
+
+[33mcommit 77299cda64ed14f23707aba79d2401898550f016[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 07:43:35 2015 +0000
+
+    Update to reflect new pages
+
+[33mcommit 07cc2ca986487bb3a3c77b1b6bf8470d07c6adf9[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 07:43:05 2015 +0000
+
+    Change to reflect moved pages
+
+[33mcommit 9ba5140633164621b3253f73d05748253902cdc8[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 07:41:46 2015 +0000
+
+    Rename for consistency; move to root dir
+
+[33mcommit f55150705876760b59b05fa4f2a3a842102d86da[m
+Author: Axon <axon@openmailbox.org>
+Date:   Tue Sep 22 07:39:10 2015 +0000
+
+    Clarify title and content; move to root dir
+
+[33mcommit 611cf04896bc77b3e2e849a5c77466065e8ba746[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Sep 21 13:42:37 2015 +0000
+
+    Typo
+
+[33mcommit 1d5a992c21e85e0f2ab7a71f5221f198e6180154[m
+Author: Axon <axon@openmailbox.org>
+Date:   Mon Sep 21 13:39:49 2015 +0000
+
+    Add Twitter username: @QubesOS
+
+[33mcommit 5e13995fbda3c950c9b1dd23d24ba42fc2348733[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Sep 21 15:15:59 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_ad48b274
+        tagger Axon <axon@openmailbox.org> 1442841343 +0000
+    
+        Tag for commit ad48b274e4a67cdb4936e3fe7614cf3043b0f6ce
+        gpg: Signature made Mon 21 Sep 2015 03:15:43 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ad48b27 Clarify language and procedure
+
+[33mcommit aab011d7c16875fe8ef2f663b835ef59b71f36e0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Sep 21 11:14:16 2015 +0200
+
+    autoupdate: _doc attachment
+    
+    _doc:
+        tag axon_a8db6eb5
+        tagger Axon <axon@openmailbox.org> 1442783348 +0000
+    
+        Tag for commit a8db6eb5fa1b50c6371714ea4a798ec84c7e0707
+        gpg: Signature made Sun 20 Sep 2015 11:09:08 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        a8db6eb Clarify oathtool procedure
+        41fea2b Add Multi-factorAuthentication to ToC
+        40f312f Minor wording changes
+        b19f2c7 Create Multi-factor Authentication page
+        2540091 Restructure UserDoc table of contents (QubesOS/qubes-issues#1175)
+    
+    attachment:
+        tag axon_9c38eec8
+        tagger Axon <axon@openmailbox.org> 1442780093 +0000
+    
+        Tag for commit 9c38eec86a706e8ec29f4f4829b1b78211180936
+        gpg: Signature made Sun 20 Sep 2015 10:14:53 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9c38eec Add multi-factor authentication example screenshots
+        9b3cdee VersionScheme: release-cycle.svg
+
+[33mcommit 3c6b464e85de1da871bc58ca2b4e6cccc0773ee5[m
+Merge: 0940729 e321d16
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 20 05:38:23 2015 +0200
+
+    Merge remote-tracking branch 'origin/pr/5'
+    
+    * origin/pr/5:
+      new helper script added to replace {% highlight trac-wiki %} and {% endhighlight %} trac-wiki leftovers
+
+[33mcommit 0940729299172f00973cd76880a788f2d426b9f7[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 20 05:34:51 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_eea0bf57
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442720072 +0200
+    
+        Tag for commit eea0bf57afd80a6280f787fb844b89c9225576b9
+        gpg: Signature made Sun 20 Sep 2015 05:34:32 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        eea0bf5 Merge remote-tracking branch 'origin/pr/42'
+        dbe1f6b Add qubes.GetImageRGBA and qubes.WindowIconUpdater protocol description
+        1c8b803 all wiki trac {% highlight trac-wiki %}{% endhighlight %} replaced with the ``` used for markdown code
+        00574e3 Restore intentional end-of-line spaces
+        4ea778c Added link to R3 template for Archlinux.md and added IPPolicy explanation to Ubuntu.md. Linked both files to UserDoc.md
+        16998a7 Merge branch 'master' of https://github.com/Jeeppler/qubes-doc
+        5309bed DocStyle description added rules for headings
+        24b1c1c just reverted (deleted) a former change
+        e352164 added a page ResizeRootDiskImage.md and removed the external link
+        5f483fa Qubes OS 3.0 rc3 release added to wikistart
+        9c971ab Merge remote-tracking branch 'upstream/master'
+        0ddfb2c added description of QvmFirewall rule
+
+[33mcommit e321d16db54c0d09c5dc880892122247f6a0484b[m
+Author: Jeepler <jeremias.eppler@mailbox.org>
+Date:   Sun Sep 20 05:21:13 2015 +0200
+
+    new helper script added to replace {% highlight trac-wiki %} and {% endhighlight %} trac-wiki leftovers
+
+[33mcommit 556e5bcc5bf387ad4e0fe885ed7da6eebd3c321f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 17 01:02:09 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_a05120cf
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442444518 +0200
+    
+        Tag for commit a05120cf7534f3d15da268be0a35a3b555487848
+        gpg: Signature made Thu 17 Sep 2015 01:01:58 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        a05120c Enable links to kernel.org mirror
+
+[33mcommit e2ccdd25bec2a96d1debbc95ef97f2dea039ea79[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Sep 16 23:56:07 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_5db85623
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442440555 +0200
+    
+        Tag for commit 5db856233b74f738cc74c5fc50698e7c25c0e2c1
+        gpg: Signature made Wed 16 Sep 2015 11:55:55 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        5db8562 release checklist - repositories related tasks
+
+[33mcommit 52587467bd20657dfb849bac99de265ec8ddd325[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Sep 16 16:24:21 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_df386c46
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442413453 +0200
+    
+        Tag for commit df386c46e6f4c12ac08aba95498ff84e70d0cef6
+        gpg: Signature made Wed 16 Sep 2015 04:24:13 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        df386c4 R3.0-rc3
+
+[33mcommit 3a781bcc384111bbfb242cedd0bfb2a781f3c860[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Sep 16 12:14:37 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_cf910210
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442398466 +0200
+    
+        Tag for commit cf910210d8d4a6877c49350505b292e4d38dfaaf
+        gpg: Signature made Wed 16 Sep 2015 12:14:26 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        cf91021 3.0 release schedule - fix table formatting
+
+[33mcommit d41478576242cc954c5ae578245c865a36256f21[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Sep 16 00:14:37 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_660994f2
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442355268 +0200
+    
+        Tag for commit 660994f273bcd49f4bb83523a327a1ad359de5fa
+        gpg: Signature made Wed 16 Sep 2015 12:14:28 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        660994f Use Rufus to write ISO image to USB on Windows
+
+[33mcommit d166875a24151f0fad90a630961da3293fdf4e16[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Sep 16 00:12:39 2015 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag mm_d58030ca
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442355149 +0200
+    
+        Tag for commit d58030ca4dd622f4af74957f673709e3e37f5125
+        gpg: Signature made Wed 16 Sep 2015 12:12:29 AM CEST using RSA key ID 42CFA724
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes OS signing key) <marmarek@invisiblethingslab.com>"
+    
+        d58030c Rufus - mark the right option
+
+[33mcommit b17c264c9b22e52a6f13c9b4bf69e40c3204f3db[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 15 23:50:08 2015 +0200
+
+    autoupdate: attachment
+    
+    attachment:
+        tag mm_5a287700
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442353733 +0200
+    
+        Tag for commit 5a287700afdbc33d524a967f53c25b286b5fb5bc
+        gpg: Signature made Tue 15 Sep 2015 11:48:53 PM CEST using RSA key ID 42CFA724
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes OS signing key) <marmarek@invisiblethingslab.com>"
+    
+        5a28770 Screenshots for Rufus usage
+
+[33mcommit 250b388601e52393aa8fb6ef47109447940ac020[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 15 23:44:21 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_ecd22417
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442353447 +0200
+    
+        Tag for commit ecd22417a27b766c2eaa85740cb92c9538c32e6f
+        gpg: Signature made Tue 15 Sep 2015 11:44:07 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        ecd2241 Unified installation guide
+
+[33mcommit 24a33113450f2074085b0bac2b3de0a850c9f16d[m
+Merge: ac455e3 5e69900
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Sep 15 00:00:13 2015 +0200
+
+    Merge remote-tracking branch 'origin/pr/4'
+    
+    * origin/pr/4:
+      Update _layout.scss
+
+[33mcommit ac455e3701cc98756cede39397dadd853a6d0388[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Sep 14 23:58:40 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_a4fd4a59
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442267905 +0200
+    
+        Tag for commit a4fd4a595a50579edd9975251258ba82a0347562
+        gpg: Signature made Mon 14 Sep 2015 11:58:25 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        a4fd4a5 Merge remote-tracking branch 'origin/pr/38'
+        a8f0539 Fixed typo and renamed AppVM "red" to "untrusted" as for consistently reasons.
+
+[33mcommit bfa367e09c3a7d7a98ffa673d2896c043c5e1481[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Sep 14 23:56:48 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_2e9096a3
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442267796 +0200
+    
+        Tag for commit 2e9096a3a5423559d5274a4ca3b8cf660145f803
+        gpg: Signature made Mon 14 Sep 2015 11:56:36 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        2e9096a Merge remote-tracking branch 'origin/pr/35'
+        6be5d46 Merge remote-tracking branch 'origin/pr/36'
+        4c71257 Merge remote-tracking branch 'origin/pr/39'
+        ef2cb1b Merge remote-tracking branch 'origin/pr/40'
+        4c366d2 fixed typo
+        4a2c7b7 fixed typos, one formatting issue
+        233b553 nitpicking some typos, wording
+        c7499fa Added ref to FAQ to security guidelines on assigning USB controllers.
+        9d65a68 Added ref to FAQ in security guidelines on using USBVM.
+
+[33mcommit 232ce9a99abd19530cc4b6235d3435bf6bc6ec09[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Sep 14 21:47:55 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_a64b715f
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1442260057 +0200
+    
+        Tag for commit a64b715fbf1571a0e7e140547fe6dedc515ec0a9
+        gpg: Signature made Mon 14 Sep 2015 09:47:37 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        a64b715 downloads: update mirrors list
+
+[33mcommit 5e699006fd85346d1595ab3122f685dd79f608f2[m
+Author: unman <unman@thirdeyesecurity.org>
+Date:   Sun Sep 6 23:53:43 2015 +0000
+
+    Update _layout.scss
+    
+    Change font sizes in headers to make greater differentiation between H1,H2 and H3.
+    Cf QubesOS/qubes-issues#1039
+
+[33mcommit 97b87b4fcebf264d51b4cd22ba63cee1c67ae396[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Sep 6 00:58:55 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_35cde9e0
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1441493899 +0200
+    
+        Tag for commit 35cde9e043eaced69823e9b4d7029e8831097ba0
+        gpg: Signature made Sun 06 Sep 2015 12:58:19 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        35cde9e Describe bug priorities meaning
+        8d1237d Update keys.qubes-os.org to HTTPS
+        ea711e9 Merge remote-tracking branch 'origin/pr/33'
+        9048ddd Add checklist for releases
+        4813999 Release 3.0 draft
+        1019352 VersionScheme: add release schedule rules
+        a58d81b VersionScheme: wrap at 80 characters
+
+[33mcommit ecb63f9ee536f3ac9138cb2d83b143008a75ba49[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Sep 3 10:59:21 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag zrubi_f74f503
+        tagger Zrubi <mail@zrubi.hu> 1441270678 +0200
+    
+        Merget pull requests: #32 #34
+        gpg: Signature made Thu 03 Sep 2015 10:58:34 AM CEST using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        000df2b Merge remote-tracking branch 'origin/pr/34'
+        f74f503 Clarified docs on USB controllers and devices.
+        2eee93e Update Debian.md
+
+[33mcommit 0d103ea4964e4ab4964dff5911a8b6d672610a28[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Aug 28 14:58:30 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag nukama_1f3bcf71
+        tagger Hakisho Nukama <nukama@gmail.com> 1440754542 +0000
+    
+        Tag for commit 1f3bcf71249013da7b220d0ae7ee497664892bf3
+        gpg: Signature made Fri 28 Aug 2015 11:35:50 AM CEST using RSA key ID 3C618D64
+        gpg: Good signature from "Hakisho Nukama (Qubes Documentation Signing Key)"
+    
+        1f3bcf7 Merge pull request #26 from kalkin/master
+        13598be Merge pull request #31 from mfc/patch-1
+        c285cfa Merge pull request #30 from unman/master
+        ce63f04 Merge pull request #24 from fowlslegs/patch-7
+        feabcb5 added 3.0rc2 and liveUSB release to Recent News
+        8339c86 Rewrite Nvidia page for clarity
+        ad5346b Fix link
+        a8e64c0 Instructions how to add new tests to core-admin
+        fb6ed54 Added a couple dependencies to the `yum install` line
+
+[33mcommit 8f489b11e0c7460e4f83ac637f5b956b5ccbcc5b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Aug 25 12:49:20 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag zrubi_a4d584c
+        tagger Zrubi <mail@zrubi.hu> 1440499490 +0200
+    
+        Merged pull requests: #27 #28 #29
+        gpg: Signature made Tue 25 Aug 2015 12:45:37 PM CEST using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        9cfbfe5 Merge remote-tracking branch 'origin/pr/29'
+        cab33f7 Merge remote-tracking branch 'origin/pr/28'
+        251303b paper source to  Vitrics updated
+        7a7d65c Trivial typo fix in SimpleIntro.md
+        a4d584c Correct spelling
+        2735f20 Edit pages on Disposable VMs to make it clear that files edited in a dispVM will be saved back to the originating VM. Updated some commands to match R3 Moved section on using a custom template to Customization page.
+        4e5817b "Virtics" source updated
+        7e678b7 Merge pull request #1 from Jeeppler/patch-1
+
+[33mcommit 5bdae4525bab237de2ca000c605c63fcd0f46bf8[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Aug 25 12:47:21 2015 +0200
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag zrubi_31e1cd6
+        tagger Zrubi <mail@zrubi.hu> 1440497435 +0200
+    
+        New HCL entries added
+        gpg: Signature made Tue 25 Aug 2015 12:10:38 PM CEST using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        31e1cd6 New HCL entries added
+
+[33mcommit 6e0ca82931a5eb5f47b785f2219927aaf9054171[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon Aug 24 21:54:28 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag zrubi_910fc8d
+        tagger Zrubi <mail@zrubi.hu> 1439542049 +0200
+    
+        Instructions how to get Lenovo 450 working with Qubes
+        gpg: Signature made Fri 14 Aug 2015 10:48:00 AM CEST using RSA key ID 6E087C23
+        gpg: Good signature from "Zrubi (Qubes Documentation Signing Key)"
+    
+        910fc8d Instructions how to get Lenovo 450 working with Qubes
+
+[33mcommit 2a720cfcd2cc4643098bd424162e9dcdb50e044c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Aug 8 21:17:14 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_547c51d1
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1439061423 +0200
+    
+        Tag for commit 547c51d12a7a087086caf1e6e2b0fa6742f4b0b9
+        gpg: Signature made Sat 08 Aug 2015 09:17:03 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        547c51d Update qvm-prefs man page
+
+[33mcommit 861b6b48a4e536b06427c6e53b355e311495e2f6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Aug 6 04:53:23 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_42d1458b
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1438829588 +0200
+    
+        Tag for commit 42d1458b7f84ba67e3b1a7562b83e03b3e6b8dc8
+        gpg: Signature made Thu 06 Aug 2015 04:53:08 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        42d1458 Change command in DispVM example
+
+[33mcommit 2e428aa97684f38b73c8438e76910ffd58bca71c[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Aug 1 20:55:52 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_c5069f20
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1438455342 +0200
+    
+        Tag for commit c5069f2000710ee397fefec51129ab68a848023a
+        gpg: Signature made Sat 01 Aug 2015 08:55:42 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        c5069f2 Update contribution guide
+
+[33mcommit 994efc814491d316f7aff53050177c169ce4e73b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Aug 1 14:53:16 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_6126f7c0
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1438433586 +0200
+    
+        Tag for commit 6126f7c0f5b867f8a02f0dbfd3cb11d0ac96e69a
+        gpg: Signature made Sat 01 Aug 2015 02:53:06 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        6126f7c Fix link to bug list
+
+[33mcommit a6f0fa3d6b542f4cf11c098962d2c1963a0c1a0a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Aug 1 01:13:19 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b9f2ce22
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1438384389 +0200
+    
+        Tag for commit b9f2ce22eda4c0e5b5998d5edd82ba7c611d2c78
+        gpg: Signature made Sat 01 Aug 2015 01:13:09 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b9f2ce2 R3.0rc2 related changes
+
+[33mcommit 2d94e03abb8e35650710bf135288dbea373cdd62[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jul 31 18:48:22 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_7e8aa4eb
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1438361286 +0200
+    
+        Tag for commit 7e8aa4eb50b30117a79d9215414108fbf7ba60c2
+        gpg: Signature made Fri 31 Jul 2015 06:48:06 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        7e8aa4e Update list of default qrexec services
+        0a64f01 StickMounting: formatting
+        d848794 Instruction how to recover from prematurely detached device
+        254a01a Merge remote-tracking branch 'origin/pr/1'
+        e159b62 Merge pull request #23 from omeg/master
+        45cfedf add instructions for uninstalling Windows Tools 2.x
+        955e2ec A different proposal for explaining USB issues
+
+[33mcommit c4f8b63fd1d3bb58e63a8ddca5541cde2728af1f[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Mon Jul 27 12:33:14 2015 +0000
+
+    autoupdate: _doc
+    
+    _doc:
+        tag nukama_04b94d85
+        tagger Hakisho Nukama <nukama@gmail.com> 1438000224 +0000
+    
+        Tag for commit 04b94d858abd11fb69c924edea30b4d6bd1e1735
+        gpg: Signature made Mon 27 Jul 2015 12:30:24 PM UTC using RSA key ID 3C618D64
+        gpg: Good signature from "Hakisho Nukama (Qubes Documentation Signing Key)" [full]
+    
+        04b94d8 Fixed merge conflict, finally.
+
+[33mcommit 98bd4e9c824111bcab53da33e53237267829c9f0[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Mon Jul 27 12:24:15 2015 +0000
+
+    Updating _doc submodule
+
+[33mcommit dad93a2d6d59a69ca442e4c7c88af9a3c9f2c514[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jul 18 00:37:31 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag nukama_15c0146c
+        tagger Hakisho Nukama <nukama@gmail.com> 1437172618 +0000
+    
+        Tag for commit 15c0146c765afe4a8856ea7e6b9ba19fed3c83fa
+        gpg: Signature made Sat 18 Jul 2015 12:36:58 AM CEST using RSA key ID 3C618D64
+        gpg: Good signature from "Hakisho Nukama (Qubes Documentation Signing Key)"
+    
+        15c0146 Supporting old trac link for backward compatibility in QSB.
+        7a070b8 Merge pull request #12 from fowlslegs/patch-1
+        3bf4212 Merge pull request #8 from Jeeppler/patch-1
+        aa2934d Updated rotten links to QubesOS Github R2 branch
+        79c54f1 Update WikiStart.md
+        750ce36 Update WikiStart.md
+
+[33mcommit c5334ecce04164838902b6e9cab991bfa84ef961[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jul 2 16:53:15 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_b05f908b
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1435848782 +0200
+    
+        Tag for commit b05f908b88ddf8023a5a6e834e46f4ea62cd6254
+        gpg: Signature made Thu 02 Jul 2015 04:53:02 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        b05f908 Merge remote-tracking branch 'origin/pr/10'
+        c1f2da6 fixed ticket link
+        c622b83 Windows Tools: fix doc link
+        d5fdb9b Windows Tools: add note about VNC server in testing VMs
+        3882315 update Windows Tools for R3
+        baf462c Update FedoraMinimal.md
+
+[33mcommit 91ee64b1e03645bcfde91f47e80e596e166a1739[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed Jul 1 11:56:28 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_cbe7a8db
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1435744577 +0200
+    
+        Tag for commit cbe7a8db011e2238b6887ca225718392d91e95fe
+        gpg: Signature made Wed 01 Jul 2015 11:56:17 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        cbe7a8d update fedora minimal template name
+
+[33mcommit 77bd69e3d3e5e7924134263a115bb4d553c4d47f[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Tue Jun 30 12:29:22 2015 +0000
+
+    autoupdate: _doc
+    
+    _doc:
+        tag nukama_8c85045b
+        tagger Hakisho Nukama <nukama@gmail.com> 1435667154 +0000
+    
+        Tag for commit 8c85045b5c07498cb4338e228f69a9053629cf7c
+        gpg: Signature made Tue 30 Jun 2015 12:25:54 PM UTC using RSA key ID 3C618D64
+        gpg: Good signature from "Hakisho Nukama (Qubes Documentation Signing Key)" [full]
+    
+        8c85045 moving community.md to qubes-doc
+        4bc09a0 Merge pull request #7 from adrelanos/patch-4
+        a561876 Merge pull request #6 from adrelanos/patch-3
+        0f7928e Merge pull request #5 from adrelanos/patch-2
+        95dff42 Merge pull request #4 from adrelanos/patch-1
+        687bec2  RPMFusion for a Fedora TemplateVM
+        c377bcf updates proxy now also supports apt
+        3265891 added Template-BasedVM to Glossary
+        4c8e420 kernel upgrade instructions
+
+[33mcommit ace8dcba5e6df6c75b679c623f682aae45a27a3e[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Tue Jun 30 12:28:36 2015 +0000
+
+    moving community.md to qubes-doc
+
+[33mcommit ea1ea9fabc3738b34b75f46123d31295339ff1ad[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun Jun 28 07:13:44 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_4c91b153
+        tagger Axon <axon@openmailbox.org> 1435468399 +0000
+    
+        Tag for commit 4c91b153a6dfab5c5dcf6c0fa82edd2b1cdd25db
+        gpg: Signature made Sun 28 Jun 2015 07:13:19 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        4c91b15 FedoraTemplateUpgrade20: add step to remove old template
+        0ea8ffe typo
+
+[33mcommit 210d3494036005afff8029ccb484c4becfd94902[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jun 23 15:50:48 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_ca6b0999
+        tagger Axon <axon@openmailbox.org> 1435067430 +0000
+    
+        Tag for commit ca6b0999709e9c0fdb5c7b3ff5233ae75d4ed625
+        gpg: Signature made Tue 23 Jun 2015 03:50:30 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        ca6b099 FedoraTemplateUpgrade20: Improve instructions
+
+[33mcommit 3bc359ce7d42fc1be4fa8b1884540d017905e4e6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue Jun 23 12:44:41 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_8b44e134
+        tagger Axon <axon@openmailbox.org> 1435056252 +0000
+    
+        Tag for commit 8b44e134181f832b28a2d93751c2648553740c5b
+        gpg: Signature made Tue 23 Jun 2015 12:44:13 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8b44e13 FedoraTemplateUpgrade20: Improve instructions
+
+[33mcommit 2f842f898ea61d083847cc8d62c532207a2a3662[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Sun Jun 21 03:43:37 2015 +0000
+
+    Define headings h1 to h6 with updated doc layout.
+    Headings increase 2px for each heading level starting above $base-font-size.
+
+[33mcommit bace7fefa4c3e9e1ecac60ddf15856da96f219e7[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 20 16:47:32 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_3b8bbb84
+        tagger Axon <axon@openmailbox.org> 1434811617 +0000
+    
+        Tag for commit 3b8bbb8419227317681a17a6af0b8b56cafe252d
+        gpg: Signature made Sat 20 Jun 2015 04:46:58 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        3b8bbb8 FedoraTemplateUpgrade18: add pointer to newer page
+        2da094c FedoraTemplateUpgrade20: add new instructions
+        9da6088 Index: create entries for new pages
+        e676bae Index: split Fedora TemplateVM upgrade pages
+
+[33mcommit 6e2eec42899e34664b324ca46c897ff6b1bdddf2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jun 19 09:08:43 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_ee09e472
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1434697709 +0200
+    
+        Tag for commit ee09e47249228073d653ec3e31a0183fe6c9bf78
+        gpg: Signature made Fri 19 Jun 2015 09:08:29 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        ee09e47 YubiKey: one more fix for lightdm
+
+[33mcommit 6840ff3cae4073d0b04b1400de820d8c547f5a79[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jun 18 16:10:12 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_a60aafc1
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1434636572 +0200
+    
+        Tag for commit a60aafc111108fb2904715763abaf4fab8723174
+        gpg: Signature made Thu 18 Jun 2015 04:09:32 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        a60aafc YubiKey: add qvm-run --nogui option to make it usable for lightdm login
+
+[33mcommit 4142d279bed2a33c9bcf519b9b04296b9d80d643[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jun 12 18:33:27 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_8afb9073
+        tagger Axon <axon@openmailbox.org> 1434126752 +0000
+    
+        Tag for commit 8afb9073b2ba16a5586ceb2766f2f91178775b25
+        gpg: Signature made Fri 12 Jun 2015 06:32:34 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        8afb907 Add FedoraTemplateUpgrade link to main index
+
+[33mcommit 8d40bd6bf69ca83fc23bc7329f26ae6a8cde9f9a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 6 03:02:44 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_0150ac08
+        tagger Axon <axon@openmailbox.org> 1433552538 +0000
+    
+        Tag for commit 0150ac08ccfa1c1ba818d0956be13ae7c5cc2a4f
+        gpg: Signature made Sat 06 Jun 2015 03:02:18 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        0150ac0 Minor cleanup.
+
+[33mcommit 974194712dbf57eb1b58fde5be2438ce1bd944c9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 6 02:45:43 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_697d65d6
+        tagger Axon <axon@openmailbox.org> 1433551517 +0000
+    
+        Tag for commit 697d65d62316cf1cb6ad4478dad186085e424a90
+        gpg: Signature made Sat 06 Jun 2015 02:45:18 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        697d65d Minor instruction fixes and style edits; major formatting cleanup.
+
+[33mcommit f5ee8b8fc82d64343db9dd3e02f243c4c3c47dae[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 6 01:51:27 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_78ec3cf3
+        tagger Axon <axon@openmailbox.org> 1433548269 +0000
+    
+        Tag for commit 78ec3cf30ff9b7f2ba203b5839d467204796a734
+        gpg: Signature made Sat 06 Jun 2015 01:51:09 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        78ec3cf Still trying to fix code block indenting!
+
+[33mcommit 6341d4ec0aed25f1ea6528bc84ace68ce8e70f13[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 6 01:47:22 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_09fcb536
+        tagger Axon <axon@openmailbox.org> 1433548021 +0000
+    
+        Tag for commit 09fcb536c150af0208cfdf7b8b62607666bbe37e
+        gpg: Signature made Sat 06 Jun 2015 01:47:02 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        09fcb53 Fixed even more code block indenting.
+
+[33mcommit 3a39bfc1c0bd0865d79d1e6ca9b2b7def58326f4[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 6 01:36:33 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_1d1e69b8
+        tagger Axon <axon@openmailbox.org> 1433547369 +0000
+    
+        Tag for commit 1d1e69b8ae2cbe501811261e331a5e7657b70226
+        gpg: Signature made Sat 06 Jun 2015 01:36:09 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1d1e69b Fixed more code block indenting.
+
+[33mcommit ffa76650eda4a82383bfb83bd67a6b4e458f69e6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sat Jun 6 01:31:50 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_fb821292
+        tagger Axon <axon@openmailbox.org> 1433547090 +0000
+    
+        Tag for commit fb821292e467b946f3a861a73f1374781a1c5e9e
+        gpg: Signature made Sat 06 Jun 2015 01:31:31 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        fb82129 Fixed code block indenting.
+
+[33mcommit 41400f1d1714e2535283edfbf61deb9aecf8a55a[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Jun 5 05:25:46 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_9e2f5fda
+        tagger Axon <axon@openmailbox.org> 1433474509 +0000
+    
+        Tag for commit 9e2f5fda8b62dee9cc8beb1dfa3514d4e99b679e
+        gpg: Signature made Fri 05 Jun 2015 05:21:50 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        9e2f5fd Added link to VersionScheme.
+        7b31877 Rewrote SecurityPack in Markdown.
+        32288f9 Merge pull request #2 from bnvk/master
+        54189ac Merge pull request #3 from mfc/master
+        aef3ad9 updated TorVM docs to R3.0rc1, fixed typo in Whonix templates doc
+        0532a20 made Glossary terms bold
+
+[33mcommit dd7260512a7181c88408e1ebfd77e8647ea471d0[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Jun 4 02:26:45 2015 +0200
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag nukama_0eb06cd4
+        tagger Hakisho Nukama <nukama@gmail.com> 1433322237 +0000
+    
+        Tag for commit 0eb06cd4b32616f43ded8c1d39a6463f7b1cf0e3
+        gpg: Signature made Wed 03 Jun 2015 11:04:01 AM CEST using RSA key ID 3C618D64
+        gpg: Good signature from "Hakisho Nukama (Qubes Documentation Signing Key)"
+    
+        0eb06cd Merge pull request #1 from banana-cake/master
+        a8e06fd Additional info, extracted from HCL reports/emails
+
+[33mcommit 95cbd0df3aab2653944c322a8ec3f7c9110faff5[m
+Merge: 3e2b0e6 8e8d94f
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 31 12:34:55 2015 +0200
+
+    Merge remote-tracking branch 'origin/pr/2'
+    
+    * origin/pr/2:
+      added .onion mirror url for site to footer, issue #1
+
+[33mcommit 8e8d94f12eb5a56c70812845bcfd4f0003ef12a1[m
+Author: Brennan Novak <hi@brennannovak.com>
+Date:   Sun May 31 11:53:25 2015 +0200
+
+    added .onion mirror url for site to footer, issue #1
+
+[33mcommit 3e2b0e699c4798764ef431b5aa1983a2203e085a[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Wed May 27 23:16:12 2015 +0000
+
+    Added CSS definition for <strong> tag
+
+[33mcommit f581481b4e1be252177b9810353a69fc849ca4cd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Wed May 27 07:16:58 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag axon_13830586
+        tagger Axon <axon@openmailbox.org> 1432703770 +0000
+    
+        Tag for commit 1383058657e562089691a588ddc341a9a1f6bd2f
+        gpg: Signature made Wed 27 May 2015 07:16:10 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        1383058 Updated FAQ entry on reporting documentation issues.
+
+[33mcommit 284b174086ea21cd4a2228ea3f05f2a6d7d7ddbd[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue May 26 21:23:38 2015 +0200
+
+    autoupdate: _doc attachment
+    
+    _doc:
+        tag axon_914514b2
+        tagger Axon <axon@openmailbox.org> 1432657745 +0000
+    
+        Tag for commit 914514b2d535d9e547145987ed3193876c514be4
+        gpg: Signature made Tue 26 May 2015 06:29:05 PM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        914514b Added instructions for using gpg2 instead of gpg.
+        64a14c9 Added FAQ entry on reporting documentation issues.
+        dc35d8f Added FAQ entry on passwordless sudo.
+        c10f332 Created page on installation security considerations.
+        79e40cc Created guidelines for documentation contributors.
+        53d8295 Created instructions for storing AppVMs on secondary drives.
+        cebb9b1 Added instructions for using Tor Browser behind TorVM.
+        c99da20 Added link to UI customization thread by user <nalu@riseup.net>.
+        753d724 Added screenshots from user <nalu@riseup.net>.
+    
+    attachment:
+        tag axon_6cc293e1
+        tagger Axon <axon@openmailbox.org> 1432633264 +0000
+    
+        Tag for commit 6cc293e11eea3148864ef3c27bd0aaff6ad510fe
+        gpg: Signature made Tue 26 May 2015 11:41:04 AM CEST using RSA key ID 2A019A17
+        gpg: Good signature from "Axon (Qubes Documentation Signing Key)"
+    
+        6cc293e Added screenshots from user <nalu@riseup.net>.
+
+[33mcommit 350a62885fe326bde5c762c258df641d6ce9e4cf[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue May 26 21:22:31 2015 +0200
+
+    autoupdate: _hcl
+    
+    _hcl:
+        tag nukama_819217d6
+        tagger Hakisho Nukama <nukama@gmail.com> 1432666951 +0000
+    
+        Tag for commit 819217d61ec5787c241ed0f1d3776333b5062e24
+        gpg: Signature made Tue 26 May 2015 09:02:31 PM CEST using RSA key ID 3C618D64
+        gpg: Good signature from "Hakisho Nukama (Qubes Documentation Signing Key)"
+    
+        819217d Added Inspirion 7537, Lenovo G505S, ThinkPad X250
+        e1cb394 fixing Latitude E6410 information
+
+[33mcommit d6ffa16e6f30bbc118ecbf5ee0549090b13e725b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue May 26 01:32:46 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_65f68840
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1432596724 +0200
+    
+        Tag for commit 65f68840cd4e0c9fccd29ca13a9f39bef0791f2a
+        gpg: Signature made Tue 26 May 2015 01:32:04 AM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        65f6884 Add YubiKey documentation
+
+[33mcommit 812492cbd7af999141f715b5592f69dfd99be747[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri May 22 22:19:34 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_21fd43f6
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1432325959 +0200
+    
+        Tag for commit 21fd43f648d4f446fe67e6d58d413ff4bdc94821
+        gpg: Signature made Fri 22 May 2015 10:19:19 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        21fd43f VMSudo: fix git link and formatting
+
+[33mcommit 5bad4c49886d1d9b9b4595f9fdff120cbd959885[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Tue May 12 23:57:20 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_e5168b0d
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1431467825 +0200
+    
+        Tag for commit e5168b0da2eb82e606ab7ef7663bcfbcca1293ac
+        gpg: Signature made Tue 12 May 2015 11:57:05 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        e5168b0 suggesting gnome-keyring as useful semi-minimal package
+
+[33mcommit 2e02153d091157d2e29b0cc759509cfdc0598482[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon May 11 21:50:59 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_6d97cb8c
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1431373838 +0200
+    
+        Tag for commit 6d97cb8c1649e01f6672abba7153f8082e41dcba
+        gpg: Signature made Mon 11 May 2015 09:50:38 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        6d97cb8 Update some git links (gitweb -> github)
+
+[33mcommit 0f37121d7003ae12e9884a07275b9e1161f135be[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 10 03:11:06 2015 +0200
+
+    update-submodules: fix updating itself
+    
+    Fetch tags. Additionally abort if it fails.
+
+[33mcommit e051cb68b82d79ba43177e7bc24341fdccb2924d[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Sat May 9 13:05:03 2015 +0000
+
+    doc update
+
+[33mcommit 66e560ee64f7754879756ee78546a7ee52d97de9[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri May 8 18:07:15 2015 +0200
+
+    Update itself before fetching submodules
+
+[33mcommit 95f5a6dd95cdcfbb0e07c77c7792c6ab01b20193[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri May 8 17:50:09 2015 +0200
+
+    Update doc migration scripts - ensure urls have slash at the end
+
+[33mcommit c8d1a2428e05f428bb1aadcb7dbece3ad427d42f[m
+Author: Wojtek Porczyk <woju@invisiblethingslab.com>
+Date:   Wed Apr 22 02:06:28 2015 +0200
+
+    some utils for checking and fixing after migration
+
+[33mcommit 76ddae49766d4ef26a5d40e6ae9c5f3f077fa13d[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri May 8 18:05:47 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_a16f01fd
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1431101132 +0200
+    
+        Tag for commit a16f01fd0ffcc1ca552cc68744b78b2869495917
+        gpg: Signature made Fri 08 May 2015 06:05:32 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        a16f01f Many links fixed
+        8a68901 Fix /wiki/ -> /doc/, add slash at the end
+        ceb8074 Remove zero-width spaces (U+200B) left by trac
+
+[33mcommit a8f003d0a702959aff2656225ffebf544b0c076f[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri May 8 14:04:23 2015 +0200
+
+    autoupdate: _doc
+    
+    _doc:
+        tag mm_0d01545c
+        tagger Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com> 1431085622 +0200
+    
+        Tag for commit 0d01545c571eedea45b9c71d638ffe7f7267ed16
+        gpg: Signature made Fri 08 May 2015 01:47:02 PM CEST using RSA key ID 9684938A
+        gpg: Good signature from "Marek Marczykowski-Górecki (Qubes Documentation Signing Key) <marmarek@invisiblethingslab.com>"
+    
+        0d01545 mutt: more useful settings provided by J.M.Porup
+        f51d11d mutt: add note about OfflineIMAP
+
+[33mcommit 226cd4373669a6c2fa5ad2394c4f10c8f016d2db[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri May 8 14:02:49 2015 +0200
+
+    scripts for automatic update of submodules
+
+[33mcommit 084819ec9ecfcbde2b6809ca80b8d08565d80ca6[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Tue May 5 18:00:38 2015 +0000
+
+    updating modules
+
+[33mcommit 7532b66eff2ddcc10564c6e6e9ed5c4e9a9a4db6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Mon May 4 01:50:24 2015 +0200
+
+    doc update
+
+[33mcommit e2158b67f6a67134285ae0a0ef00b6f77de081f2[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Sun May 3 03:04:22 2015 +0200
+
+    update doc, change code font size to match text
+
+[33mcommit 2c1ac38fd0566ab7ac4b5a8fab325534783bb5a6[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Apr 24 21:27:16 2015 +0200
+
+    doc update
+
+[33mcommit 9f2580d4b2a0d1f9b4bd51f08148e0ad66bc3228[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Apr 24 21:06:03 2015 +0200
+
+    trigger rebuild
+
+[33mcommit d8fcc84ea86a763ea7df99da43ee23d0d6ee4e77[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Fri Apr 24 20:40:48 2015 +0200
+
+    doc update
+
+[33mcommit 60d607014b2dd874813cb398e082a9cc0adb39eb[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Apr 23 18:04:13 2015 +0200
+
+    doc update
+
+[33mcommit af2b6cf8c060e16278823782bd4787e250ae0dad[m
+Merge: 938ba37 ca3bde7
+Author: Joanna Rutkowska <joanna@invisiblethingslab.com>
+Date:   Thu Apr 23 17:51:16 2015 +0200
+
+    Merge branch 'master' of github.com:QubesOS/qubesos.github.io
+
+[33mcommit 938ba3779defd2a85cbaefd74460461cdffc81c2[m
+Author: Joanna Rutkowska <joanna@invisiblethingslab.com>
+Date:   Thu Apr 23 17:48:45 2015 +0200
+
+    Simplify layout for less cluttered look
+
+[33mcommit 5a1981e6ce7c8c93013da5cf3ecc596f9a511c03[m
+Author: Joanna Rutkowska <joanna@invisiblethingslab.com>
+Date:   Thu Apr 23 17:47:41 2015 +0200
+
+    Use smaller font
+
+[33mcommit dc6d00ae2a310ff06158529ebd0f910d14e93334[m
+Author: Joanna Rutkowska <joanna@invisiblethingslab.com>
+Date:   Thu Apr 23 17:46:20 2015 +0200
+
+    Cosmetics: make community.md layout consitent with other pages
+
+[33mcommit ca3bde7c3e17a41510400fcc62bdbc77a1f08d7b[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Apr 23 16:20:16 2015 +0200
+
+    doc update
+
+[33mcommit 48a848d49623b40068b65cff6b7072689d263736[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Apr 23 16:17:02 2015 +0200
+
+    doc update
+
+[33mcommit 8891cbc9fb338d16c8abdf5b2b9d5a9216d394d5[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Apr 23 15:15:45 2015 +0200
+
+    Update doc
+
+[33mcommit ff09ee74b992b8690917d392b398cdad6b66fc9c[m
+Author: Joanna Rutkowska <joanna@invisiblethingslab.com>
+Date:   Thu Apr 23 09:13:44 2015 +0200
+
+    _config.yml: shorten the project description in the footer
+
+[33mcommit db6e95307efcb9dd6bc69c5097cc09ce4f1642cf[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Apr 23 06:40:12 2015 +0200
+
+    Update doc
+
+[33mcommit 0defacfce4346e84238633ddeae953a3388b5291[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Apr 23 06:34:47 2015 +0200
+
+    Update submodule
+
+[33mcommit e6e05f7c1ba5eeb9df71a77426b813e882d26982[m
+Author: Marek Marczykowski-Górecki <marmarek@invisiblethingslab.com>
+Date:   Thu Apr 23 03:40:56 2015 +0200
+
+    Switch to qubes-doc on QubesOS account
+
+[33mcommit 0ea86798aee85ac244c0e2a9b7fb013392db144b[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Tue Apr 14 09:18:48 2015 +0000
+
+    updated submodule, increased logo source
+
+[33mcommit a7e9b8ac5bcb3e3443422823c7168ae14b10b336[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Tue Apr 14 08:45:52 2015 +0000
+
+    wiki to doc migration, submodule update
+
+[33mcommit e87babd796ead36acfbbd869d6f4367a97e80aad[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Mon Mar 30 19:54:43 2015 +0000
+
+    removing link to edit source
+
+[33mcommit 70decd7d8c0d84f507d0dac71d0f2af6614875eb[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Mon Mar 30 17:43:02 2015 +0000
+
+    fixed hcl table with only one version, include link to report
+
+[33mcommit a2b0b22031b4f13411b94598e69171c1813c195d[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Mon Mar 30 17:26:42 2015 +0000
+
+    adding simple search functionality
+
+[33mcommit bea80fb6087db125483f02aa5a66fb750024d294[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Mon Mar 30 17:10:35 2015 +0000
+
+    updating hcl table and submodule
+
+[33mcommit 2adf96cdbf3d529982def7cfaaa3f7bbad482600[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Wed Mar 11 00:11:48 2015 +0000
+
+    setting site.url to https
+
+[33mcommit c9bf69c48ffb6a49fcbeabb70c52e06f860debca[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Wed Mar 11 00:03:57 2015 +0000
+
+    feed.xml update
+
+[33mcommit 6d9f76fdccfa4aa16dbb8b1fa1e12cb822afb0ef[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Tue Mar 10 23:55:37 2015 +0000
+
+    added `jekyll new` site
+
+[33mcommit 1da918c01ef1ff4d79995bb0154f4b2b549602c7[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Tue Mar 10 23:27:52 2015 +0000
+
+    remove old jekyll site
+
+[33mcommit b9899b3a601e9af028b18f78d6b42cbec01b7e38[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Wed Mar 4 19:17:55 2015 +0000
+
+    Use site.url https://www.qubes-os.org, added canonical URLs
+
+[33mcommit 271bf5c34e8ef55132d0a09fbd3947904c90ddc0[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Wed Mar 4 18:43:39 2015 +0000
+
+    Removing url entry from _config
+
+[33mcommit 1a9f2733383f677c76074e05bcf4cfe4ce139e97[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Wed Mar 4 18:30:56 2015 +0000
+
+    Only use site.baseurl
+
+[33mcommit 73336dcffb62ed378a41953361930de9a633f1ec[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Wed Mar 4 00:28:30 2015 +0000
+
+    Added Initial git submodules
+
+[33mcommit 05b04c3de9b8916e4c133e4b305cf40054842333[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Wed Mar 4 00:15:44 2015 +0000
+
+    Initial Qubes OS Project Website
+
+[33mcommit 853de4c2f45bb00e0f8723cde6dfec539e6c5577[m
+Author: Hakisho Nukama <nukama@gmail.com>
+Date:   Mon Mar 2 20:50:35 2015 +0000
+
+    Links to development version
+
+[33mcommit 38a21a1637a66aaac028f9d2e3b3039cb15bbef3[m
+Author: Axon <axon@openmailbox.org>
+Date:   Sat Feb 28 21:04:28 2015 -0800
+
+    index: added links to installation guides for all releases
+
+[33mcommit b764af7f6eb6f1ccdb7cdec110d131257d5066bb[m
+Author: Nukama <nukama@gmail.com>
+Date:   Tue Feb 24 12:37:14 2015 +0000
+
+    index: link to archive.org snapshot
+
+[33mcommit c7567485df29a434e7a7efb2273e1bd5d0fd5658[m
+Author: Joanna Rutkowska <joanna@invisiblethingslab.com>
+Date:   Mon Feb 23 18:38:13 2015 +0100
+
+    index: link to Wiki backup
+
+[33mcommit 5f30cef63654fd23338131d88d5de7021da4ce32[m
+Author: Joanna Rutkowska <joanna@invisiblethingslab.com>
+Date:   Mon Feb 23 17:32:32 2015 +0100
+
+    Website migration message
+
+[33mcommit ba89b164d1a4af52c994f6611c79204b13ef85b9[m
+Author: Joanna Rutkowska <joanna@invisiblethingslab.com>
+Date:   Mon Feb 23 17:08:22 2015 +0100
+
+    CNAME for www.qubes-os.org
+
+[33mcommit d0f20b37e8ff28fd7abca7092d867731bd0db4c5[m
+Author: Joanna Rutkowska <joanna@invisiblethingslab.com>
+Date:   Mon Feb 23 16:48:44 2015 +0100
+
+    Coming soon

--- a/pages/donate.md
+++ b/pages/donate.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Donations
+title: Donate to Qubes
 permalink: /donate/
 redirect_from:
 - /en/donate/
@@ -8,72 +8,77 @@ redirect_from:
 - /wiki/Donations/
 ---
 
-**News:** [Qubes OS Begins Commercialization and Community Funding Efforts!](/news/2016/11/30/qubes-commercialization/)
+# Donate to Qubes – Your Support Counts!
 
-Thank you for your interest in supporting Qubes! The Qubes Project accepts
-monetary donations in
-<a href="#bitcoin"><i class="fa fa-btc black-icon" aria-hidden="true"></i> Bitcoin</a>
-(preferred) or by
-<a href="#credit-card"><i class="fa fa-credit-card black-icon" aria-hidden="true"></i> Credit Card</a>.
-If you are interested instead in donating hardware or providing substantial and
-sustained [funding], please visit the [Qubes Partners page].
+## Ways to Donate
+We accept monetary donations via Bitcoin and credit card in the following three ways:
 
-<h2 id="bitcoin"><img src="/attachment/site/btc.png"> Donate Bitcoin</h2>
+### 1. Give a One-Time Donation
+Donating with Bitcoin ensures that 100% of your money supports Qubes development because we do not incur any administrative costs. With credit card donations, [we lose roughly 14%][open-collective-faq] to administrative costs.
 
-Bitcoin donations have zero administrative overhead for us, which means 100% of
-your donation goes towards supporting Qubes development!
++ **Donate to Our Bitcoin Address:** 3GakuQQDUGyyUnV1p5Jc3zd6CpQDkDwmDq ([read more about verifying our Bitcoin address](#verify-address))
++ **Donate with Credit Card:** [visit our Open Collective page][Open Collective]
 
-#### Donation Address:
+### 2. Join Our Sustaining Supporters
+Please consider becoming a sustaining supporter of the Qubes Project by giving a recurring monthly donation. Qubes is a long and ongoing project. If we know how much funding to expect every month, we can better plan our efforts and the use of available resources.
 
-<form class="more-bottom">
-  <div class="form-group">
-  <div class="input-group input-group-lg">
-    <span class="input-group-addon" id="donate-btn-icon"><i class="fa fa-btc"></i></span>
-    <input type="text" class="form-control" aria-describedby="donate-btc-icon" value="3GakuQQDUGyyUnV1p5Jc3zd6CpQDkDwmDq" readonly>
-  </div>
-  </div>
-</form>
+Set up an [automatically recurring donation on our Open Collective page][Open Collective donate]. Thank you!
 
-#### How to Verify the Address
+### 3. Become a Qubes Partner
+Are you an organization, company, or individual who believes in our vision and wants to make an impact on our efforts? [Become a Qubes Partner][Qubes Partners page] by giving a significant financial contribution.
 
-The donation address can be verified via the [Qubes Security Pack]
-(QSP or `qubes-secpack`), specifically in the [fund] directory. Detailed
-instructions for verifying the digital signatures are available [here][verify].
-You can also view the address on [blockexplorer.com] and [blockchain.info].
+## Help Us Spread the Word
+If you are a Qubes OS user or support our cause, help us expand our community by introducing Qubes to your circle, including
++ privacy advocates
++ IT companies
++ individuals who value and appreciate privacy in general
++ Bitcoin companies
++ sysadmins and other professionals who work with security.
 
-#### About the Donation Fund
+## FAQs on Donating
 
-The Qubes Project maintains a decentralized Bitcoin fund using a
-multi-signature wallet. This means that no single person is capable of spending
-these funds. For further details, please see [here][announcement].
+### Why Should I Donate?
+Qubes OS is free and open-source software. This means we do not earn any revenue by selling it. Instead, we rely on your financial support. If you rely on Qubes for secure computing in your work or personal life, or see the value in our efforts, then please donate now.
 
-<h2 id="credit-card"><i class="fa fa-credit-card" aria-hidden="true"></i> Donate with a Credit Card</h2>
+Qubes is one of the few operating systems that places the security of its users above all else. It has the potential to be a worldwide game changer in endpoint security. But for that to happen, the project requires a wide spectrum of expertise. In order to both retain and expand our core team, we require substantial funding from supporters like you.
 
-You can donate towards Qubes development using your credit card through
-[Open Collective] (which uses [Stripe][stripe] to process financial
-transactions). Please note that, unlike [Bitcoin donations], we lose
-[~14%][open-collective-faq] of every credit card donation to administrative
-overhead.
+With the help of our community, we hope to eventually build a nonprofit organization that will ensure the long-term future of the Qubes Project.
 
----
+### How is My Donation Used?
+Your donation pays directly for individual developers who have been hired to work on the open source edition of Qubes. 
 
-## About Your Donation
+We regret that we cannot implement requested features based on funding (if everybody were to decide, then nothing would get implemented).
 
-- We will use your donations to fund our continued development of Qubes.
-- We regret that we cannot implement requested features based on funding. (If
-  everybody were to decide, then nothing would get implemented.)
-- Donations to the Qubes project are not tax-deductible.
+### Is My Donation Tax Deductible?
+Donations to the Qubes project are not tax deductible.
 
-[funding]: /funding/
+### Can I Donate Something Other Than Money?
+We prefer monetary contributions which allow us greater flexibility. However, if you or your organization has relevant knowledge, experience, leads, or resources and would like to help us secure the future of Qubes OS, don’t hesitate to [contact us][contact].
+
+### <a name="verify-address"></a>How Do I Verify Your Bitcoin Address?
+The donation address can be verified via the [Qubes Security Pack][Qubes Security Pack], specifically in the [fund directory][fund]. We provide [detailed instructions for verifying the digital signatures][verify]. You can also view the address on [blockexplorer.com][blockexplorer.com] and [blockchain.info][blockchain.info].
+
+The Qubes Project maintains a [decentralized Bitcoin fund using a multi-signature wallet][announcement]. This means that no single person is capable of spending these funds.
+
+### What is Qubes?
+Qubes OS is a free and open source operating system that focuses on security and privacy. Its architecture is built to enable you to define and visualize different security environments on your computer and control how they interact, helping you to get your work done safely.
+
+Visit our [introduction page to Qubes][intro page] or watch a [video overview of the system][video page] to learn more.
+
+[Bitcoin donations]: #bitcoin
+[stripe]: https://stripe.com
+
+[open-collective-faq]: https://opencollective.com/faq
+[verify address]: #
+[Open Collective]: https://opencollective.com/qubes-os
+[Open Collective donate]: https://opencollective.com/qubes-os#support
 [Qubes Partners page]: /partners/
+[contact]: mailto:funding@qubes-os.org
 [Qubes Security Pack]: /doc/security-pack/
 [fund]: https://github.com/QubesOS/qubes-secpack/tree/master/fund
-[announcement]: /news/2016/07/13/qubes-distributed-fund/
 [verify]: /doc/security-pack/#how-to-obtain-verify-and-read
 [blockexplorer.com]: https://blockexplorer.com/address/3GakuQQDUGyyUnV1p5Jc3zd6CpQDkDwmDq
 [blockchain.info]: https://blockchain.info/address/3GakuQQDUGyyUnV1p5Jc3zd6CpQDkDwmDq
-[Open Collective]: https://opencollective.com/qubes-os
-[Bitcoin donations]: #bitcoin
-[open-collective-faq]: https://opencollective.com/faq
-[stripe]: https://stripe.com
-
+[announcement]: /news/2016/07/13/qubes-distributed-fund/
+[intro page]: /intro/
+[video page]: /video-tours/

--- a/pages/funding.md
+++ b/pages/funding.md
@@ -52,7 +52,7 @@ Below you can find the funding of the project by year.
 | $50,000+  |
 | $10,000+  |
 
-2010-2014
+2010–2014
 ---------
 
 | Funding tiers

--- a/pages/partners.md
+++ b/pages/partners.md
@@ -1,44 +1,46 @@
 ---
 layout: default
-title: Partners
+title: Qubes Partners
 permalink: /partners/
 redirect_from: /en/partners/
 ---
 
-Qubes Partners
+Our Partners
 ==============
 
-This page is dedicated to recogizing the organizations, companies, and
-individuals who have contributed support to the development of Qubes OS. The
-Qubes Project is grateful for their support! If your organization is interested
-in becoming a Qubes Partner, please [contact us]. You can also read more about
-how Qubes is [funded] and about making a [monetary donation] to the project.
+The Qubes Project relies greatly on the generous support of the organizations, companies, and individuals who have become Qubes Partners. Each year, we seek new sources of significant funding to support our ongoing efforts.
 
-<table class="partners">
-  <thead>
-    <tr>
-      <th>Tier</th>
-      <th>Partner</th>
-      <th>Description</th>
-    </tr>
-  </thead>
+Please [contact us][contact] if you or your organization is interested in becoming a Qubes Partner.
+
+## Funding by Year
+
+### 2017
+- We are seeking funders in all tiers for 2017.
+
+### 2016
+- **$250,000+** [Open Technology Fund](#open-technology-fund)
+- **$10,000+** [NLnet Foundation](#nlnet-foundation)
+
+### 2015
+- **$100,000+** [Open Technology Fund](#open-technology-fund)    
+
+### 2014 and earlier
+- **$∞** [Invisible Things Lab](#invisible-things-lab)
+
+## Our Partners
+We would like to recognize the following Qubes Partners. We are grateful for their support!
+
+<table class="partners" border="0">
   <tbody>
     <tr id="invisible-things-lab">
-      <td rowspan="2">
-        $500,000+
-      </td>
       <td>
         <a href="http://invisiblethingslab.com/itl/Welcome.html">
           <img src="/attachment/site/itl.png">
         </a>
       </td>
       <td>
-        <a href="http://invisiblethingslab.com/itl/Welcome.html">Invisible
-        Things Lab s.c. (ITL)</a> is a privately held company based in
-        Warsaw, Poland, owned by Joanna Rutkowska and Joanna Gołębiewska. ITL
-        supported Qubes OS development from the beginning of the project in 2010
-        until the end of 2014. ITL's primary source of revenue is security
-        research and development.
+        <h3>Invisible Things Lab</h3><a href="http://invisiblethingslab.com/itl/Welcome.html">
+        <p>Invisible Things Lab s.c. (ITL)</a> is a privately held company based in Warsaw, Poland, owned by Joanna Rutkowska and Joanna Gołębiewska. ITL supported Qubes OS development from the beginning of the project in 2010 through 2014. The company’s primary source of revenue is security research and development.</p>
       </td>
     </tr>
     <tr id="open-technology-fund">
@@ -48,39 +50,25 @@ how Qubes is [funded] and about making a [monetary donation] to the project.
         </a>
       </td>
       <td>
-        <a href="https://www.opentechfund.org/">Open Technology Fund (OTF)</a>
+        <h3>Open Technology Fund</h3>
+        <p><a href="https://www.opentechfund.org/">Open Technology Fund (OTF)</a>
         is a United States government-funded program of
-        <a href="http://www.rfa.org">Radio Free Asia</a>, whose
-        <a href="https://www.opentech.fund/about/program">stated mission</a> is
+        <a href="http://www.rfa.org">Radio Free Asia</a>, whose stated mission is
         to "support open technologies and communities that increase free
         expression, circumvent censorship, and obstruct repressive surveillance
-        as a way to promote human rights and open societies." In 2015-2016, OTF
-        <a href="https://www.opentech.fund/project/qubes-os">funded</a> the
-        Qubes project in a number of activities to improve Qubes, make it easier
-        to use and more accessible. In 2014-2015, OTF
-        <a href="https://www.opentech.fund/project/qubes-os">funded</a> the
-        Qubes project to integrate <a href="https://www.whonix.org/">Whonix</a>,
-        improve hardware compatibility and user experience. The complete
-        announcement is available
-        <a href="http://blog.invisiblethings.org/2015/06/04/otf-funding-announcement.html">here</a>.
+        as a way to promote human rights and open societies."</p>
+        <p><a href="https://blog.invisiblethings.org/2015/06/04/otf-funding-announcement.html">OTF has funded a number of improvements to Qubes</a>, including better accessibility and user experience, integration of Whonix, and improved hardware compatibility. Visit the <a href="https://www.opentech.fund/project/qubes-os">Qubes funding page on OTF’s website</a> for more information.</p>
       </td>
     </tr>
     <tr id="access-now">
-      <td rowspan="2">
-        $10,000+
-      </td>
       <td>
         <a href="https://www.accessnow.org/">
           <img src="/attachment/site/accessnow.png">
         </a>
       </td>
       <td>
-        <a href="https://www.accessnow.org/">Access Now</a> is an international
-        human rights organization whose
-        <a href="https://www.accessnow.org/about-us/">stated mission</a> is to
-        "defend and extend the digital rights of users at risk around the
-        world." Beginning in 2015, Access Now generously agreed to provide staff
-        time to help manage the Qubes OS project.
+        <h3>Access Now</h3>
+        <p><a href="https://www.accessnow.org/">Access Now</a> is an international human rights organization whose stated mission is to “defend and extend the digital rights of users at risk around the world.” Beginning in 2015, Access Now generously agreed to provide staff time to help manage the Qubes OS project.</p>
       </td>
     </tr>
     <tr id="nlnet-foundation">
@@ -90,20 +78,12 @@ how Qubes is [funded] and about making a [monetary donation] to the project.
         </a>
       </td>
       <td>
-        <a href="https://nlnet.nl">Stichting NLnet</a> ("NLnet Foundation" in
-        English) is a recognized philanthropic non-profit foundation based in
-        the Netherlands, whose <a href="https://nlnet.nl/foundation/">stated
-        mission</a> is "to promote the exchange of electronic information
-        and all that is related or beneficial to that purpose." In 2016, the
-        NLnet Foundation provided a grant to the Qubes project to support
-        improvements in automated build processes, Debian template packaging,
-        networking & privacy, and hardware compatibility.
+        <h3>NLnet Foundation</h3>
+        <p><a href="https://nlnet.nl">NLnet Foundation</a> is a recognized philanthropic nonprofit foundation based in the Netherlands and whose stated mission is "to promote the exchange of electronic information and all that is related or beneficial to that purpose."</p>
+        <p>In 2016, the NLnet Foundation provided a grant to the Qubes project to support improvements in automated build processes, Debian template packaging, networking and privacy, and hardware compatibility.</p>
       </td>
     </tr>
   </tbody>
 </table>
 
-[funded]: /funding/
-[monetary donation]: /donate/
-[contact us]: mailto:funding@qubes-os.org
-
+[contact]: mailto:funding@qubes-os.org


### PR DESCRIPTION
The content of the Donate and Partners pages has been rewritten from a communications standpoint to

- address the needs of the target audience
- provide a better information UX
- clarify the donation options
- simplify the donation process for potential donors.

The purpose of separate Funding and Partner pages was unclear and confusing. To remedy this, the information on the Funding page has been folded into the Donate and Partners pages and should therefore be removed.