### PR TITLE
Differential spell checking

### DIFF
--- a/_utils/spellcheck.sh
+++ b/_utils/spellcheck.sh
@@ -88,11 +88,11 @@ check_one() {
     v "Checking out $ref..."
     mkdir -p "$checkout"
     cp -pr .git "$checkout"
-    git -C "$checkout" checkout --force "$ref"
-    git -C "$checkout" submodule update --checkout --recursive --force
+    git -q -C "$checkout" checkout --force "$ref"
+    git -q -C "$checkout" submodule update --checkout --recursive --force
 
     v "Building $ref..."
-    ( cd "$checkout" && make > /dev/null )
+    ( cd "$checkout" && make >/dev/null 2>&1 )
     find_suspects "$checkout/_site" "$tree"
     find "$tree" -type f -exec cat {} + | sort -u > "$flat"
 }

--- a/_utils/spellcheck.sh
+++ b/_utils/spellcheck.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+v() { [ -n "$VERBOSE" ] && echo "$@" ; }
+
+if command -v hunspell > /dev/null; then
+    check_words() { hunspell -l; }
+elif command -v aspell > /dev/null; then
+    check_words() { aspell | grep '^[#&]' | cut -d' ' -f2; }
+else
+    echo "${0##*/}: No spell checker installed. Need hunspell or aspell." >&2
+    exit 1
+fi
+
+extract_words() {
+    pandoc -tjson "$@" | jq -r '
+    # will be builtin in a future version of jq. is already in master
+    # Apply f to composite entities recursively, and to atoms
+    def walk(f):
+      . as $in
+      | if type == "object" then
+          reduce keys[] as $key
+            ( {}; . + { ($key):  ($in[$key] | walk(f)) } ) | f
+      elif type == "array" then map( walk(f) ) | f
+      else f
+      end;
+
+    # strip code
+    walk (
+      if (type == "object") then
+        if (.t == "CodeBlock" or .t == "Code") then
+          empty
+        else
+          .
+        end
+      else
+        .
+      end
+    ) |
+
+    # extract raw string nodes
+    .. | select(type=="object" and has("t") and .t=="Str") | .c
+    '
+}
+
+find_suspects() {
+    local workdir=$1
+    local outdir=$2
+    mkdir -p "$outdir"
+    v "Parsing $outdir..."
+    find "$workdir" -mindepth 1 -type d -printf '%P\0' \
+      | ( cd "$outdir" && xargs -0 mkdir -p ) >&2
+    find "$workdir" -type f -name '*.html' -printf '%P\0' \
+      | while read -d '' f; do
+        extract_words "${workdir}/${f}" | check_words | sort -u \
+          > "${outdir}/${f}.wrong"
+    done
+}
+
+check_one() {
+    local ref=$1
+    local checkout="${d}/${ref}.checkout"
+    [ -d "$checkout" ] && { v "Using cached $ref"; return; }
+    local tree="${d}/${ref}.suspects.tree"
+    local flat="${d}/${ref}.suspects.flat"
+    v "Checking out $ref..."
+    mkdir -p "$checkout"
+    git --work-tree="$checkout" checkout "$ref" -- .
+    v "Building $ref..."
+    ( cd "$checkout" && make > /dev/null )
+    find_suspects "$checkout/_site" "$tree"
+    find "$tree" -type f -exec cat {} + | sort -u > "$flat"
+}
+
+diff_two() {
+    local old=$1
+    local new=$2
+    local cmp="${d}/${old}..${new}"
+    check_one "$old"
+    check_one "$new"
+    [ -e "${cmp}.plusminus" ] && { v "Using cached diff"; return; }
+    diff -urd "$d"/{"${old}","${new}"}.suspects.tree > "${cmp}.diff.tree" || :
+    diff -ur  "$d"/{"${old}","${new}"}.suspects.flat > "${cmp}.diff.flat" || :
+    grep -v '^\( \|@\|+++\|---\)' < "${cmp}.diff.flat" | LC_ALL=C sort \
+      > "${cmp}.plusminus" || :
+    grep '^+' < "${cmp}.plusminus" > "${cmp}.plus" || :
+    grep '^-' < "${cmp}.plusminus" > "${cmp}.minus" || :
+}
+
+show() {
+    local ref=$1
+    while read -d $'\n' suspect; do
+        ( cd "$d/${ref}.checkout" && \
+          find -type f -exec grep --color=always -rHnwF "$suspect" {} + )
+    done
+}
+
+
+if [ -n "$SPELL_CHECK_CACHE" ]; then
+    d=$SPELL_CHECK_CACHE
+    mkdir -p "$d"
+    echo "Using spell check cache dir: $d"
+else
+    d=$(mktemp -d)
+    trap 'rm -rf "$d"' EXIT
+fi
+
+case $# in
+0)
+    old=$(git rev-parse HEAD)
+    new=$(git rev-parse refs/remotes/origin/master)
+    ;;
+1)
+    old=$(git rev-parse "$1"^)
+    new=$(git rev-parse "$1")
+    ;;
+2)
+    old=$(git rev-parse "$1")
+    new=$(git rev-parse "$2")
+    ;;
+*)
+    echo "Usage: ${0##*/} [[old-ref] new-ref]" >&2
+    exit 2
+esac
+
+diff_two "$old" "$new"
+
+ansi() { cc=$1; shift; printf "\x1b[${cc}m%s\x1b[0m\n" "$*" ; }
+red() { ansi 31 "$@" ; }
+green() { ansi 32 "$@" ; }
+
+plus=${d}/${old}..${new}.plus
+minus=${d}/${old}..${new}.minus
+
+echo "Spelling report for ${old:0:8}..${new:0:8}:"
+echo
+if [ -s "$plus" ]; then
+    red 'The following new unknown spellings were introduced:'
+    sed 's/^/	/' < "$plus"
+else
+    green 'No new unique misspellings were introduced.'
+fi
+if [ -s "$minus" ]; then
+    echo
+    echo 'In addition, the following suspicious spellings were eliminated:'
+    sed 's/^/	/' < "$minus"
+fi
+
+# exit 0 if no new unknown unique spellings were introduced, 1 otherwise
+test -s "$plus"

--- a/_utils/spellcheck.sh
+++ b/_utils/spellcheck.sh
@@ -3,7 +3,11 @@
 set -e
 set -o pipefail
 
-v() { [ -n "$VERBOSE" ] && echo "$@" ; }
+v() {
+    if [ -n "$VERBOSE" ]; then
+        echo "$@"
+    fi
+}
 
 if command -v hunspell > /dev/null; then
     check_words() { hunspell -l; }
@@ -81,8 +85,7 @@ diff_two() {
     check_one "$old"
     check_one "$new"
     [ -e "${cmp}.plusminus" ] && { v "Using cached diff"; return; }
-    diff -urd "$d"/{"${old}","${new}"}.suspects.tree > "${cmp}.diff.tree" || :
-    diff -ur  "$d"/{"${old}","${new}"}.suspects.flat > "${cmp}.diff.flat" || :
+    diff -u "$d"/{"${old}","${new}"}.suspects.flat > "${cmp}.diff.flat" || :
     grep -v '^\( \|@\|+++\|---\)' < "${cmp}.diff.flat" | LC_ALL=C sort \
       > "${cmp}.plusminus" || :
     grep '^+' < "${cmp}.plusminus" > "${cmp}.plus" || :
@@ -149,4 +152,4 @@ if [ -s "$minus" ]; then
 fi
 
 # exit 0 if no new unknown unique spellings were introduced, 1 otherwise
-test -s "$plus"
+! test -s "$plus"


### PR DESCRIPTION
This script does not attempt to find all misspellings, but rather show
when new words not previously known are introduced. This mean it's
useful in a continuous integration pipeline where we don't necessarily
want each contributor to have to be responsible for the bad spelling of
whoever came before them, but rather at least not make things worse.
The existing spelling can then be incrementally cleaned up.

This approach also means we don't need to maintain a local dictionary to
avoid false-positives, because existing "misspelled words" ("AppVM",
"marmarek", etc.) will be ignored.

In adition, effort is made to only check prose, not code. All the actual
parsing logic is handled by pandoc, and we just filter and transform a
JSON AST that it produces.

We also operate on the fully built HTML site rather than the source
markdown, meaning we see all spellings as they exist post-templating,
including all values from _data/*.yaml and such already filled in.

This was written primarily for use in a CI hook, but is of course also
useful locally. The default invocation checks the net difference between
origin/master and your local HEAD. You can also set SPELL_CHECK_CACHE to
a directory in which to keep results of previous runs, which speeds up
re-checking incremental changes.

Introduced dependencies are: hunspell (preferred) or aspell, and jq.

Fixes: https://github.com/QubesOS/qubes-issues/issues/2725