### PR TITLE
Reduce jekyll build verbosity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,10 @@
-JEKYLLOPTS = --verbose --trace
-
 all:
-	bundle exec jekyll build $(JEKYLLOPTS)
+	bundle exec jekyll build
 
 clean:
 	$(RM) -r _site
 
 serve:
-	bundle exec jekyll serve --watch $(JEKYLLOPTS)
+	bundle exec jekyll serve --watch
 
 .PHONY: all clean serve


### PR DESCRIPTION
So that warnings are actually noticed instead of instantly scrolling off the screen.