### PR TITLE
travis: use separate working directory for main repo too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: ruby
 dist: trusty
 rvm:
  - 2.1
-install: true
-script: ./_utils/travis.sh
+install: git clone https://github.com/${TRAVIS_REPO_SLUG%%/*}/qubesos.github.io ~/qubesos.github.io
+script: ~/qubesos.github.io/_utils/travis.sh
 notifications:
   email:
     recipients:


### PR DESCRIPTION
Do not start from what travis have downloaded, because in case of PR we
expect to build the old version first (but travis have downloaded new
one already).

Fixes QubesOS/qubes-issues#2935