### PR TITLE
Spell checking redux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,13 @@ rvm:
  - 2.1
 install: git clone https://github.com/${TRAVIS_REPO_SLUG%%/*}/qubesos.github.io ~/qubesos.github.io
 script: ~/qubesos.github.io/_utils/travis.sh
+addons:
+  apt:
+    # These must be kept in sync with the .travis.yml in submodules
+    packages:
+    - hunspell
+    - pandoc
+    - jq
 notifications:
   email:
     recipients:

--- a/_utils/spellcheck.sh
+++ b/_utils/spellcheck.sh
@@ -136,8 +136,17 @@ usage() {
     exit 2
 }
 
-d=$(mktemp -d)
-trap 'rm -rf "$d"' EXIT
+# Allow specifying someplace to save the intermediate state,
+# otherwise put it in a temp dir and remove it on exit
+if [ -n "$SPELLCHECK_WORKDIR" ]; then
+    d="$SPELLCHECK_WORKDIR"
+    rm -rf "$d"
+    mkdir -p "$d"
+else
+    d=$(mktemp -d)
+    trap 'rm -rf "$d"' EXIT
+fi
+v "Using $d as work dir"
 
 repo="$(dirname "$(dirname "$(readlink -f "$0")")")"
 

--- a/_utils/spellcheck.sh
+++ b/_utils/spellcheck.sh
@@ -1,0 +1,171 @@
+#!/bin/bash
+
+set -e
+set -o pipefail
+
+v() {
+    if [ -n "$VERBOSE" ]; then
+        echo "$@"
+    fi
+}
+vtime() {
+    if [ -n "$VERBOSE" ]; then
+        time "$@"
+    else
+        "$@"
+    fi
+}
+
+if command -v hunspell > /dev/null; then
+    check_words() { hunspell -l; }
+elif command -v aspell > /dev/null; then
+    check_words() { aspell | grep '^[#&]' | cut -d' ' -f2; }
+else
+    echo "${0##*/}: No spell checker installed. Need hunspell or aspell." >&2
+    exit 1
+fi
+
+extract_words() {
+    pandoc -tjson "$@" | jq -r '
+    # will be builtin in a future version of jq. is already in master
+    # Apply f to composite entities recursively, and to atoms
+    def walk(f):
+      . as $in
+      | if type == "object" then
+          reduce keys[] as $key
+            ( {}; . + { ($key):  ($in[$key] | walk(f)) } ) | f
+      elif type == "array" then map( walk(f) ) | f
+      else f
+      end;
+
+    # strip code
+    walk (
+      if (type == "object") then
+        if (.t == "CodeBlock" or .t == "Code") then
+          empty
+        else
+          .
+        end
+      else
+        .
+      end
+    ) |
+
+    # extract raw string nodes
+    .. | select(type=="object" and has("t") and .t=="Str") | .c
+    '
+}
+
+check_site() {
+    local site_in=$1
+    local words_out=$2
+
+    rm -rf "$words_out"
+    mkdir -p "$words_out/suspects.tree"
+    v "Checking $site_in, storing results in $words_out"
+    find "$site_in" -mindepth 1 -type d -printf '%P\0' \
+      | ( cd "$words_out/suspects.tree" && xargs -0 mkdir -p ) >&2
+    find "$site_in" -type f -name '*.html' -printf '%P\0' \
+      | while read -d '' f; do
+        extract_words "$site_in/$f" | check_words | sort -u \
+          > "$words_out/suspects.tree/${f}.wrong"
+    done
+    find "$words_out/suspects.tree" -type f -exec cat {} + | sort -u \
+      > "$words_out/suspects.flat"
+}
+
+diff_checked() {
+    local old=$1
+    local new=$2
+    local diff_dir=$3
+
+    rm -rf "$diff_dir"
+    mkdir -p "$diff_dir"
+    diff -u {"$old","$new"}/suspects.flat > "$diff_dir/diff" || :
+    grep -v '^\( \|@\|+++\|---\)' < "$diff_dir/diff" | LC_ALL=C sort \
+      > "$diff_dir/plusminus" || :
+    grep '^+' < "$diff_dir/plusminus" > "$diff_dir/plus" || :
+    grep '^-' < "$diff_dir/plusminus" > "$diff_dir/minus" || :
+}
+
+
+ansi() { cc=$1; shift; printf "\x1b[${cc}m%s\x1b[0m\n" "$*" ; }
+red() { ansi 31 "$@" ; }
+green() { ansi 32 "$@" ; }
+
+show_in_src() {
+    local src_dir=$1
+
+    while read -d $'\n' suspect; do
+        ( cd "$src_dir" && \
+          find -type f -not -path './_site/*' -not -path './.git/*' \
+            -exec grep --color=always -rHnwF "$suspect" {} + )
+    done
+}
+
+report_diff() {
+    local diff_dir=$1
+    local src_dir=$2
+
+    if [ -s "$diff_dir/plus" ]; then
+        red 'The following new unknown spellings were introduced:'
+        sed 's/^/    /' < "$diff_dir/plus"
+    else
+        green 'No new unique misspellings were introduced.'
+    fi
+
+    if [ -s "$diff_dir/minus" ]; then
+        echo
+        echo 'In addition, the following suspicious spellings were eliminated:'
+        sed 's/^/    /' < "$diff_dir/minus"
+    fi
+
+    if [ -s "$diff_dir/plus" ]; then
+        echo
+        echo 'The introduced suspects in context are:'
+        echo
+        sed 's/^+//' < "$diff_dir/plus" | show_in_src "$src_dir"
+        echo
+        echo 'If these are false-positives, simply commit as is and they will'
+        echo 'be ignored in the future.'
+    fi
+}
+
+usage() {
+    echo "Usage: ${0##*/} [[old-built-site] HEAD-built-site]" >&2
+    exit 2
+}
+
+d=$(mktemp -d)
+trap 'rm -rf "$d"' EXIT
+
+repo="$(dirname "$(dirname "$(readlink -f "$0")")")"
+
+case $# in
+0)
+    if ! [ -d "$repo/_site" ]; then
+        echo "${0##*/}: zero-argument form requires a built site in _site" >&2
+        usage
+    fi
+    vtime check_site "$repo/_site" "$d"
+    v
+    show_in_src "$repo" < "$d/suspects.flat"
+    ;;
+1)
+    vtime check_site "$1" "$d"
+    v
+    show_in_src "$repo" < "$d/suspects.flat"
+    ;;
+2)
+    vtime check_site "$1" "$d/old"
+    vtime check_site "$2" "$d/new"
+    v
+    diff_checked "$d/old" "$d/new" "$d/diff"
+    report_diff "$d/diff"
+    # exit 0 if no new unknown unique spellings were introduced, 1 otherwise
+    ! test -s "$d/diff/plus"
+    ;;
+*)
+    usage
+    ;;
+esac

--- a/_utils/travis.sh
+++ b/_utils/travis.sh
@@ -5,7 +5,7 @@ set -e
 set -o pipefail
 
 is_pr() {
-	test -n "$TRAVIS_PULL_REQUEST" -a false != "$TRAVIS_PULL_REQUEST"
+    test -n "$TRAVIS_PULL_REQUEST" -a false != "$TRAVIS_PULL_REQUEST"
 }
 
 cd "$(dirname "$0")/.."
@@ -23,11 +23,11 @@ repo_name=${TRAVIS_REPO_SLUG#*/}
 # Use modules of same owner so you can test whole site before proposing PR
 git config --file .gitmodules --get-regexp '.*\.url' \
 | while read repo url; do
-	owner_url="${url/github.com\/[^\/]*\//github.com/${repo_owner}/}"
-	: url=$url
-	: repo_owner=$repo_owner
-	: owner_url=$owner_url
-	git config --file .gitmodules "$repo" "$owner_url"
+    owner_url="${url/github.com\/[^\/]*\//github.com/${repo_owner}/}"
+    : url=$url
+    : repo_owner=$repo_owner
+    : owner_url=$owner_url
+    git config --file .gitmodules "$repo" "$owner_url"
 done
 
 git submodule update --init --recursive
@@ -36,8 +36,8 @@ if is_pr; then
     echo "building original site to compare"
     bundle exec jekyll build
 
-	echo moving old site
-	mv _site ~/old_site
+    echo moving old site
+    mv _site ~/old_site
 fi
 
 if [ "$repo_name" != "qubesos.github.io" ]; then
@@ -51,8 +51,8 @@ git -C "$sub_path" checkout FETCH_HEAD
 bundle exec jekyll build
 
 if [ -d ~/old_site ]; then
-	echo diffing
-	diff -ur ~/old_site ./_site || true
+    echo diffing
+    diff -ur ~/old_site ./_site || true
 fi
 
 htmlproofer ./_site --disable-external --checks-to-ignore ImageCheck --file-ignore ./_site/video-tours/index.html --url-ignore "/qubes-issues/"

--- a/_utils/travis.sh
+++ b/_utils/travis.sh
@@ -50,9 +50,28 @@ git -C "$sub_path" fetch --update-shallow ${TRAVIS_BUILD_DIR} HEAD
 git -C "$sub_path" checkout FETCH_HEAD
 bundle exec jekyll build
 
+all_ok=true
+
 if [ -d ~/old_site ]; then
     echo diffing
     diff -ur ~/old_site ./_site || true
+
+    echo
+    echo "Spelling report for $TRAVIS_COMMIT_RANGE:"
+    echo
+    _utils/spellcheck.sh ~/old_site _site || all_ok=false
+    echo
 fi
 
-htmlproofer ./_site --disable-external --checks-to-ignore ImageCheck --file-ignore ./_site/video-tours/index.html --url-ignore "/qubes-issues/"
+htmlproofer ./_site \
+  --disable-external \
+  --checks-to-ignore ImageCheck \
+  --file-ignore ./_site/video-tours/index.html \
+  --url-ignore "/qubes-issues/" || all_ok=false
+
+if $all_ok; then
+    echo 'All checks passed!'
+else
+    echo 'Some checked failed. See above.'
+    exit 1
+fi


### PR DESCRIPTION
Differential spell checking

This script does not attempt to find all misspellings, but rather show when new words not previously known are introduced. This means it's useful in a continuous integration pipeline where we don't necessarily want each contributor to have to be responsible for the bad spelling of whoever came before them, but rather at least not make things worse. The existing spelling can then be incrementally cleaned up.

This approach also means we don't need to maintain a local dictionary to avoid false-positives, because existing "misspelled words" ("AppVM", "marmarek", etc.) will be ignored.

In addition, effort is made to only check prose, not code. All the actual parsing logic is handled by pandoc, and we just filter and transform a JSON AST that it produces.

We also operate on the fully built HTML site rather than the source markdown, meaning we see all spellings as they exist post-templating, including all values from _data/*.yaml and such already filled in.

This was written primarily for use in a CI hook, but is also useful locally. It can be used in non-differential mode to show all existing "misspellings" (with lots of false positives), or in differential mode if you keep around an old copy of the built site. This only operates on built copies of the site, so it is up to the caller to keep around an old copy of the built site to compare against.

A previous version of this script which attempted to check out and build the correct sites from git for comparison can be found in https://github.com/QubesOS/qubesos.github.io/pull/110. It was determined that this was not the right way to approach the problem.

Introduced dependencies are:
- hunspell (preferred) or aspell
- pandoc
- jq

All builds for submodules will fail until these are merged too:
- https://github.com/QubesOS/qubes-doc/pull/448
- https://github.com/QubesOS/qubes-hcl/pull/14
- https://github.com/QubesOS/qubes-posts/pull/51

As an example of the results, see the following test commits & builds:
- A baseline test where no additional misspellings are introduced
  - PR: https://github.com/qubesos-bot-jpo/qubes-doc/pull/5/files
  - build: https://travis-ci.org/qubesos-bot-jpo/qubes-doc/builds/256446011#L836
- A test with a misspelling in the main qubesos.github.io repo:
  - PR: https://github.com/qubesos-bot-jpo/qubesos.github.io/pull/5/files
  - build: https://travis-ci.org/qubesos-bot-jpo/qubesos.github.io/builds/256986273#L927
- A test with a misspelling in qubes-doc:
  - PR: https://github.com/qubesos-bot-jpo/qubes-doc/pull/4/files
  - build: https://travis-ci.org/qubesos-bot-jpo/qubes-doc/builds/256445279#L850

Be aware that only the PR builds (not the commit builds) fail on new misspellings. This is because misspelling detection is edge-triggered rather than level-triggered (in order to avoid false-positives without maintaining a massive local dictionary), and commit builds do not have a base to compare against whereas PR build do.

Fixes https://github.com/QubesOS/qubes-issues/issues/2725