### PR TITLE
Keep links the same font size as the text they appear in

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -92,7 +92,6 @@ img {
 a {
   color: $brand-primary;
   text-decoration: none;
-  font-size: 14px;
   font-family: $base-font-family-bold;
   font-weight: bold;
   border-bottom: 0px solid transparent;

--- a/_sass/_toc.scss
+++ b/_sass/_toc.scss
@@ -56,6 +56,7 @@
       list-style-type: none;
       padding-left: 5px;
       margin-bottom: $spacing-unit;
+      font-size: 14px;
     }
     li > ul li:last-child {
       margin-bottom: ($spacing-unit / 2);


### PR DESCRIPTION
This was causing problems for example in links in headers, as seen (before this commit) in:
- https://www.qubes-os.org/doc/qubes-builder-details/

The only regression I saw was for the size of entries in the auto-generated table-of-contents on docs pages (which I've fixed). There may be other regressions, but I think this is the right approach regardless and there is a clear existing problem it addresses.