### PR TITLE
Delete query `?v=bOv986l09r` from image URLs.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -78,12 +78,12 @@
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }} - Feed" href="/feed.xml" />
 
   <!-- Favicons -->
-  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=bOv986l09r">
-  <link rel="icon" type="image/png" href="/favicon-32x32.png?v=bOv986l09r" sizes="32x32">
-  <link rel="icon" type="image/png" href="/favicon-16x16.png?v=bOv986l09r" sizes="16x16">
-  <link rel="manifest" href="/manifest.json?v=bOv986l09r">
-  <link rel="mask-icon" href="/safari-pinned-tab.svg?v=bOv986l09r" color="#5bbad5">
-  <link rel="shortcut icon" href="/favicon.ico?v=bOv986l09r">
+  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
+  <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32">
+  <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16">
+  <link rel="manifest" href="/manifest.json">
+  <link rel="mask-icon" href="/safari-pinned-tab.svg" color="#5bbad5">
+  <link rel="shortcut icon" href="/favicon.ico">
   <meta name="apple-mobile-web-app-title" content="Qubes OS">
   <meta name="application-name" content="Qubes OS">
   <meta name="theme-color" content="#ffffff">

--- a/browserconfig.xml
+++ b/browserconfig.xml
@@ -2,7 +2,7 @@
 <browserconfig>
   <msapplication>
     <tile>
-      <square150x150logo src="/mstile-150x150.png?v=bOv986l09r"/>
+      <square150x150logo src="/mstile-150x150.png"/>
       <TileColor>#ffffff</TileColor>
     </tile>
   </msapplication>

--- a/manifest.json
+++ b/manifest.json
@@ -2,12 +2,12 @@
 	"name": "Qubes OS",
 	"icons": [
 		{
-			"src": "\/android-chrome-192x192.png?v=bOv986l09r",
+			"src": "\/android-chrome-192x192.png",
 			"sizes": "192x192",
 			"type": "image\/png"
 		},
 		{
-			"src": "\/android-chrome-512x512.png?v=bOv986l09r",
+			"src": "\/android-chrome-512x512.png",
 			"sizes": "512x512",
 			"type": "image\/png"
 		}


### PR DESCRIPTION
There is the query `?v=bOv986l09r` inside some image-related URLs:

```
$ grep --exclude-dir _site -nre '\?v=bOv986l09r'
browserconfig.xml:5:      <square150x150logo src="/mstile-150x150.png?v=bOv986l09r"/>
_includes/head.html:81:  <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=bOv986l09r">
_includes/head.html:82:  <link rel="icon" type="image/png" href="/favicon-32x32.png?v=bOv986l09r" sizes="32x32">
_includes/head.html:83:  <link rel="icon" type="image/png" href="/favicon-16x16.png?v=bOv986l09r" sizes="16x16">
_includes/head.html:84:  <link rel="manifest" href="/manifest.json?v=bOv986l09r">
_includes/head.html:85:  <link rel="mask-icon" href="/safari-pinned-tab.svg?v=bOv986l09r" color="#5bbad5">
_includes/head.html:86:  <link rel="shortcut icon" href="/favicon.ico?v=bOv986l09r">
manifest.json:5:                        "src": "\/android-chrome-192x192.png?v=bOv986l09r",
manifest.json:10:                       "src": "\/android-chrome-512x512.png?v=bOv986l09r",
```

The appropriate Git logs for the lines above

```
$ git log --pretty=short -u -L 5:browserconfig.xml
$ git log --pretty=short -u -L 81,86:_includes/head.html
$ git log --pretty=short -u -L 5:manifest.json
$ git log --pretty=short -u -L 10:manifest.json
```

all belong to

```
commit 4a7ad5903a418d6d0796026af1d2097459880e8f (tag: adw_4a7ad590)
Author: Andrew David Wong <adw@qubes-os.org>

    Generate favicons for all browsers and platforms
```

and don't reveal any motivation for it. 

Deleting it doesn't seem to break anything.

I couldn't find any similar queries in this repo.