### PR TITLE
Use --only_4xx to prevent failure on successful redirects

### DIFF
--- a/_utils/travis.sh
+++ b/_utils/travis.sh
@@ -67,7 +67,8 @@ htmlproofer ./_site \
   --disable-external \
   --checks-to-ignore ImageCheck \
   --file-ignore ./_site/video-tours/index.html \
-  --url-ignore "/qubes-issues/" || all_ok=false
+  --url-ignore "/qubes-issues/" || all_ok=false \
+  --only_4xx
 
 if $all_ok; then
     echo 'All checks passed!'


### PR DESCRIPTION
Any objections, @marmarek?

> Adds the '--only_4xx' option to HTMLProofer, which "Only reports errors
> for links that fall within the 4xx status code range." [1] The rationale
> is that Travis CI should not fail just because there are successful
> redirects.
> 
> In particular, redirects from unversioned URLs to versioned URLs are
> desirable to support release-specific documentation (see
> QubesOS/qubes-issues#5308).
> 
> [1] https://github.com/gjtorikian/html-proofer#configuration