### PR TITLE
Allow setting custom messages in HCL cells

### DIFF
--- a/_includes/hcl-cell.html
+++ b/_includes/hcl-cell.html
@@ -1,8 +1,14 @@
-{% if include.param %}
-  {% assign value = include.param %}
+{% if include.param['status'] %}
+    {% assign value = include.param.message %}
+    {% assign status = include.param.status %}
 {% else %}
-  {% assign value = 'unknown' %}
+  {% if include.param %}
+    {% assign value = include.param %}
+  {% else %}
+    {% assign value = 'unknown' %}
+  {% endif %}
+    {% assign status = value %}
 {% endif %}
-<td{{ include.rowspan }} class="{% include hcl-color.css value=value %} text-center">
+<td{{ include.rowspan }} class="{% include hcl-color.css value=status %} text-center">
   {{ value }}
 </td>


### PR DESCRIPTION
The previous behavior is retained, but now you can specify a `status` key which is whatever would've been there before (no/yes/partial/etc.) which defines the color, and a `message` key which is what actually shows in the cell in the final HTML. I patched this mostly because I was in the middle of updating someone's HCL report for the laptop I'm using, and I wanted to use this exact functionality.

This needs to be documented somewhere but I'm still not sure what the best place to do that is...