### PR TITLE
Slightly improve wide tables usablility

### DIFF
--- a/css/main.scss
+++ b/css/main.scss
@@ -141,7 +141,6 @@ article table {
     display: block;
     overflow: auto;
     border-collapse: collapse;
-    white-space: nowrap;
     margin: 0 0 25px;
 }
 article td, article th {


### PR DESCRIPTION
- Reenable word wrap. Everything becomes super wide otherwise, and
  even normally not-wide tables break badly.
- Use "display: table". This makes the table go outside of normal
  layout, but doesn't hide the scrollbar (with "display: block",
  the scrollbar is attached to the table, potentially several
  screens down).
- Make sure table rows aren't transparent to fix glitches from
  going outside of normal layout.