### PR TITLE
Add Onion-Location meta tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,6 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="onion-location" content="http://qubesosfasa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion" />
 
   <title>
     {% if page.title and page.title != site.title and page.layout != 'home' %}


### PR DESCRIPTION
Starting with the release of [Tor Browser 9.5](https://blog.torproject.org/new-release-tor-browser-95), websites can have their alternate .onion addresses advertised to Tor desktop users who have the 'Onion Location' option enabled.

Sites that add the .onion address advertisement HTTP header can prompt their visitors to switch to a version delivered using the Onion service for improved security.

Final result:
![ezgif-2-354636e604ed](https://user-images.githubusercontent.com/46527252/83661669-bced5700-a5c6-11ea-9416-789ff30e52ef.gif)