### PR TITLE
Append the path to the active page in the Onion-Location header 

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="onion-location" content="http://qubesosfasa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion" />
+  <meta http-equiv="onion-location" content="http://qubesosfasa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion{{ page.url | replace:'index.html',''}}" />
 
   <title>
     {% if page.title and page.title != site.title and page.layout != 'home' %}

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -2,7 +2,7 @@
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta http-equiv="onion-location" content="http://qubesosfasa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion{{ page.url | replace:'index.html',''}}" />
+  <meta http-equiv="onion-location" content="http://qubesosfasa4zl44o4tws22di6kepyzfeqv3tg4e3ztknltfxqrymdad.onion{{ page.url | replace:'index.html','' }}" />
 
   <title>
     {% if page.title and page.title != site.title and page.layout != 'home' %}


### PR DESCRIPTION
The Onion-Location is set as a meta tag but is hard-coded to the front page. If a user is on another page on the site and decides to switch to the onion, they'll be taken to the front page rather than the onion equivalent of the current page.

See the docs at https://community.torproject.org/onion-services/advanced/onion-location/ which demonstrate header-based use with $request_uri / %{REQUEST_URI} (nginx/apache)

This fixes the issue (I hope!) by re-using your 'canonical' tag's method in the template to find the current URL.