### PR TITLE
Make External Documentation Warning Sticky

### DIFF
--- a/_includes/doc-external-warning.html
+++ b/_includes/doc-external-warning.html
@@ -1,4 +1,4 @@
-<div class="alert alert-warning" role="alert">
+<div class="alert alert-sticky alert-warning" role="alert">
   <i class="fa fa-exclamation-circle"></i>
   This is unofficial, third-party documentation.
   The Qubes OS Project cannot guarantee the accuracy of this page.

--- a/css/main.scss
+++ b/css/main.scss
@@ -185,3 +185,9 @@ article tr.center {
   }
 }
 
+// Custom - Sticky external documentation warning
+.alert-sticky {
+  position: sticky;
+  z-index: 1;
+  top: 10px;
+}


### PR DESCRIPTION
**The problem you're addressing (if any)**
Sharing a anchor link to an external documentation (within qubes-os.org/doc) page bypasses the warning to exercise caution (standard anchor link). Example: https://www.qubes-os.org/doc/network-bridge-support/#qubes-manager-patch-qubes-r2b2 (simply by using the anchor link to a lower part of the page). Anchor links are often shared in the support grups and I've found myself not noticing the warning.

Even though users are warned not to trust the website (distrust the infrastructure moto), in practice, I think most people coming to Qubes have no better alternative than to trust the website. So I'd argue it's better to show the warning at all times. (This has also happened to myself and even with me distrusting the website, it's good to have the "external docs" indicator)

The long-term solution as @andrewdavidwong argues is to move external docs away from qubes-doc

**Describe the solution you've implemented**
Sticky warning that scrolls with the page. It stays fixed in place at the top, but as the users scrolls

![qubes-sticky](https://user-images.githubusercontent.com/47065258/93013141-3832b180-f595-11ea-91c2-9a2268601fbf.png)

**Where is the value to a user, and who might that user be?**
New user to Qubes (has to trust the documentation on the website). When looking through the forum or the mailing lists if someone shares an anchor link to the external docs (within qubes-os.org/doc), they may miss the warning that that is external documentation and to proceed with caution.

**Additional context**
* There's only one issue that I've identified, which is when someone anchor links, the sticky bar will cover the beginning of the page. So the user will have to scroll slightly up to see the beginning.

* The solution works in modern firefox and chromium (tested with ones shipped with Qubes)

* It has been tested locally