### PR TITLE
fix Marta's github

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -66,7 +66,7 @@
   type: core
   picture: team-marta.jpg
   fingerprint: 7D22 413E F3DB 0761 2CF7  3808 7D77 9BFA 6C80 6F69
-  github: marta
+  github: marmarta
 
 - name: Michał Chiliński
   email: mich@invisiblethingslab.com


### PR DESCRIPTION
Marta's github was linking to https://github.com/marta instead of https://github.com/marmarta on the team page https://www.qubes-os.org/team/