### PR TITLE
Add helper scripts for signed reviews

### DIFF
--- a/_utils/review-ok
+++ b/_utils/review-ok
@@ -1,0 +1,43 @@
+#!/bin/bash
+  
+if [ -z "$1" ]; then
+    echo "usage: $0 origin/pr/NUMBER [message]" >&2
+    exit 2
+fi
+
+GNUPG=${GNUPG:-gpg}
+
+rev="$1"
+extra_msg="$2"
+
+sha=$(git rev-parse "$rev")
+
+num=${rev##*/}
+
+token=$(grep _token ~/.config/hub|cut -f 2 -d :)
+
+repo=$(git config remote.origin.url|
+        sed -e 's#[^:]*://[^/]*/##;s#git@github.com:##')
+repo=${repo%.git}
+
+review_msg="Approved as of $sha"
+if [ -n "$extra_msg" ]; then
+    review_msg="$extra_msg
+$review_msg"
+fi
+review_msg='```\n
+'"$(echo "$review_msg" | $GNUPG --clearsign|sed -e 's:$:\\n:')"'
+```'
+
+curl -o /dev/null -f -d @- -H "Authorization: token $token" https://api.github.com/repos/$repo/pulls/$num/reviews <<EOF
+{ "commit_id": "$sha",
+    "body": "$review_msg",
+    "event": "APPROVE",
+    "comments": []
+}
+EOF
+if [ $? -ne 0 ]; then
+    echo fail
+else
+    echo ok
+fi

--- a/_utils/review-verify
+++ b/_utils/review-verify
@@ -30,7 +30,7 @@ curl -sf https://api.github.com/repos/$repo/pulls/$num/reviews | jq -r '.[-1].bo
 approved_sha=
 
 # verify signed review
-$GNUPG --verify --output="$tmpdir/verified" --status-fd=3 3>"$tmpdir/gpg-status" <"$tmpdir/unverified" 2>/dev/null
+$GNUPG --verify --output "$tmpdir/verified" --status-fd 3 3>"$tmpdir/gpg-status" <"$tmpdir/unverified" 2>/dev/null
 if [ $(grep -c "^\[GNUPG:\] NEWSIG" "$tmpdir/gpg-status") -eq 1 ] && \
        grep -q '^\[GNUPG:\] TRUST_\(FULLY\|ULTIMATE\)' "$tmpdir/gpg-status"; then
     # verified

--- a/_utils/review-verify
+++ b/_utils/review-verify
@@ -1,0 +1,58 @@
+#!/bin/bash
+  
+if [ -z "$1" ]; then
+    echo "usage: $0 origin/pr/NUMBER" >&2
+    exit 2
+fi
+
+set -eu
+
+GNUPG=${GNUPG:-gpg}
+
+rev="$1"
+
+sha=$(git rev-parse "$rev")
+
+num=${rev##*/}
+
+token=$(grep _token ~/.config/hub|cut -f 2 -d :)
+
+repo=$(git config remote.origin.url|
+        sed -e 's#[^:]*://[^/]*/##;s#git@github.com:##')
+repo=${repo%.git}
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf -- "$tmpdir"' EXIT
+
+# get latest review text
+curl -sf https://api.github.com/repos/$repo/pulls/$num/reviews | jq -r '.[-1].body' > "$tmpdir/unverified"
+
+approved_sha=
+
+# verify signed review
+$GNUPG --verify --output="$tmpdir/verified" --status-fd=3 3>"$tmpdir/gpg-status" <"$tmpdir/unverified" 2>/dev/null
+if [ $(grep -c "^\[GNUPG:\] NEWSIG" "$tmpdir/gpg-status") -eq 1 ] && \
+       grep -q '^\[GNUPG:\] TRUST_\(FULLY\|ULTIMATE\)' "$tmpdir/gpg-status"; then
+    # verified
+    approved_sha=$(grep -o "^Approved as of [a-z0-9]\+" "$tmpdir/verified")
+    approved_sha=${approved_sha#Approved as of }
+else
+    echo "Signature verification failed"
+    exit 1
+fi
+
+if [ -z "$approved_sha" ]; then
+    echo "No 'Approved as of ...' message"
+    exit 1
+fi
+
+# print who approved
+grep '^\[GNUPG:\] GOODSIG ' "$tmpdir/gpg-status"
+
+if [ "$approved_sha" = "$sha" ]; then
+    echo "$approved_sha $(tput setaf 2)approved and matches$(tput sgr0) $rev"
+    exit 0
+else
+    echo "$rev approved as of $approved_sha but currently at $sha"
+    exit 1
+fi


### PR DESCRIPTION
1. `review-ok` post a review on github with clearsigned message
   including reviewed commit hash
2. `review-verify` downloads that review and verifies signature, then
   compares with the current commit at that PR

The review-ok script takes Github API token from ~/.config/hub (a
config for the `hub` tool).
The review-verify script uses default gpg keyring and expects trusted
keys to be marked as such ("ultimate" or "fully"). Split GPG can be used
by setting GNUPG env variable to qubes-gpg-client-wrapper.

@andrewdavidwong here is also the script for you.