### PR TITLE
HCL flat html-template for sorttable.js compatibility

### DIFF
--- a/_includes/hcl-cell.html
+++ b/_includes/hcl-cell.html
@@ -9,6 +9,6 @@
   {% endif %}
     {% assign status = value %}
 {% endif %}
-<td{{ include.rowspan }} class="{% include hcl-color.css value=status %} text-center">
+<td class="{% include hcl-color.css value=status %} text-center">
   {{ value }}
 </td>

--- a/_includes/hcl-device.html
+++ b/_includes/hcl-device.html
@@ -1,10 +1,8 @@
 {% assign rowspan = device.versions | size %}
 {% assign range = rowspan | minus:1 %}
-{% if rowspan >= 1 %}
-  {% capture rowspan %} rowspan="{{ rowspan }}"{% endcapture %}
-{% endif %}
+{% for i in (0..range) %}
 <tr id="{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}">
-  <td{{ rowspan }}>
+  <td>
     <a href="#{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}">
       <strong>{{ device.brand }} {{ device.model }}</strong><br/>
       {% if device.cpu-short != "" or device.chipset-short != "" or device.gpu-short != "" %}
@@ -12,20 +10,15 @@
       {% endif %}
     </a>
   </td>
-  <td{{ rowspan }}>{{ device.bios }}</td>
+  <td>{{ device.bios }}</td>
   {% assign param=device.hvm %}
-  {% include hcl-cell.html param=param rowspan=rowspan %}
+  {% include hcl-cell.html param=param %}
   {% assign param=device.iommu %}
-  {% include hcl-cell.html param=param rowspan=rowspan %}
+  {% include hcl-cell.html param=param %}
   {% assign param=device.slat %}
-  {% include hcl-cell.html param=param rowspan=rowspan %}
+  {% include hcl-cell.html param=param %}
   {% assign param=device.tpm %}
-  {% include hcl-cell.html param=param rowspan=rowspan %}
-  {% assign version = device.versions[0] %}
-  {% include hcl-version.html version=version %}
-</tr>
-{% for i in (1..range) %}
-<tr>
+  {% include hcl-cell.html param=param %}
   {% assign version = device.versions[i] %}
   {% include hcl-version.html version=version %}
 </tr>


### PR DESCRIPTION
sorttable.js doesn't support the rowspan table.
So change the HCL html-template for rendering HCL reports
with multiple versions as HTML TR multiple lines (= flat structure).

This PR completes the https://github.com/QubesOS/qubesos.github.io/pull/150 PR and is a contribution to https://github.com/QubesOS/qubes-issues/issues/3795