### PR TITLE
replace split ssh with community docs

### DIFF
--- a/_data/index.yml
+++ b/_data/index.yml
@@ -368,7 +368,7 @@
       - text: Split dm-crypt
         url: https://github.com/rustybird/qubes-split-dm-crypt
       - text: Split SSH
-        url: https://kushaldas.in/posts/using-split-ssh-in-qubesos-4-0.html
+        url: https://github.com/Qubes-Community/Contents/blob/master/docs/configuration/split-ssh.md
       - text: Using OnlyKey with Qubes OS
         url: https://docs.crp.to/qubes.html
 


### PR DESCRIPTION
Guide is the result of an effort made in https://qubes-os.discourse.group/t/best-split-ssh-setup-guide/385/ (some months ago)

This change was previously made in https://github.com/QubesOS/qubes-doc/pull/1106/ but somehow got revered.

If this revert turns out to be more wide-spread (expanded upon [in this issue](https://github.com/QubesOS/qubes-issues/issues/6605)), please disregard this PR and address the root issue.