### PR TITLE
Update doc-index.yml

### DIFF
--- a/_data/doc-index.yml
+++ b/_data/doc-index.yml
@@ -6,6 +6,7 @@
   category: introduction
   sub-pages:
     - url: /doc/getting-started/
+    - url: /doc/glossary/
     - url: /faq/
     - url: /doc/issue-tracking/
     - url: /support/
@@ -93,6 +94,7 @@
   - title: Advanced Topics
     subcategory: advanced-topics
     sub-pages:
+      - url: /doc/tools/
       - url: /doc/how-to-install-software-in-dom0/
       - url: /doc/volume-backup-revert/
       - url: /doc/standalones-and-hvms/
@@ -113,12 +115,6 @@
       - url: /doc/kde/
       - url: /doc/i3/
       - url: /doc/awesomewm/
-
-  - title: Reference
-    subcategory: reference
-    sub-pages:
-      - url: /doc/tools/
-      - url: /doc/glossary/
 
 - title: Project Security
   category: project-security


### PR DESCRIPTION
Moved `Glossary` to "Introduction," and `CLI Tools` to "Advanced Topics."
See #3 and #4 in this comment: https://github.com/QubesOS/qubes-issues/issues/6756#issuecomment-873456424

TL;DR, this is where people are more likely to find them, than per organizational structures more "correct" to library sciences or encyclopedic knowledge management standards. Ordering determined not by alphabetization, but by guessing "What are folks most likely to desire finding, and when" w/o proper user research to inform this stuff.

"Introduction" is really the section for the 5 things people need to absolutely not miss, before bothering everyone else with a question. "CLI Tools" is also findable in "Advanced Topics," I'd speculate—moreso than in a "Reference" section. 

Not keen to die on this hill though, so am happy to discuss if there's strong pushback.