### PR TITLE
Correct percentage for administrative fees

### DIFF
--- a/pages/donate.md
+++ b/pages/donate.md
@@ -20,7 +20,7 @@ We accept monetary donations via Bitcoin and credit card in the following three 
 ### 1. Give a one-time donation
 
 Donating with Bitcoin ensures that 100% of your money supports Qubes development because we do not incur any administrative costs.
-With credit card donations, [we lose roughly 14%](https://docs.opencollective.foundation/how-it-works/fees) to administrative costs.
+With credit card donations, [we lose roughly 5%-8%](https://docs.opencollective.foundation/how-it-works/fees) to administrative costs.
 
 **<i class="fa fa-2x fa-fw black-icon fa-bitcoin"></i> Bitcoin (BTC):** `3GakuQQDUGyyUnV1p5Jc3zd6CpQDkDwmDq` ([How to verify our Bitcoin address](#how-do-i-verify-your-bitcoin-address))
 


### PR DESCRIPTION
I rechecked the Open Collective source & saw that the fees are 5% via
crowdfunding or 8% via bank transfer/check. There are reductions for
the latter, but only if at least $500k is raised (annually, I think).

So, the "final" percentage for admin fees would be a weighted average
between 5% and 8%.

The fees may have been 14% at some point in the past, but that is not
the administrative fee rate today.