### PR TITLE
Attempt to fix error when serving website locally by adding webrick gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'json', '~> 2.0'
+
+gem "webrick", "~> 1.7"


### PR DESCRIPTION
**_Disclaimer: I am just a basic jekyll user and entirely unburdened with any ruby/gem knowledge. So please don't just merge this!_**

When I forked the repo and attempted the `sudo make` I received the following error message:

> /usr/gem/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)

A web search later I entered `bundle add webrick` and then `sudo make` again and it worked. In order to be able to do the `bundle add webrick` I also had to install ruby and follow the normal jekyll install procedure, because I have no idea what podman even is beyond 'docker magic' ;-)

In any case as a result of all of this the only change in the repository was this added line in the Gemfile. I don't know if the fix is as easy as that or if other steps are needed. So this is more of a bug report then a pull request. _...because if it would really be required, why does the automatic build work without it?_