### PR TITLE
unique slug for each report

### DIFF
--- a/_includes/hcl-device.html
+++ b/_includes/hcl-device.html
@@ -1,9 +1,9 @@
 {% assign rowspan = device.versions | size %}
 {% assign range = rowspan | minus:1 %}
 {% for i in (0..range) %}
-<tr id="{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}">
+<tr id="{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.versions[i].credit | slugify }}_{{ device.versions[i].qubes | slugify }}">
   <td>
-    <a href="#{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}">
+    <a href="#{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.versions[i].credit | slugify }}_{{ device.versions[i].qubes | slugify }}">
       <strong>{{ device.brand }} {{ device.model }}</strong><br/>
       {% if device.cpu-short != "" or device.chipset-short != "" or device.gpu-short != "" %}
         <small>{{ device.cpu-short }} {{ device.chipset-short }} {{ device.gpu-short }}</small>


### PR DESCRIPTION
Change HCL slug from `brand+model+cpu_short+chipset_short+gpu_short` to `brand+model+version[i].credit+version[i].qubes` to be unique for each report, based on the discussion in [this forum thread](https://forum.qubes-os.org/t/hcl-links-broken/8594/27).

**Pro**: unique slug as requested by community
**Contra**: while I can update the links in the [list of community recommended computers](https://forum.qubes-os.org/t/5560) and linked machine posts, there will be **_hundreds of links in the forum and the mailing list archive broken forever_**

Example:
`https://www.qubes-os.org/hcl/#lenovo_thinkpad-t430-23477c8_i7-3840qm_ivy-bridge_integrated-graphics-hd-4000` --> `https://www.qubes-os.org/hcl/#lenovo_thinkpad-t430-23477c8_sven-semmler_r4-1`