### PR TITLE
unique HCL URLs (slugs)

### DIFF
--- a/_includes/hcl-device.html
+++ b/_includes/hcl-device.html
@@ -1,17 +1,9 @@
 {% assign rowspan = device.versions | size %}
 {% assign range = rowspan | minus:1 %}
 {% for i in (0..range) %}
-{% if i > 0 %}
-<tr id="{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}_{{ i | string }}">
-{% else %}
-<tr id="{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}">
-{% endif %}
+<tr id="{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.gpu-short | slugify }}_{{ device.versions[i].credit | slugify }}_{{ device.versions[i].qubes | slugify }}">
   <td>
-    {% if i > 0 %}
-    <a href="#{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}_{{ i | string }}">
-    {% else %}
-    <a href="#{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}">
-    {% endif %}
+    <a href="#{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.gpu-short | slugify }}_{{ device.versions[i].credit | slugify }}_{{ device.versions[i].qubes | slugify }}">
       <strong>{{ device.brand }} {{ device.model }}</strong><br/>
       {% if device.cpu-short != "" or device.chipset-short != "" or device.gpu-short != "" %}
         <small>{{ device.cpu-short }} {{ device.chipset-short }} {{ device.gpu-short }}</small>

--- a/_includes/hcl-device.html
+++ b/_includes/hcl-device.html
@@ -1,9 +1,17 @@
 {% assign rowspan = device.versions | size %}
 {% assign range = rowspan | minus:1 %}
 {% for i in (0..range) %}
+{% if i > 0 %}
+<tr id="{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}_{{ i | string }}">
+{% else %}
 <tr id="{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}">
+{% endif %}
   <td>
+    {% if i > 0 %}
+    <a href="#{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}_{{ i | string }}">
+    {% else %}
     <a href="#{{ device.brand | slugify }}_{{ device.model | slugify }}_{{ device.cpu-short | slugify }}_{{ device.chipset-short | slugify }}_{{ device.gpu-short | slugify }}">
+    {% endif %}
       <strong>{{ device.brand }} {{ device.model }}</strong><br/>
       {% if device.cpu-short != "" or device.chipset-short != "" or device.gpu-short != "" %}
         <small>{{ device.cpu-short }} {{ device.chipset-short }} {{ device.gpu-short }}</small>


### PR DESCRIPTION
This is a better solution than [PR 198](https://github.com/QubesOS/qubesos.github.io/pull/198). 

Instead of changing the structure of the slugs, we add the version index to the end of it if there is more than one version. I tested this locally and recommend to go ahead with this solution as it doesn't break any links but still introduces unique links for each report.