### PR TITLE
Add security announcement scripts and secpack instructions

### DIFF
--- a/_includes/secpack-instructions.md
+++ b/_includes/secpack-instructions.md
@@ -1,0 +1,167 @@
+The following command-line instructions assume a Linux system with `git` and `gpg` installed. (See [here](/security/verifying-signatures/#openpgp-software) for Windows and Mac options.)
+
+1. Obtain the Qubes Master Signing Key (QMSK), e.g.:
+
+   ```shell_session
+   $ gpg --fetch-keys https://keys.qubes-os.org/keys/qubes-master-signing-key.asc
+   gpg: directory '/home/user/.gnupg' created
+   gpg: keybox '/home/user/.gnupg/pubring.kbx' created
+   gpg: requesting key from 'https://keys.qubes-os.org/keys/qubes-master-signing-key.asc'
+   gpg: /home/user/.gnupg/trustdb.gpg: trustdb created
+   gpg: key DDFA1A3E36879494: public key "Qubes Master Signing Key" imported
+   gpg: Total number processed: 1
+   gpg:               imported: 1
+   ```
+
+   (See [here](/security/verifying-signatures/#how-to-import-and-authenticate-the-qubes-master-signing-key) for more ways to obtain the QMSK.)
+
+2. View the fingerprint of the PGP key you just imported. (Note: `gpg>` indicates a prompt inside of the GnuPG program. Type what appears after it when prompted.)
+
+   ```shell_session
+   $ gpg --edit-key 0x427F11FD0FAA4B080123F01CDDFA1A3E36879494
+   gpg (GnuPG) 2.2.27; Copyright (C) 2021 Free Software Foundation, Inc.
+   This is free software: you are free to change and redistribute it.
+   There is NO WARRANTY, to the extent permitted by law.
+   
+   
+   pub  rsa4096/DDFA1A3E36879494
+        created: 2010-04-01  expires: never       usage: SC
+        trust: unknown       validity: unknown
+   [ unknown] (1). Qubes Master Signing Key
+   
+   gpg> fpr
+   pub   rsa4096/DDFA1A3E36879494 2010-04-01 Qubes Master Signing Key
+    Primary key fingerprint: 427F 11FD 0FAA 4B08 0123  F01C DDFA 1A3E 3687 9494
+   ```
+
+3. **Important:** At this point, you still don't know whether the key you just imported is the genuine QMSK or a forgery. In order for this entire procedure to provide meaningful security benefits, you *must* authenticate the QMSK out-of-band. **Do not skip this step!** The standard method is to obtain the QMSK fingerprint from *multiple independent sources in several different ways* and check to see whether they match the key you just imported. See [here](/security/verifying-signatures/#how-to-import-and-authenticate-the-qubes-master-signing-key) for more details and ideas for how to do that.
+
+   **Tip:** Record the genuine QMSK fingerprint in a safe place (or several) so that you don't have to repeat this step in the future.
+
+4. Once you are satisfied that you have the genuine QMSK, set its trust level to 5 ("ultimate"), then quit GnuPG with `q`.
+
+   ```shell_session
+   gpg> trust
+   pub  rsa4096/DDFA1A3E36879494
+        created: 2010-04-01  expires: never       usage: SC
+        trust: unknown       validity: unknown
+   [ unknown] (1). Qubes Master Signing Key
+   
+   Please decide how far you trust this user to correctly verify other users' keys
+   (by looking at passports, checking fingerprints from different sources, etc.)
+   
+     1 = I don't know or won't say
+     2 = I do NOT trust
+     3 = I trust marginally
+     4 = I trust fully
+     5 = I trust ultimately
+     m = back to the main menu
+   
+   Your decision? 5
+   Do you really want to set this key to ultimate trust? (y/N) y
+   
+   pub  rsa4096/DDFA1A3E36879494
+        created: 2010-04-01  expires: never       usage: SC
+        trust: ultimate      validity: unknown
+   [ unknown] (1). Qubes Master Signing Key
+   Please note that the shown key validity is not necessarily correct
+   unless you restart the program.
+   
+   gpg> q
+   ```
+
+5. Use Git to clone the qubes-secpack repo.
+
+   ```shell_session
+   $ git clone https://github.com/QubesOS/qubes-secpack.git
+   Cloning into 'qubes-secpack'...
+   remote: Enumerating objects: 4065, done.
+   remote: Counting objects: 100% (1474/1474), done.
+   remote: Compressing objects: 100% (742/742), done.
+   remote: Total 4065 (delta 743), reused 1413 (delta 731), pack-reused 2591
+   Receiving objects: 100% (4065/4065), 1.64 MiB | 2.53 MiB/s, done.
+   Resolving deltas: 100% (1910/1910), done.
+   ```
+
+6. Import the included PGP keys. (See our [PGP key policies](/security/pack/#pgp-key-policies) for important information about these keys.)
+
+   ```shell_session
+   $ gpg --import qubes-secpack/keys/*/*
+   gpg: key 063938BA42CFA724: public key "Marek Marczykowski-Górecki (Qubes OS signing key)" imported
+   gpg: qubes-secpack/keys/core-devs/retired: read error: Is a directory
+   gpg: no valid OpenPGP data found.
+   gpg: key 8C05216CE09C093C: 1 signature not checked due to a missing key
+   gpg: key 8C05216CE09C093C: public key "HW42 (Qubes Signing Key)" imported
+   gpg: key DA0434BC706E1FCF: public key "Simon Gaiser (Qubes OS signing key)" imported
+   gpg: key 8CE137352A019A17: 2 signatures not checked due to missing keys
+   gpg: key 8CE137352A019A17: public key "Andrew David Wong (Qubes Documentation Signing Key)" imported
+   gpg: key AAA743B42FBC07A9: public key "Brennan Novak (Qubes Website & Documentation Signing)" imported
+   gpg: key B6A0BB95CA74A5C3: public key "Joanna Rutkowska (Qubes Documentation Signing Key)" imported
+   gpg: key F32894BE9684938A: public key "Marek Marczykowski-Górecki (Qubes Documentation Signing Key)" imported
+   gpg: key 6E7A27B909DAFB92: public key "Hakisho Nukama (Qubes Documentation Signing Key)" imported
+   gpg: key 485C7504F27D0A72: 1 signature not checked due to a missing key
+   gpg: key 485C7504F27D0A72: public key "Sven Semmler (Qubes Documentation Signing Key)" imported
+   gpg: key BB52274595B71262: public key "unman (Qubes Documentation Signing Key)" imported
+   gpg: key DC2F3678D272F2A8: 1 signature not checked due to a missing key
+   gpg: key DC2F3678D272F2A8: public key "Wojtek Porczyk (Qubes OS documentation signing key)" imported
+   gpg: key FD64F4F9E9720C4D: 1 signature not checked due to a missing key
+   gpg: key FD64F4F9E9720C4D: public key "Zrubi (Qubes Documentation Signing Key)" imported
+   gpg: key DDFA1A3E36879494: "Qubes Master Signing Key" not changed
+   gpg: key 1848792F9E2795E9: public key "Qubes OS Release 4 Signing Key" imported
+   gpg: qubes-secpack/keys/release-keys/retired: read error: Is a directory
+   gpg: no valid OpenPGP data found.
+   gpg: key D655A4F21830E06A: public key "Marek Marczykowski-Górecki (Qubes security pack)" imported
+   gpg: key ACC2602F3F48CB21: public key "Qubes OS Security Team" imported
+   gpg: qubes-secpack/keys/security-team/retired: read error: Is a directory
+   gpg: no valid OpenPGP data found.
+   gpg: key 4AC18DE1112E1490: public key "Simon Gaiser (Qubes Security Pack signing key)" imported
+   gpg: Total number processed: 17
+   gpg:               imported: 16
+   gpg:              unchanged: 1
+   gpg: marginals needed: 3  completes needed: 1  trust model: pgp
+   gpg: depth: 0  valid:   1  signed:   6  trust: 0-, 0q, 0n, 0m, 0f, 1u
+   gpg: depth: 1  valid:   6  signed:   0  trust: 6-, 0q, 0n, 0m, 0f, 0u
+   ```
+
+7. Verify signed Git tags.
+
+   ```shell_session
+   $ cd qubes-secpack/
+   $ git tag -v `git describe`
+   object 266e14a6fae57c9a91362c9ac784d3a891f4d351
+   type commit
+   tag marmarek_sec_266e14a6
+   tagger Marek Marczykowski-Górecki 1677757924 +0100
+   
+   Tag for commit 266e14a6fae57c9a91362c9ac784d3a891f4d351
+   gpg: Signature made Thu 02 Mar 2023 03:52:04 AM PST
+   gpg:                using RSA key 2D1771FE4D767EDC76B089FAD655A4F21830E06A
+   gpg: Good signature from "Marek Marczykowski-Górecki (Qubes security pack)" [full]
+   ```
+
+   The exact output will differ, but the final line should always start with `gpg: Good signature from...` followed by an appropriate key. The `[full]` indicates full trust, which this key inherits in virtue of being validly signed by the QMSK.
+
+8. Verify PGP signatures, e.g.:
+
+   ```shell_session
+   $ cd QSBs/
+   $ gpg --verify qsb-087-2022.txt.sig.marmarek qsb-087-2022.txt
+   gpg: Signature made Wed 23 Nov 2022 04:05:51 AM PST
+   gpg:                using RSA key 2D1771FE4D767EDC76B089FAD655A4F21830E06A
+   gpg: Good signature from "Marek Marczykowski-Górecki (Qubes security pack)" [full]
+   $ gpg --verify qsb-087-2022.txt.sig.simon qsb-087-2022.txt
+   gpg: Signature made Wed 23 Nov 2022 03:50:42 AM PST
+   gpg:                using RSA key EA18E7F040C41DDAEFE9AA0F4AC18DE1112E1490
+   gpg: Good signature from "Simon Gaiser (Qubes Security Pack signing key)" [full]
+   $ cd ../canaries/
+   $ gpg --verify canary-034-2023.txt.sig.marmarek canary-034-2023.txt
+   gpg: Signature made Thu 02 Mar 2023 03:51:48 AM PST
+   gpg:                using RSA key 2D1771FE4D767EDC76B089FAD655A4F21830E06A
+   gpg: Good signature from "Marek Marczykowski-Górecki (Qubes security pack)" [full]
+   $ gpg --verify canary-034-2023.txt.sig.simon canary-034-2023.txt
+   gpg: Signature made Thu 02 Mar 2023 01:47:52 AM PST
+   gpg:                using RSA key EA18E7F040C41DDAEFE9AA0F4AC18DE1112E1490
+   gpg: Good signature from "Simon Gaiser (Qubes Security Pack signing key)" [full]
+   ```
+
+   Again, the exact output will differ, but the final line of output from each `gpg --verify` command should always start with `gpg: Good signature from...` followed by an appropriate key.

--- a/_utils/canary.sh
+++ b/_utils/canary.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+
+# Canary text file location
+CANARY_LOC=${HOME}/repo/qubes/qubes-secpack/canaries
+# Canary website data location
+CANARY_DATA=${HOME}/repo/qubes/qubesos.github.io/_data/sec-canary.yml
+# Secpack instructions location
+SECPACK=${HOME}/repo/qubes/qubesos.github.io/_includes/secpack-instructions.md
+
+# Update the qubes-secpack repo
+cd $CANARY_LOC && git pl
+
+# Get user input
+read -p 'Canary number (e.g., 034): ' CANARY
+read -p 'Canary date (e.g., 2023-03-02): ' CANARY_DATE
+read -p 'Post date: ' POST_DATE
+
+# Get the year (assumes post year and canary year are the same)
+YEAR=`echo $POST_DATE | cut -c1-4`
+
+# Get the input canary and signatures files
+CANARY_FILE=${CANARY_LOC}/canary-${CANARY}-${YEAR}.txt
+SIG_MAREK=${CANARY_LOC}/canary-${CANARY}-${YEAR}.txt.sig.marmarek
+SIG_SIMON=${CANARY_LOC}/canary-${CANARY}-${YEAR}.txt.sig.simon
+
+# Get the input canary file
+CANARY_FILE=${CANARY_LOC}/canary-${CANARY}-${YEAR}.txt
+
+# Update canary website data
+printf -- "
+- canary: \"${CANARY}\"
+  date: $CANARY_DATE
+" >> $CANARY_DATA
+
+# Output post file
+POST=${HOME}/repo/qubes/qubesos.github.io/_posts/${POST_DATE}-canary-${CANARY}.md
+
+# Generate the post
+printf -- "---
+layout: post
+title: \"Qubes canary ${CANARY}\"
+categories: security
+---
+
+We have published [Qubes canary ${CANARY}](https://github.com/QubesOS/qubes-secpack/blob/master/canaries/canary-${CANARY}-${YEAR}.txt). The text of this canary and its accompanying cryptographic signatures are reproduced below. For an explanation of this announcement and instructions for authenticating this canary, please see the end of this announcement.
+
+## Qubes canary $CANARY
+
+\`\`\`
+" >> $POST
+cat $CANARY_FILE >> $POST
+printf "
+\`\`\`
+
+Source: <https://github.com/QubesOS/qubes-secpack/blob/master/canaries/canary-${CANARY}-${YEAR}.txt>
+
+## [Marek Marczykowski-Górecki](/team/#marek-marczykowski-górecki)'s PGP signature
+
+\`\`\`
+" >> $POST
+cat $SIG_MAREK >> $POST
+printf "\`\`\`
+
+Source: <https://github.com/QubesOS/qubes-secpack/blob/master/canaries/canary-${CANARY}-${YEAR}.txt.sig.marmarek>
+
+## [Simon Gaiser (aka HW42)](/team/#simon-gaiser-aka-hw42)'s PGP signature
+
+\`\`\`
+" >> $POST
+cat $SIG_SIMON >> $POST
+printf "\`\`\`
+
+Source: <https://github.com/QubesOS/qubes-secpack/blob/master/canaries/canary-${CANARY}-${YEAR}.txt.sig.simon>
+
+## What is the purpose of this announcement?
+
+The purpose of this announcement is to inform the Qubes community that a new Qubes canary has been published.
+
+## What is a Qubes canary?
+
+A Qubes canary is a security announcement periodically issued by the [Qubes security team](/security/#qubes-security-team) consisting of several statements to the effect that the signers of the canary have not been compromised. The idea is that, as long as signed canaries including such statements continue to be published, all is well. However, if the canaries should suddenly cease, if one or more signers begin declining to sign them, or if the included statements change significantly without plausible explanation, then this may indicate that something has gone wrong. A list of all canaries is available [here](/security/canary/).
+
+The name originates from the practice in which miners would bring caged canaries into coal mines. If the level of methane gas in the mine reached a dangerous level, the canary would die, indicating to miners that they should evacuate. (See the [Wikipedia article on warrant canaries](https://en.wikipedia.org/wiki/Warrant_canary) for more information, but bear in mind that Qubes Canaries are not strictly limited to legal warrants.)
+
+## Why should I care about canaries?
+
+Canaries provide an important indication about the security status of the project. If the canary is healthy, it's a strong sign that things are running normally. However, if the canary is unhealthy, it could mean that the project or its members are being coerced in some way.
+
+## What are some signs of an unhealthy canary?
+
+Here is a non-exhaustive list of examples:
+
+- **Dead canary.** In each canary, we state a window of time during which you should expect the next canary to be published. If no canary is published within that window of time and no good explanation is provided for missing the deadline, then the canary has died.
+- **Missing statement(s).** Every canary contains the same set of statements (sometimes along with special announcements, which are not the same in every canary). If an important statement was present in older canaries but suddenly goes missing from new canaries with no correction or explanation, then this may be an indication that the signers can no longer truthfully make that statement.
+- **Missing signature(s).** Qubes canaries are signed by the members of the [Qubes security team](/security/#qubes-security-team) (see below). If one of them has been signing all canaries but suddenly and permanently stops signing new canaries without any explanation, then this may indicate that this person is under duress or can no longer truthfully sign the statements contained in the canary.
+
+## Does every unexpected or unusual occurrence related to a canary indicate something bad?
+
+No, there are many canary-related possibilities that should *not* worry you. Here is a non-exhaustive list of examples:
+
+- **Unusual reposts.** The only canaries that matter are the ones that are validly signed in the [Qubes security pack (qubes-secpack)](/security/pack/). Reposts of canaries (like the one in this announcement) do not have any authority (except insofar as they reproduce validly-signed text from the qubes-secpack). If the actual canary in the qubes-secpack is healthy, but reposts are late, absent, or modified on the website, mailing lists, forum, or social media platforms, you should not be concerned about the canary.
+- **Last-minute signature(s).** If the canary is signed at the last minute but before the deadline, that's okay. (People get busy and procrastinate sometimes.)
+- **Signatures at different times.** If one signature is earlier or later than the other, but both are present within a reasonable period of time, that's okay. (For example, sometimes one signer is out of town, but we try to plan the deadlines around this.)
+- **Permitted changes.** If something about a canary changes without violating any of statements in prior canaries, that's okay. (For example, canaries are usually scheduled for the first fourteen days of a given month, but there's no rule that says they have to be.)
+- **Unusual but planned changes.** If something unusual happens, but it was announced in advance, and the appropriate statements are signed, that's okay (e.g., when Joanna left the security team and Simon joined it).
+
+In general, it would not be realistic for an organization to exist that never changed, had zero turnover, and never made mistakes. Therefore, it would be reasonable to expect such events to occur periodically, and it would be unreasonable to regard *every* unusual or unexpected canary-related event as a sign of compromise. For example, if something usual happens with a canary, and we say it was a mistake and correct it, you will have to decide for yourself whether it's more likely that it really was just a mistake or that something is wrong and that this is how we chose to send you a subtle signal about it. This will require you to think carefully about which among many possible scenarios is most likely given the evidence available to you. Since this is fundamentally a matter of judgment, canaries are ultimately a *social* scheme, not a technical one.
+
+## What are the PGP signatures that accompany canaries?
+
+A [PGP](https://en.wikipedia.org/wiki/Pretty_Good_Privacy) signature is a cryptographic [digital signature](https://en.wikipedia.org/wiki/Digital_signature) made in accordance with the [OpenPGP](https://en.wikipedia.org/wiki/Pretty_Good_Privacy#OpenPGP) standard. PGP signatures can be cryptographically verified with programs like [GNU Privacy Guard (GPG)](https://en.wikipedia.org/wiki/GNU_Privacy_Guard). The Qubes security team cryptographically signs all canaries so that Qubes users have a reliable way to check whether canaries are genuine. The only way to be certain that a canary is authentic is by verifying its PGP signatures.
+
+## Why should I care whether a canary is authentic?
+
+If you fail to notice that a canary is unhealthy or has died, you may continue to trust the Qubes security team even after they have signaled via the canary (or lack thereof) that they been compromised or coerced. Falsified canaries could include manipulated text designed to sow fear, uncertainty, and doubt about the security of Qubes OS or the status of the Qubes OS Project.
+
+## How do I verify the PGP signatures on a canary?
+
+" >> $POST
+cat $SECPACK >> $POST
+printf "
+
+For this announcement (Qubes canary $CANARY), the commands are:
+
+\`\`\`
+$ gpg --verify canary-${CANARY}-${YEAR}.txt.sig.marmarek canary-${CANARY}-${YEAR}.txt
+$ gpg --verify canary-${CANARY}-${YEAR}.txt.sig.simon canary-${CANARY}-${YEAR}.txt
+\`\`\`
+
+You can also verify the signatures directly from this announcement in addition to or instead of verifying the files from the qubes-secpack. Simply copy and paste the Qubes canary $CANARY text into a plain text file and do the same for both signature files. Then, perform the same authentication steps as listed above, substituting the filenames above with the names of the files you just created." >> $POST
+
+exit

--- a/_utils/qsb.sh
+++ b/_utils/qsb.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+
+# QSB text file location
+QSB_LOC=${HOME}/repo/qubes/qubes-secpack/QSBs
+# QSB website data location
+QSB_DATA=${HOME}/repo/qubes/qubesos.github.io/_data/sec-qsb.yml
+# XSA website data location
+XSA_DATA=${HOME}/repo/qubes/qubesos.github.io/_data/sec-xsa.yml
+# Secpack instructions location
+SECPACK=${HOME}/repo/qubes/qubesos.github.io/_includes/secpack-instructions.md
+
+# Update the qubes-secpack repo
+cd $QSB_LOC && git pl
+
+# Get user input
+read -p 'QSB number (e.g., 049): ' QSB
+read -p 'Post date: ' POST_DATE
+#read -p 'XSA Number (e.g., 123; leave blank if N/A): ' XSA
+#read -p 'XSA Date (leave blank if N/A): ' XSA_DATE
+
+# Get the year (assumes post year and QSB year are the same)
+YEAR=`echo $POST_DATE | cut -c1-4`
+
+# Get the input QSB and signatures files
+QSB_FILE=${QSB_LOC}/qsb-${QSB}-${YEAR}.txt
+SIG_MAREK=${QSB_LOC}/qsb-${QSB}-${YEAR}.txt.sig.marmarek
+SIG_SIMON=${QSB_LOC}/qsb-${QSB}-${YEAR}.txt.sig.simon
+
+# Get the QSB title
+TITLE=`sed -n '6p' $QSB_FILE | sed -e 's/^[ \t]*//'`
+# Get the QSB date
+QSB_DATE=`sed -n '4p' $QSB_FILE | sed -e 's/^[ \t]*//'`
+
+# Update QSB website data
+printf -- "
+- qsb: \"${QSB}\"
+  title: \"${TITLE}\"
+  date: $QSB_DATE
+" >> $QSB_DATA
+
+# Update XSA website data (if applicable)
+#@TODO: Create a loop to handle multiple XSAs
+#if [ -n "$XSA" ]
+#    then
+#        printf -- "- xsa: $XSA
+#  date: $XSA_DATE
+#  affected: yes
+#  qsb: ${QSB}-${YEAR}
+#  mitigation:
+#\n" >> $XSA_DATA
+#fi
+
+# Output post file
+POST=${HOME}/repo/qubes/qubesos.github.io/_posts/${POST_DATE}-qsb-${QSB}.md
+
+# Generate the post
+printf -- "---
+layout: post
+title: \"QSB-${QSB}: ${TITLE}\"
+categories: security
+---
+
+We have published [Qubes Security Bulletin (QSB) ${QSB}: ${TITLE}](https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-${QSB}-${YEAR}.txt). The text of this QSB and its accompanying cryptographic signatures are reproduced below. For an explanation of this announcement and instructions for authenticating this QSB, please see the end of this announcement.
+
+## Qubes Security Bulletin $QSB
+
+\`\`\`
+" >> $POST
+cat $QSB_FILE >> $POST
+printf "
+\`\`\`
+
+Source: <https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-${QSB}-${YEAR}.txt>
+
+## [Marek Marczykowski-Górecki](/team/#marek-marczykowski-górecki)'s PGP signature
+
+\`\`\`
+" >> $POST
+cat $SIG_MAREK >> $POST
+printf "\`\`\`
+
+Source: <https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-${QSB}-${YEAR}.txt.sig.marmarek>
+
+## [Simon Gaiser (aka HW42)](/team/#simon-gaiser-aka-hw42)'s PGP signature
+
+\`\`\`
+" >> $POST
+cat $SIG_SIMON >> $POST
+printf "\`\`\`
+
+Source: <https://github.com/QubesOS/qubes-secpack/blob/master/QSBs/qsb-${QSB}-${YEAR}.txt.sig.simon>
+
+## What is the purpose of this announcement?
+
+The purpose of this announcement is to inform the Qubes community that a new Qubes Security Bulletin (QSB) has been published.
+
+## What is a Qubes Security Bulletin (QSB)?
+
+A Qubes security bulletin (QSB) is a security announcement issued by the [Qubes security team](/security/#qubes-security-team). A QSB typically provides a summary and impact analysis of one or more recently-discovered software vulnerabilities, including details about patching to address them. A list of all QSBs is available [here](/security/qsb/).
+
+## Why should I care about QSBs?
+
+QSBs tell you what actions you must take in order to protect yourself from recently-discovered security vulnerabilities. In most cases, security vulnerabilities are addressed by [updating normally](/doc/how-to-update/). However, in some cases, special user action is required. In all cases, the required actions are detailed in QSBs.
+
+## What are the PGP signatures that accompany QSBs?
+
+A [PGP](https://en.wikipedia.org/wiki/Pretty_Good_Privacy) signature is a cryptographic [digital signature](https://en.wikipedia.org/wiki/Digital_signature) made in accordance with the [OpenPGP](https://en.wikipedia.org/wiki/Pretty_Good_Privacy#OpenPGP) standard. PGP signatures can be cryptographically verified with programs like [GNU Privacy Guard (GPG)](https://en.wikipedia.org/wiki/GNU_Privacy_Guard). The Qubes security team cryptographically signs all QSBs so that Qubes users have a reliable way to check whether QSBs are genuine. The only way to be certain that a QSB is authentic is by verifying its PGP signatures.
+
+## Why should I care whether a QSB is authentic?
+
+A forged QSB could deceive you into taking actions that adversely affect the security of your Qubes OS system, such as installing malware or making configuration changes that render your system vulnerable to attack. Falsified QSBs could sow fear, uncertainty, and doubt about the security of Qubes OS or the status of the Qubes OS Project.
+
+## How do I verify the PGP signatures on a QSB?
+
+" >> $POST
+cat $SECPACK >> $POST
+printf "
+
+For this announcement (QSB-$QSB), the commands are:
+
+\`\`\`
+$ gpg --verify qsb-${QSB}-${YEAR}.txt.sig.marmarek qsb-${QSB}-${YEAR}.txt
+$ gpg --verify qsb-${QSB}-${YEAR}.txt.sig.simon qsb-${QSB}-${YEAR}.txt
+\`\`\`
+
+You can also verify the signatures directly from this announcement in addition to or instead of verifying the files from the qubes-secpack. Simply copy and paste the QSB-$QSB text into a plain text file and do the same for both signature files. Then, perform the same authentication steps as listed above, substituting the filenames above with the names of the files you just created." >> $POST
+
+exit


### PR DESCRIPTION
@marmarek, @HW42: I plan to use these scripts to the generate the next QSB and canary announcements. Please let me know if you have any suggestions for improvement.

(Side note: I also plan to use `secpack-instructions.md` as an include on the https://www.qubes-os.org/security/pack/ page to avoid maintaining duplicated content.)