### PR TITLE
Reference software versions that build the site properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,7 @@ Git submodules for content:
 
 ### Podman Compose
 
-These instructions have been tested on a Fedora 33 qube. Podman is not
-available in Debian 10. You must use a Fedora-based machine or Debian 11.
+These instructions have been tested on a Fedora 36 qube.
 
 1. Install `podman` and `podman-compose`.
 

--- a/compose.yml
+++ b/compose.yml
@@ -1,6 +1,6 @@
 services:
     jekyll:
-        image: jekyll/jekyll:pages
+        image: jekyll/jekyll:4.2.0
         command: jekyll serve
         ports:
             - 4000:4000


### PR DESCRIPTION
The instructions for using the jekyll/jekyll:pages podman image were no longer working for me. This is most likely due to the image being a rolling release rather than a fixed release and in the meantime changes got introduced that broke building the site locally.

The compose.yml file got a change introduced so from now on the images is always of a fixed version. Furthermore, README.md has been updates so it references the environment used for testing as of today.

For anyone interested, here's a log of trying to build the site in a fresh disposable qube with Fedora 36:

```
[user@LAPTOP-F83A0KT4 ~]$ git clone --recursive https://github.com/QubesOS/qubesos.github.io.git && cd qubesos.github.io/ && sudo make
Cloning into 'qubesos.github.io'...
remote: Enumerating objects: 17028, done.
remote: Counting objects: 100% (1050/1050), done.
remote: Compressing objects: 100% (679/679), done.
remote: Total 17028 (delta 385), reused 1034 (delta 371), pack-reused 15978
Receiving objects: 100% (17028/17028), 11.66 MiB | 12.77 MiB/s, done.
Resolving deltas: 100% (7771/7771), done.
Submodule '_doc' (https://github.com/QubesOS/qubes-doc) registered for path '_doc'
Submodule '_hcl' (https://github.com/QubesOS/qubes-hcl) registered for path '_hcl'
Submodule '_posts' (https://github.com/QubesOS/qubes-posts) registered for path '_posts'
Submodule 'attachment' (https://github.com/QubesOS/qubes-attachment) registered for path 'attachment'
Cloning into '/home/user/qubesos.github.io/_doc'...
remote: Enumerating objects: 32883, done.
remote: Counting objects: 100% (538/538), done.
remote: Compressing objects: 100% (278/278), done.
remote: Total 32883 (delta 296), reused 493 (delta 260), pack-reused 32345      
Receiving objects: 100% (32883/32883), 11.37 MiB | 16.78 MiB/s, done.
Resolving deltas: 100% (20997/20997), done.
Cloning into '/home/user/qubesos.github.io/_hcl'...
remote: Enumerating objects: 7648, done.
remote: Counting objects: 100% (561/561), done.
remote: Compressing objects: 100% (241/241), done.
remote: Total 7648 (delta 348), reused 531 (delta 320), pack-reused 7087
Receiving objects: 100% (7648/7648), 2.24 MiB | 7.98 MiB/s, done.
Resolving deltas: 100% (6049/6049), done.
Cloning into '/home/user/qubesos.github.io/_posts'...
remote: Enumerating objects: 3307, done.
remote: Counting objects: 100% (1112/1112), done.
remote: Compressing objects: 100% (374/374), done.
remote: Total 3307 (delta 838), reused 1011 (delta 738), pack-reused 2195       
Receiving objects: 100% (3307/3307), 1.75 MiB | 11.14 MiB/s, done.
Resolving deltas: 100% (1692/1692), done.
Cloning into '/home/user/qubesos.github.io/attachment'...
remote: Enumerating objects: 1645, done.
remote: Counting objects: 100% (1645/1645), done.
remote: Compressing objects: 100% (1231/1231), done.
remote: Total 1645 (delta 383), reused 1640 (delta 382), pack-reused 0
Receiving objects: 100% (1645/1645), 146.84 MiB | 24.88 MiB/s, done.
Resolving deltas: 100% (383/383), done.
Submodule path '_doc': checked out '01d3bf419c1546d802bb4fa31f3570126f6e0a13'
Submodule path '_hcl': checked out 'd72f3d6bb608286571c2731d7bfdc59eb99e04ef'
Submodule path '_posts': checked out 'c85324e142571cc20a40f7d1c4da41fa77c7d252'
Submodule path 'attachment': checked out '2063fba368e0b62c04377b604a90cf93bde06703'
podman-compose up
podman-compose version: 1.0.6
['podman', '--version', '']
using podman version: 4.4.1
** excluding:  set()
['podman', 'ps', '--filter', 'label=io.podman.compose.project=qubesosgithubio', '-a', '--format', '{{ index .Labels "io.podman.compose.config-hash"}}']
['podman', 'network', 'exists', 'qubesosgithubio_default']
['podman', 'network', 'create', '--label', 'io.podman.compose.project=qubesosgithubio', '--label', 'com.docker.compose.project=qubesosgithubio', 'qubesosgithubio_default']
['podman', 'network', 'exists', 'qubesosgithubio_default']
podman create --name=qubesosgithubio_jekyll_1 --label io.podman.compose.config-hash=014d80fce81dec8a11a8f8ff67e061b4042bc4f4426b2655c9f1b76975074ae5 --label io.podman.compose.project=qubesosgithubio --label io.podman.compose.version=1.0.6 --label PODMAN_SYSTEMD_UNIT=podman-compose@qubesosgithubio.service --label com.docker.compose.project=qubesosgithubio --label com.docker.compose.project.working_dir=/home/user/qubesos.github.io --label com.docker.compose.project.config_files=compose.yml --label com.docker.compose.container-number=1 --label com.docker.compose.service=jekyll -v /home/user/qubesos.github.io:/srv/jekyll --net qubesosgithubio_default --network-alias jekyll -p 4000:4000 jekyll/jekyll:pages jekyll serve
✔ docker.io/jekyll/jekyll:pages
Trying to pull docker.io/jekyll/jekyll:pages...
Getting image source signatures
Copying blob a5aa679d5ce3 done
Copying blob 837e9cfc7e43 done
Copying blob df9b9388f04a done
Copying blob 6ca4c39baa3d done
Copying blob c7850f1a8c23 done
Copying blob daa3a8cb79d3 done
Copying config f1faef81f1 done
Writing manifest to image destination
Storing signatures
7b4e59f733dccb3f77aba47fcc7462e661c611de6155632db2d4205a833e16f8
exit code: 0
podman start -a qubesosgithubio_jekyll_1
[jekyll] | ruby 3.1.1p18 (2022-02-18 revision 53f5fc4236) [x86_64-linux-musl]
[jekyll] | Configuration file: /srv/jekyll/_config.yml
[jekyll] |             Source: /srv/jekyll
[jekyll] |        Destination: /srv/jekyll/_site
[jekyll] |  Incremental build: disabled. Enable with --incremental
[jekyll] |       Generating...
   GitHub Metadata: No GitHub API authentication could be found. Some fields may be missing or have incorrect data.
[jekyll] |                     done in 24.088 seconds.
[jekyll] |  Auto-regeneration: enabled for '/srv/jekyll'
/usr/gem/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in `require': cannot load such file -- webrick (LoadError)
        from /usr/gem/gems/jekyll-3.9.2/lib/jekyll/commands/serve/servlet.rb:3:in `<top (required)>'
        from /usr/gem/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:184:in `require_relative'
        from /usr/gem/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:184:in `setup'
        from /usr/gem/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:102:in `process'
        from /usr/gem/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `block in start'
        from /usr/gem/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `each'
        from /usr/gem/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:93:in `start'
        from /usr/gem/gems/jekyll-3.9.2/lib/jekyll/commands/serve.rb:75:in `block (2 levels) in init_with_program'
        from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `block in execute'
        from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `each'
        from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/command.rb:220:in `execute'
        from /usr/gem/gems/mercenary-0.3.6/lib/mercenary/program.rb:42:in `go'
        from /usr/gem/gems/mercenary-0.3.6/lib/mercenary.rb:19:in `program'
        from /usr/gem/gems/jekyll-3.9.2/exe/jekyll:15:in `<top (required)>'
        from /usr/gem/bin/jekyll:25:in `load'
        from /usr/gem/bin/jekyll:25:in `<main>'
exit code: 1
[user@LAPTOP-F83A0KT4 qubesos.github.io]$
```