### PR TITLE
change my public key (again)

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -283,7 +283,7 @@
   email: Sven@SvenSemmler.org
   role: "HCL maintainer, Qubes Forum moderator"
   type: community
-  fingerprint: DA59 75C9 ABC4 0C83 3B2F 620B 2A63 2C53 7D74 4BC7
+  fingerprint: 0C27 6715 E93D 4CE5 4007 BDBF 54EB 584E 8668 B05F
 
 - name: Andrew Sorensen
   email: andrew@localcoast.net


### PR DESCRIPTION
I use a Nitrokey to generate and store my private key. When re-flashing my Heads install, I answered some of the prompts without fully comprehending my actions and accidentally wiped my private key.

I no longer have access to it and needed to generate [a new one](https://keys.openpgp.org/vks/v1/by-fingerprint/0C276715E93D4CE54007BDBF54EB584E8668B05F). This new key is signed by an [older key](https://keys.openpgp.org/vks/v1/by-fingerprint/D7CAF2DB658D89BC08D6A7AADA6E167B8F541FB6), which is known to several of my contacts. It is also signed using my [Qubes Documentation Signing Key](https://github.com/QubesOS/qubes-secpack/blob/main/keys/doc-signing/sven-qubes-doc-signing-keys.asc), which in turn was previously signed by [the lost key](https://keys.openpgp.org/vks/v1/by-fingerprint/DA5975C9ABC40C833B2F620B2A632C537D744BC7).