### PR TITLE
Add .well-known/security.txt file, closes QubesOS/qubes-issues#7022

### DIFF
--- a/.well-known/security.txt
+++ b/.well-known/security.txt
@@ -1,0 +1,6 @@
+Contact: https://www.qubes-os.org/security/
+Expires: 2028-01-01T08:00:00.000Z
+Encryption: https://keys.qubes-os.org/keys/qubes-os-security-team-key.asc
+Canonical: https://qubes-os.org/.well-known/security.txt
+Policy: https://www.qubes-os.org/security/
+

--- a/_config.yml
+++ b/_config.yml
@@ -44,3 +44,6 @@ allowed_categories:
 
 default_author: "The Qubes team"
 default_category: "announcements"
+
+include:
+  - .well-known


### PR DESCRIPTION
Copy-pasting @andrewdavidwong content, and following @SaswatPadhi instructions, only changing the expiration date (first proposition was +4 years).

See:

- QubesOS/qubes-issues#7022
- https://forum.qubes-os.org/t/github-issue-7022-provide-https-qubes-os-org-well-known-security-txt/26972