### PR TITLE
Make Qubes version collumn sorted by default

### DIFF
--- a/_includes/hcl.html
+++ b/_includes/hcl.html
@@ -138,7 +138,7 @@
       <th style="width=32px">IOMMU</th>
       <th style="width=32px">SLAT</th>
       <th style="width=32px">TPM</th>
-      <th style="width=42px">Qubes</th>
+      <th style="width=42px" class=" sorttable_sorted_reverse">Qubes<span id="sorttable_sortrevind">&nbsp;▴</span></th>
       <th style="width=42px">Xen</th>
       <th style="width=42px">Kernel</th>
       <th>Remark</th>
@@ -160,7 +160,7 @@
       <th style="width=32px">IOMMU</th>
       <th style="width=32px">SLAT</th>
       <th style="width=32px">TPM</th>
-      <th style="width=42px">Qubes</th>
+      <th style="width=42px" class=" sorttable_sorted_reverse">Qubes<span id="sorttable_sortrevind">&nbsp;▴</span></th>
       <th style="width=42px">Xen</th>
       <th style="width=42px">Kernel</th>
       <th>Remark</th>


### PR DESCRIPTION
Partly addresses QubesOS/qubes-issues#8720, in specific [a suggestion](https://github.com/QubesOS/qubes-issues/issues/8720#issuecomment-1822604828) by @marmarta.

I don't know if I'm implementing this correctly. What I did here was to sort the table and inspect the HTML to see what changed. Then I loaded this page with the change and it seems to have it sorted by default. Not sure if it's the right way of doing it, but it's probably better than the current unsorted version, anyways.