### PR TITLE
Add @alimirjamali to community contributors

### DIFF
--- a/_data/team.yml
+++ b/_data/team.yml
@@ -244,6 +244,12 @@
   type: community
   fingerprint:
 
+- name: Ali Mirjamali
+  email: 
+  role: "Core and Qubes Manager contributions"
+  type: community
+  fingerprint:
+
 - name: Simon Newton
   email: theplexus@ctemplar.com
   role: "Qubes Forum moderator"


### PR DESCRIPTION
@alimirjamali has contributed a ton of PRs lately, but he's not listed on https://www.qubes-os.org/team/#community-contributors, which seems like a major oversight.

@alimirjamali, I wasn't sure whether you want your email address included here (or which one). Likewise for a PGP fingerprint. Also, I wasn't sure what "role" description you wanted. (This is just based on a quick skim of your contribution activity on https://github.com/alimirjamali.) Please help improve this entry and make it the way you want. Thank you for all of your contributions!