### PR TITLE
Fix missing OTF and NLnet logos in partners page

### DIFF
--- a/pages/partners.html
+++ b/pages/partners.html
@@ -397,7 +397,7 @@ redirect_from:
     <tr id="nlnet-foundation">
       <td>
         <a href="https://nlnet.nl">
-          <img src="/attachment/site/nlnet.gif">
+          <img src="/attachment/site/nlnet.svg">
         </a>
       </td>
       <td>
@@ -410,7 +410,7 @@ redirect_from:
     <tr id="open-technology-fund">
       <td>
         <a href="https://www.opentechfund.org/">
-          <img src="/attachment/site/OTF-logo.png">
+          <img src="/attachment/site/OTF-logo.svg">
         </a>
       </td>
       <td>


### PR DESCRIPTION
The logos are available as SVGs. Not GIFFs