### PR TITLE
changed "Awards & Grants" to "Partners"

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -195,25 +195,25 @@ title: "Qubes OS: A reasonably secure operating system"
       </div>
     </div>
     <div class="col-lg-6 col-md-6 more-bottom">
-      <h3 class="text-center"><i class="fa fa-trophy"></i> Awards &amp; Grants</h3>
+      <h3 class="text-center"><i class="fa fa-trophy"></i> Partners</h3>
       <div class="white-box">
       <ul class="list-unstyled remove-bottom">
       <li class="list-links text-center">
-        <a href="https://nlnet.nl/" target="_blank">
-          <img src="/attachment/site/nlnet.svg" class="featured-logo center-block">
-          <span>2016</span>
+        <a href="https://mullvad.net/" target="_blank">
+          <img src="/attachment/site/mullvad-logo.png" class="featured-logo center-block">
+          <span></span>
         </a>
       </li>
       <li class="list-links text-center">
-        <a href="https://www.opentech.fund/project/qubes-os" target="_blank">
-          <img src="/attachment/site/OTF-logo.svg" class="featured-logo center-block">
-          <span>2015 and 2016</span>
+        <a href="https://www.freedom.press" target="_blank">
+          <img src="/attachment/site/FPF-logo.svg" class="featured-logo center-block">
+          <span></span>
         </a>
       </li>
       <li class="list-links text-center">
-        <a href="https://www.accessnow.org/blog/2014/02/13/endpoint-security-prize-finalists-announced" target="_blank">
-          <img src="/attachment/site/access-innovation-prize.jpg" class="featured-logo center-block">
-          <span>2014 Finalist for Endpoint Security</span>
+        <a href="https://www.invisiblethingslab.com" target="_blank">
+          <img src="/attachment/site/itl.png" class="featured-logo center-block">
+          <span></span>
         </a>
       </li>
       <li class="list-links text-center">


### PR DESCRIPTION
changed "Awards & Grants" to "Partners" and changed the list to the top 3 partners (from 2023): Mullvad, FPF, ITL.

i deleted the years but kept the `<span>`, i dont know if they're needed or not.

feel free to edit the commit or implement differently. also would be great to have all images be SVGs instead of some PNGs for background transparency.