### PR TITLE
Add download links for R4.3.0-rc1

### DIFF
--- a/_data/downloads.yml
+++ b/_data/downloads.yml
@@ -5,6 +5,91 @@
 # Releases are removed when they reach EOL.
 
 releases:
+  R4.3.0-rc1:
+    testing: true
+    latest: false
+    aging: false
+    deprecated: false
+    sources:
+    - name: qubes-os.org
+      display: false
+      method: HTTPS
+      type: ISO
+      filename: Qubes-R4.3.0-rc1-x86_64.iso
+      size: 7.2 GiB (7,750,068,224 bytes)
+      url: https://ftp.qubes-os.org/iso/Qubes-R4.3.0-rc1-x86_64.iso
+      verifiers:
+        hash: https://ftp.qubes-os.org/iso/Qubes-R4.3.0-rc1-x86_64.iso.DIGESTS
+        sig: https://ftp.qubes-os.org/iso/Qubes-R4.3.0-rc1-x86_64.iso.asc
+        key: https://keys.qubes-os.org/keys/qubes-release-4.2-signing-key.asc
+    - name: qubes-os.org
+      display: false
+      method: BitTorrent
+      type: Torrent
+      filename: Qubes-R4.3.0-rc1-x86_64.torrent
+      size: 145.0 KiB (148,455 bytes)
+      url: https://ftp.qubes-os.org/iso/Qubes-R4.3.0-rc1-x86_64.torrent
+      verifiers:
+        hash: https://ftp.qubes-os.org/iso/Qubes-R4.3.0-rc1-x86_64.iso.DIGESTS
+        sig: https://ftp.qubes-os.org/iso/Qubes-R4.3.0-rc1-x86_64.iso.asc
+        key: https://keys.qubes-os.org/keys/qubes-release-4.2-signing-key.asc
+    - name: kernel.org
+      display: true
+      method: HTTPS
+      type: ISO
+      filename: Qubes-R4.3.0-rc1-x86_64.iso
+      size: 7.2 GiB (7,750,068,224 bytes)
+      url: https://mirrors.edge.kernel.org/qubes/iso/Qubes-R4.3.0-rc1-x86_64.iso
+      verifiers:
+        hash: https://mirrors.edge.kernel.org/qubes/iso/Qubes-R4.3.0-rc1-x86_64.iso.DIGESTS
+        sig: https://mirrors.edge.kernel.org/qubes/iso/Qubes-R4.3.0-rc1-x86_64.iso.asc
+        key: https://keys.qubes-os.org/keys/qubes-release-4.2-signing-key.asc
+    - name: halifax.rwth-aachen.de
+      display: false
+      method: HTTP
+      type: ISO
+      filename: Qubes-R4.3.0-rc1-x86_64.iso
+      size: 7.2 GiB (7,750,068,224 bytes)
+      url: http://ftp.halifax.rwth-aachen.de/qubes/iso/Qubes-R4.3.0-rc1-x86_64.iso
+      verifiers:
+        hash: http://ftp.halifax.rwth-aachen.de/qubes/iso/Qubes-R4.3.0-rc1-x86_64.iso.DIGESTS
+        sig: http://ftp.halifax.rwth-aachen.de/qubes/iso/Qubes-R4.3.0-rc1-x86_64.iso.asc
+        key: https://keys.qubes-os.org/keys/qubes-release-4.2-signing-key.asc
+    - name: kernel.org
+      display: true
+      method: BitTorrent
+      type: Torrent
+      filename: Qubes-R4.3.0-rc1-x86_64.torrent
+      size: 145.0 KiB (148,455 bytes)
+      url: https://mirrors.edge.kernel.org/qubes/iso/Qubes-R4.3.0-rc1-x86_64.torrent
+      verifiers:
+        hash: https://mirrors.edge.kernel.org/qubes/iso/Qubes-R4.3.0-rc1-x86_64.iso.DIGESTS
+        sig: https://mirrors.edge.kernel.org/qubes/iso/Qubes-R4.3.0-rc1-x86_64.iso.asc
+        key: https://keys.qubes-os.org/keys/qubes-release-4.2-signing-key.asc
+    - name: halifax.rwth-aachen.de
+      display: false
+      method: BitTorrent
+      type: Torrent
+      filename: Qubes-R4.3.0-rc1-x86_64.torrent
+      size: 145.0 KiB (148,455 bytes)
+      url: http://ftp.halifax.rwth-aachen.de/qubes/iso/Qubes-R4.3.0-rc1-x86_64.torrent
+      verifiers:
+        hash: http://ftp.halifax.rwth-aachen.de/qubes/iso/Qubes-R4.3.0-rc1-x86_64.iso.DIGESTS
+        sig: http://ftp.halifax.rwth-aachen.de/qubes/iso/Qubes-R4.3.0-rc1-x86_64.iso.asc
+        key: https://keys.qubes-os.org/keys/qubes-release-4.2-signing-key.asc
+    docs:
+      Installation guide:
+        featured: true
+        url: https://doc.qubes-os.org/en/latest/user/downloading-installing-upgrading/installation-guide.html
+      Release notes:
+        url: https://qubes-doc--1504.org.readthedocs.build/en/1504/developer/releases/4_3/release-notes.html
+      Release schedule:
+        url: https://qubes-doc--1504.org.readthedocs.build/en/1504/developer/releases/4_3/schedule.html
+      Upgrading to Qubes R4.2:
+        url: https://qubes-doc--1504.org.readthedocs.build/en/1504/user/downloading-installing-upgrading/upgrade/4_3.html
+    featured_docs:
+      get:
+      - Release notes
   Qubes OS 4.2.4:
     testing: false
     latest: true


### PR DESCRIPTION
Those links don't work yet.

I used release notes link pointing at PR build, not final version (as it isn't merged yet). Needs to be updated once PR is merged. Similar for upgrade guide (which doesn't exist yet).