### PR TITLE
Update download link rendering + new doc URLs

### DIFF
--- a/_data/downloads-page.yml
+++ b/_data/downloads-page.yml
@@ -9,7 +9,7 @@
     - r_version: testing
       snippets:
         - snippet: This is a testing release.
-          url: /doc/testing/
+          url: https://doc.qubes-os.org/en/latest/user/downloading-installing-upgrading/testing.html
         - snippet: Please help us improve it by reporting any bugs you encounter. For important work, we recommend the latest stable release.
     - r_version: stable
       snippets:
@@ -27,7 +27,7 @@
     - text: Detached PGP signature
     - text: Release signing key
     - text: How to verify downloads
-      url: /security/verifying-signatures/
+      url: https://doc.qubes-os.org/en/latest/project-security/verifying-signatures.html
     - text: All download mirrors
       url: '#mirrors'
       hover: View all download mirrors

--- a/_includes/downloads.html
+++ b/_includes/downloads.html
@@ -128,15 +128,7 @@
           {% for docdata in release.docs %}
             {% assign doc_name = docdata[0] %}
             {% assign doc = docdata[1] %}
-            {% if doc_name == "Installation guide" %}
-              <li><a href="{{ lang }}{{ doc.url }}" class="black-link" title="Installation guide">{{ doc_name }}</a></li>
-            {% endif %}
-            {% if doc_name == "Release notes" %}
-              <li><a href="{{ lang }}{{ doc.url }}" class="black-link" title="Release notes">{{ doc_name }}</a></li>
-            {% endif %}
-            {% if doc_name == "Release schedule" %}
-              <li><a href="{{ lang }}{{ doc.url }}" class="black-link" title="Release schedule">{{ doc_name }}</a></li>
-            {% endif %}
+            <li><a href="{{ lang }}{{ doc.url }}" class="black-link">{{ doc_name }}</a></li>
           {% endfor %}
         <li><a href="{{ downcont.links[4].url }}" class="black-link" title="{{ downcont.links[4].hover }}">{{ downcont.links[4].text }}</a></li>
       </ul>


### PR DESCRIPTION
After another discussion (QubesOS/qubesos.github.io#273), I did the following:

* update some links from the download page, that were pointing to documentation URLs on www.qubes-os.org instead of doc.qubes-os.org
* remove the filtering of the download links based on their name, allowing "Upgrading to Qubes R[...]" links to be displayed
* remove duplicate title attribute on links, because I don't think it is good for accessibility